### PR TITLE
Support Springframework 5.x for MessageConverter & JsonView.

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -58,6 +58,27 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>5.2.20.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.2.20.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.79</version>

--- a/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
@@ -1,0 +1,168 @@
+package com.alibaba.fastjson2.support.config;
+
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.Filter;
+
+import java.nio.charset.Charset;
+
+/**
+ * Configuration for FastJson.
+ *
+ * @author Victor.Zxy
+ * @see JSONReader.Feature
+ * @see JSONWriter.Feature
+ * @see Filter
+ * @see 2.0.2
+ */
+public class FastJsonConfig {
+
+    /**
+     * default charset
+     */
+    private Charset charset;
+
+    /**
+     * format date type
+     */
+    private String dateFormat;
+
+    /**
+     * JSONReader Features
+     */
+    private JSONReader.Feature[] readerFeatures;
+
+    /**
+     * JSONWriter Features
+     */
+    private JSONWriter.Feature[] writerFeatures;
+
+    /**
+     * JSONWriter Filters
+     */
+    private Filter[] writerFilters;
+
+    /**
+     * The Write content length.
+     */
+    private boolean writeContentLength;
+
+    /**
+     * init param.
+     */
+    public FastJsonConfig() {
+        this.charset = Charset.forName("UTF-8");
+        this.readerFeatures = new JSONReader.Feature[0];
+        this.writerFeatures = new JSONWriter.Feature[0];
+        this.writerFilters = new Filter[0];
+        this.writeContentLength = true;
+    }
+
+    /**
+     * Gets charset.
+     *
+     * @return the charset
+     */
+    public Charset getCharset() {
+        return charset;
+    }
+
+    /**
+     * Sets charset.
+     *
+     * @param charset the charset
+     */
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
+
+    /**
+     * Gets date format.
+     *
+     * @return the date format
+     */
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    /**
+     * Sets date format.
+     *
+     * @param dateFormat the date format
+     */
+    public void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    /**
+     * Get reader features json reader . feature [ ].
+     *
+     * @return the json reader . feature [ ]
+     */
+    public JSONReader.Feature[] getReaderFeatures() {
+        return readerFeatures;
+    }
+
+    /**
+     * Sets reader features.
+     *
+     * @param readerFeatures the reader features
+     */
+    public void setReaderFeatures(JSONReader.Feature... readerFeatures) {
+        this.readerFeatures = readerFeatures;
+    }
+
+    /**
+     * Get writer features json writer . feature [ ].
+     *
+     * @return the json writer . feature [ ]
+     */
+    public JSONWriter.Feature[] getWriterFeatures() {
+        return writerFeatures;
+    }
+
+    /**
+     * Sets writer features.
+     *
+     * @param writerFeatures the writer features
+     */
+    public void setWriterFeatures(JSONWriter.Feature... writerFeatures) {
+        this.writerFeatures = writerFeatures;
+    }
+
+    /**
+     * Get writer filters filter [ ].
+     *
+     * @return the filter [ ]
+     */
+    public Filter[] getWriterFilters() {
+        return writerFilters;
+    }
+
+    /**
+     * Sets writer filters.
+     *
+     * @param writerFilters the writer filters
+     */
+    public void setWriterFilters(Filter... writerFilters) {
+        this.writerFilters = writerFilters;
+    }
+
+    /**
+     * Is write content length boolean.
+     *
+     * @return the boolean
+     */
+    public boolean isWriteContentLength() {
+        return writeContentLength;
+    }
+
+    /**
+     * Sets write content length.
+     *
+     * @param writeContentLength the write content length
+     */
+    public void setWriteContentLength(boolean writeContentLength) {
+        this.writeContentLength = writeContentLength;
+    }
+}

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/FastJsonHttpMessageConverter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/FastJsonHttpMessageConverter.java
@@ -1,0 +1,231 @@
+package com.alibaba.fastjson2.support.spring;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.GenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+
+/**
+ * Fastjson for Spring MVC Converter.
+ *
+ * @author Victor.Zxy
+ * @see AbstractHttpMessageConverter
+ * @see GenericHttpMessageConverter
+ * @since 2.0.2
+ */
+public class FastJsonHttpMessageConverter extends AbstractHttpMessageConverter<Object> implements GenericHttpMessageConverter<Object> {
+
+    /**
+     * with fastJson config
+     */
+    private FastJsonConfig fastJsonConfig = new FastJsonConfig();
+
+    /**
+     * @return the fastJsonConfig.
+     */
+    public FastJsonConfig getFastJsonConfig() {
+        return fastJsonConfig;
+    }
+
+    /**
+     * @param fastJsonConfig the fastJsonConfig to set.
+     */
+    public void setFastJsonConfig(FastJsonConfig fastJsonConfig) {
+        this.fastJsonConfig = fastJsonConfig;
+    }
+
+    /**
+     * Can serialize/deserialize all types.
+     */
+    public FastJsonHttpMessageConverter() {
+
+        super(MediaType.ALL);
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return true;
+    }
+
+    @Override
+    public boolean canRead(Type type, Class<?> contextClass, MediaType mediaType) {
+        return super.canRead(contextClass, mediaType);
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return super.canWrite(clazz, mediaType);
+    }
+
+    @Override
+    public Object read(Type type, //
+                       Class<?> contextClass, //
+                       HttpInputMessage inputMessage //
+    ) throws IOException, HttpMessageNotReadableException {
+        return readType(getType(type, contextClass), inputMessage);
+    }
+
+    @Override
+    public void write(Object o, Type type, MediaType contentType, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+        // support StreamingHttpOutputMessage in spring4.0+
+        super.write(o, contentType, outputMessage);
+    }
+
+    @Override
+    protected Object readInternal(Class<?> clazz, //
+                                  HttpInputMessage inputMessage //
+    ) throws IOException, HttpMessageNotReadableException {
+        return readType(getType(clazz, null), inputMessage);
+    }
+
+    private Object readType(Type type, HttpInputMessage inputMessage) {
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            InputStream in = inputMessage.getBody();
+
+            byte[] buf = new byte[1024 * 64];
+            for (; ; ) {
+                int len = in.read(buf);
+                if (len == -1) {
+                    break;
+                }
+
+                if (len > 0) {
+                    baos.write(buf, 0, len);
+                }
+            }
+            byte[] bytes = baos.toByteArray();
+
+            return JSON.parseObject(bytes, type, fastJsonConfig.getReaderFeatures());
+        } catch (JSONException ex) {
+            throw new HttpMessageNotReadableException("JSON parse error: " + ex.getMessage(), ex, inputMessage);
+        } catch (IOException ex) {
+            throw new HttpMessageNotReadableException("I/O error while reading input message", ex, inputMessage);
+        }
+    }
+
+    @Override
+    protected void writeInternal(Object object, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+
+            HttpHeaders headers = outputMessage.getHeaders();
+
+            int len = JSON.writeTo(baos, object, fastJsonConfig.getWriterFeatures());
+
+            if (headers.getContentLength() < 0 && fastJsonConfig.isWriteContentLength()) {
+
+                headers.setContentLength(len);
+            }
+
+            baos.writeTo(outputMessage.getBody());
+
+        } catch (JSONException ex) {
+            throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
+        } catch (IOException ex) {
+            throw new HttpMessageNotWritableException("I/O error while writing output message", ex);
+        }
+    }
+
+    protected Type getType(Type type, Class<?> contextClass) {
+        if (Spring4TypeResolvableHelper.isSupport()) {
+            return Spring4TypeResolvableHelper.getType(type, contextClass);
+        }
+        return type;
+    }
+
+
+    private static class Spring4TypeResolvableHelper {
+        private static boolean hasClazzResolvableType;
+
+        static {
+            try {
+                Class.forName("org.springframework.core.ResolvableType");
+                hasClazzResolvableType = true;
+            } catch (ClassNotFoundException e) {
+                hasClazzResolvableType = false;
+            }
+        }
+
+        private static boolean isSupport() {
+            return hasClazzResolvableType;
+        }
+
+
+        private static Type getType(Type type, Class<?> contextClass) {
+            if (contextClass != null) {
+                ResolvableType resolvedType = ResolvableType.forType(type);
+                if (type instanceof TypeVariable) {
+                    ResolvableType resolvedTypeVariable = resolveVariable((TypeVariable) type, ResolvableType.forClass(contextClass));
+                    if (resolvedTypeVariable != ResolvableType.NONE) {
+                        return resolvedTypeVariable.resolve();
+                    }
+                } else if (type instanceof ParameterizedType && resolvedType.hasUnresolvableGenerics()) {
+                    ParameterizedType parameterizedType = (ParameterizedType) type;
+                    Class<?>[] generics = new Class[parameterizedType.getActualTypeArguments().length];
+                    Type[] typeArguments = parameterizedType.getActualTypeArguments();
+
+                    for (int i = 0; i < typeArguments.length; ++i) {
+                        Type typeArgument = typeArguments[i];
+                        if (typeArgument instanceof TypeVariable) {
+                            ResolvableType resolvedTypeArgument = resolveVariable((TypeVariable) typeArgument, ResolvableType.forClass(contextClass));
+                            if (resolvedTypeArgument != ResolvableType.NONE) {
+                                generics[i] = resolvedTypeArgument.resolve();
+                            } else {
+                                generics[i] = ResolvableType.forType(typeArgument).resolve();
+                            }
+                        } else {
+                            generics[i] = ResolvableType.forType(typeArgument).resolve();
+                        }
+                    }
+
+                    return ResolvableType.forClassWithGenerics(resolvedType.getRawClass(), generics).getType();
+                }
+            }
+
+            return type;
+        }
+
+        private static ResolvableType resolveVariable(TypeVariable<?> typeVariable, ResolvableType contextType) {
+            ResolvableType resolvedType;
+            if (contextType.hasGenerics()) {
+                resolvedType = ResolvableType.forType(typeVariable, contextType);
+                if (resolvedType.resolve() != null) {
+                    return resolvedType;
+                }
+            }
+
+            ResolvableType superType = contextType.getSuperType();
+            if (superType != ResolvableType.NONE) {
+                resolvedType = resolveVariable(typeVariable, superType);
+                if (resolvedType.resolve() != null) {
+                    return resolvedType;
+                }
+            }
+            for (ResolvableType ifc : contextType.getInterfaces()) {
+                resolvedType = resolveVariable(typeVariable, ifc);
+                if (resolvedType.resolve() != null) {
+                    return resolvedType;
+                }
+            }
+            return ResolvableType.NONE;
+        }
+    }
+
+
+}

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/FastJsonJsonView.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/FastJsonJsonView.java
@@ -1,0 +1,191 @@
+package com.alibaba.fastjson2.support.spring;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.springframework.http.MediaType;
+import org.springframework.util.CollectionUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.view.AbstractView;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Fastjson for Spring MVC View.
+ *
+ * @author Victor.Zxy
+ * @see AbstractView
+ * @since 2.0.2
+ */
+public class FastJsonJsonView extends AbstractView {
+
+    /**
+     * renderedAttributes
+     */
+    private Set<String> renderedAttributes;
+
+    /**
+     * disableCaching
+     */
+    private boolean disableCaching = true;
+
+    /**
+     * extractValueFromSingleKeyModel
+     */
+    private boolean extractValueFromSingleKeyModel = false;
+
+    /**
+     * with fastJson config
+     */
+    private FastJsonConfig fastJsonConfig = new FastJsonConfig();
+
+    /**
+     * Set default param.
+     */
+    public FastJsonJsonView() {
+
+        setContentType(MediaType.APPLICATION_JSON_VALUE);
+        setExposePathVariables(false);
+    }
+
+    /**
+     * @return the fastJsonConfig.
+     */
+    public FastJsonConfig getFastJsonConfig() {
+        return fastJsonConfig;
+    }
+
+    /**
+     * @param fastJsonConfig the fastJsonConfig to set.
+     */
+    public void setFastJsonConfig(FastJsonConfig fastJsonConfig) {
+        this.fastJsonConfig = fastJsonConfig;
+    }
+
+    /**
+     * Set renderedAttributes.
+     *
+     * @param renderedAttributes renderedAttributes
+     */
+    public void setRenderedAttributes(Set<String> renderedAttributes) {
+        this.renderedAttributes = renderedAttributes;
+    }
+
+    /**
+     * Check extractValueFromSingleKeyModel.
+     *
+     * @return extractValueFromSingleKeyModel
+     */
+    public boolean isExtractValueFromSingleKeyModel() {
+        return extractValueFromSingleKeyModel;
+    }
+
+    /**
+     * Set extractValueFromSingleKeyModel.
+     *
+     * @param extractValueFromSingleKeyModel
+     */
+    public void setExtractValueFromSingleKeyModel(boolean extractValueFromSingleKeyModel) {
+        this.extractValueFromSingleKeyModel = extractValueFromSingleKeyModel;
+    }
+
+    @Override
+    protected void renderMergedOutputModel(Map<String, Object> model, //
+                                           HttpServletRequest request, //
+                                           HttpServletResponse response) throws Exception {
+        Object value = filterModel(model);
+
+        ByteArrayOutputStream outnew = new ByteArrayOutputStream();
+
+        int len = JSON.writeTo(outnew, value, fastJsonConfig.getWriterFeatures());
+
+        if (fastJsonConfig.isWriteContentLength()) {
+            // Write content length (determined via byte array).
+            response.setContentLength(len);
+        }
+
+        // Flush byte array to servlet output stream.
+        ServletOutputStream out = response.getOutputStream();
+        outnew.writeTo(out);
+        outnew.close();
+        out.flush();
+    }
+
+    @Override
+    protected void prepareResponse(HttpServletRequest request, //
+                                   HttpServletResponse response) {
+
+        setResponseContentType(request, response);
+        response.setCharacterEncoding(fastJsonConfig.getCharset().name());
+        if (this.disableCaching) {
+            response.addHeader("Pragma", "no-cache");
+            response.addHeader("Cache-Control", "no-cache, no-store, max-age=0");
+            response.addDateHeader("Expires", 1L);
+        }
+    }
+
+    /**
+     * Disables caching of the generated JSON.
+     * <p>
+     * Default is {@code true}, which will prevent the client from caching the
+     * generated JSON.
+     */
+    public void setDisableCaching(boolean disableCaching) {
+        this.disableCaching = disableCaching;
+    }
+
+    /**
+     * Whether to update the 'Content-Length' header of the response. When set
+     * to {@code true}, the response is buffered in order to determine the
+     * content length and set the 'Content-Length' header of the response.
+     * <p>
+     * The default setting is {@code false}.
+     */
+    public void setUpdateContentLength(boolean updateContentLength) {
+        this.fastJsonConfig.setWriteContentLength(updateContentLength);
+    }
+
+    /**
+     * Filters out undesired attributes from the given model. The return value
+     * can be either another {@link Map}, or a single value object.
+     * <p>
+     * Default implementation removes {@link BindingResult} instances and
+     * entries not included in the {@link #setRenderedAttributes(Set)
+     * renderedAttributes} property.
+     *
+     * @param model the model, as passed on to {@link #renderMergedOutputModel}
+     * @return the object to be rendered
+     */
+    protected Object filterModel(Map<String, Object> model) {
+        Map<String, Object> result = new HashMap<String, Object>(model.size());
+        Set<String> renderedAttributes = !CollectionUtils.isEmpty(this.renderedAttributes) ? //
+                this.renderedAttributes //
+                : model.keySet();
+
+        for (Map.Entry<String, Object> entry : model.entrySet()) {
+            if (!(entry.getValue() instanceof BindingResult)
+                    && renderedAttributes.contains(entry.getKey())) {
+                result.put(entry.getKey(), entry.getValue());
+            }
+        }
+        if (extractValueFromSingleKeyModel) {
+            if (result.size() == 1) {
+                for (Map.Entry<String, Object> entry : result.entrySet()) {
+                    return entry.getValue();
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    protected void setResponseContentType(HttpServletRequest request, HttpServletResponse response) {
+        super.setResponseContentType(request, response);
+    }
+
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/config/FastJsonConfigTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/config/FastJsonConfigTest.java
@@ -1,0 +1,32 @@
+package com.alibaba.fastjson2.config;
+
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.SimplePropertyPreFilter;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.Charset;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class FastJsonConfigTest {
+
+    @Test
+    public void test() throws Exception {
+        FastJsonConfig fastJsonConfig = new FastJsonConfig();
+
+        fastJsonConfig.setWriteContentLength(false);
+        assertEquals(fastJsonConfig.isWriteContentLength(), false);
+        fastJsonConfig.setCharset(Charset.forName("UTF-8"));
+        assertEquals(fastJsonConfig.getCharset().name(), "UTF-8");
+        fastJsonConfig.setDateFormat("yyyyMMdd");
+        assertEquals(fastJsonConfig.getDateFormat(), "yyyyMMdd");
+        fastJsonConfig.setReaderFeatures(JSONReader.Feature.FieldBased);
+        assertEquals(fastJsonConfig.getReaderFeatures()[0], JSONReader.Feature.FieldBased);
+        fastJsonConfig.setWriterFeatures(JSONWriter.Feature.FieldBased);
+        assertEquals(fastJsonConfig.getWriterFeatures()[0], JSONWriter.Feature.FieldBased);
+        fastJsonConfig.setWriterFilters(new SimplePropertyPreFilter());
+        assertEquals(fastJsonConfig.getWriterFilters().length > 0, true);
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterMockTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterMockTest.java
@@ -1,0 +1,131 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.support.spring.FastJsonHttpMessageConverter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration
+public class FastJsonHttpMessageConverterMockTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac) //
+                .addFilter(new CharacterEncodingFilter("UTF-8", true)) // 设置服务器端返回的字符集为：UTF-8
+                .build();
+    }
+
+    public static class AbstractController<ID extends Serializable, PO extends GenericEntity<ID>> {
+
+        @PostMapping(path = "/typeVariableBean", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+        public PO save(@RequestBody PO dto) {
+            //do something
+            return dto;
+        }
+    }
+
+    @RestController
+    @RequestMapping()
+    public static class BeanController extends AbstractController<Long, TypeVariableBean> {
+
+        @PostMapping(path = "/parameterizedTypeBean", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+        public String parameterizedTypeBean(@RequestBody ParameterizedTypeBean<String> parameterizedTypeBean) {
+            return parameterizedTypeBean.t;
+        }
+    }
+
+    @ComponentScan(basePackages = "com.alibaba.fastjson2.spring")
+    @Configuration
+    @Order(Ordered.LOWEST_PRECEDENCE + 1)
+    @EnableWebMvc
+    public static class WebMvcConfig implements WebMvcConfigurer {
+        @Override
+        public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+            FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+            converters.add(converter);
+        }
+    }
+
+    @Test
+    public void testParameterizedTypeBean() throws Exception {
+        mockMvc.perform(
+                (post("/parameterizedTypeBean").characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("{\"t\": \"neil dong\"}")
+                )).andExpect(status().isOk()).andDo(print());
+    }
+
+    @Test
+    public void testTypeVariableBean() throws Exception {
+        mockMvc.perform(
+                (post("/typeVariableBean").characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content("{\"id\": 1}")
+                )).andExpect(status().isOk()).andDo(print());
+
+    }
+
+
+    static abstract class GenericEntity<ID extends Serializable> {
+        public abstract ID getId();
+    }
+
+    static class TypeVariableBean extends GenericEntity<Long> {
+        private Long id;
+
+        @Override
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+    }
+
+    static class ParameterizedTypeBean<T> {
+        private T t;
+
+        public T getT() {
+            return t;
+        }
+
+        public void setT(T t) {
+            this.t = t;
+        }
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterUnitTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterUnitTest.java
@@ -1,0 +1,79 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.FastJsonHttpMessageConverter;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+
+import static junit.framework.TestCase.*;
+
+public class FastJsonHttpMessageConverterUnitTest {
+
+    @Test
+    public void test() throws Exception {
+        FastJsonHttpMessageConverter messageConverter = new FastJsonHttpMessageConverter();
+        messageConverter.setFastJsonConfig(new FastJsonConfig());
+        assertNotNull(messageConverter.getFastJsonConfig());
+        assertTrue(messageConverter.canRead(VO.class, VO.class, MediaType.APPLICATION_JSON));
+        assertTrue(messageConverter.canWrite(VO.class, VO.class, MediaType.APPLICATION_JSON));
+
+        messageConverter.setSupportedMediaTypes(Arrays
+                .asList(new MediaType[]{MediaType.APPLICATION_JSON}));
+        Assert.assertEquals(1, messageConverter.getSupportedMediaTypes().size());
+
+        Method method = com.alibaba.fastjson2.support.spring.FastJsonHttpMessageConverter.class.getDeclaredMethod(
+                "supports", Class.class);
+        method.setAccessible(true);
+        method.invoke(messageConverter, int.class);
+
+        VO vo = (VO) messageConverter.read(VO.class, VO.class, new HttpInputMessage() {
+            @Override
+            public InputStream getBody() {
+                return new ByteArrayInputStream("{\"id\":123}".getBytes(Charset.forName("UTF-8")));
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders();
+            }
+        });
+        assertEquals(vo.getId(), 123);
+
+        messageConverter.write(vo, VO.class, MediaType.APPLICATION_JSON, new HttpOutputMessage() {
+            @Override
+            public OutputStream getBody() {
+                return new ByteArrayOutputStream();
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders();
+            }
+        });
+    }
+
+    public static class VO {
+
+        private int id;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonJsonViewMockTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonJsonViewMockTest.java
@@ -1,0 +1,178 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.support.spring.FastJsonHttpMessageConverter;
+import com.alibaba.fastjson2.support.spring.FastJsonJsonView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.stereotype.Controller;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ViewResolverRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration
+public class FastJsonJsonViewMockTest {
+
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @Before
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac) //
+                .addFilter(new CharacterEncodingFilter("UTF-8", true)) // 设置服务器端返回的字符集为：UTF-8
+                .build();
+    }
+
+    @Controller
+    @RequestMapping("fastjson")
+    public static class BeanController {
+
+        @RequestMapping(value = "/mocktest", method = RequestMethod.GET)
+        public
+        @ResponseBody
+        ModelAndView test7() {
+
+            AuthIdentityRequest authRequest = new AuthIdentityRequest();
+            authRequest.setAppId("cert01");
+            authRequest.setUserId(2307643);
+            authRequest.setIdNumber("34324324234234");
+            authRequest.setRealName("victorzeng");
+            authRequest.setBusinessLine("");
+            authRequest.setIgnoreIdNumberRepeat(false);
+            authRequest.setOffline(false);
+
+            ModelAndView modelAndView = new ModelAndView();
+            modelAndView.addObject("message", authRequest);
+            modelAndView.addObject("title", "testPage");
+            modelAndView.setViewName("test");
+
+            return modelAndView;
+        }
+
+    }
+
+
+    @ComponentScan(basePackages = "com.alibaba.fastjson2.spring")
+    @Configuration
+    @Order(Ordered.LOWEST_PRECEDENCE + 1)
+    @EnableWebMvc
+    public static class WebMvcConfig implements WebMvcConfigurer {
+        @Override
+        public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+            FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+            converters.add(converter);
+        }
+
+        @Override
+        public void configureViewResolvers(ViewResolverRegistry registry) {
+            FastJsonJsonView fastJsonJsonView = new FastJsonJsonView();
+            registry.enableContentNegotiation(fastJsonJsonView);
+        }
+    }
+
+    @Test
+    public void test() throws Exception {
+
+        mockMvc.perform(
+                (get("/fastjson/mocktest").characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                )).andExpect(status().isOk()).andDo(print());
+    }
+
+    static class AuthIdentityRequest {
+
+        private String appId;
+        private int userId;
+        private String idNumber;
+        private String realName;
+        private String businessLine;
+        private boolean ignoreIdNumberRepeat;
+        private boolean offline;
+
+        public String getAppId() {
+            return appId;
+        }
+
+        public void setAppId(String appId) {
+            this.appId = appId;
+        }
+
+        public int getUserId() {
+            return userId;
+        }
+
+        public void setUserId(int userId) {
+            this.userId = userId;
+        }
+
+        public String getIdNumber() {
+            return idNumber;
+        }
+
+        public void setIdNumber(String idNumber) {
+            this.idNumber = idNumber;
+        }
+
+        public String getRealName() {
+            return realName;
+        }
+
+        public void setRealName(String realName) {
+            this.realName = realName;
+        }
+
+        public String getBusinessLine() {
+            return businessLine;
+        }
+
+        public void setBusinessLine(String businessLine) {
+            this.businessLine = businessLine;
+        }
+
+        public boolean isIgnoreIdNumberRepeat() {
+            return ignoreIdNumberRepeat;
+        }
+
+        public void setIgnoreIdNumberRepeat(boolean ignoreIdNumberRepeat) {
+            this.ignoreIdNumberRepeat = ignoreIdNumberRepeat;
+        }
+
+        public boolean isOffline() {
+            return offline;
+        }
+
+        public void setOffline(boolean offline) {
+            this.offline = offline;
+        }
+    }
+
+
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonJsonViewUnitTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonJsonViewUnitTest.java
@@ -1,0 +1,114 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.FastJsonJsonView;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class FastJsonJsonViewUnitTest {
+
+    @Test
+    public void test_0() throws Exception {
+        FastJsonJsonView view = new FastJsonJsonView();
+        FastJsonConfig config = new FastJsonConfig();
+
+        Map<String, Object> model = new HashMap<String, Object>();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        view.setFastJsonConfig(config);
+        view.render(model, request, response);
+
+        view.setRenderedAttributes(null);
+        view.render(model, request, response);
+
+        view.setUpdateContentLength(true);
+        view.render(model, request, response);
+
+        view.render(Collections.singletonMap("abc", "cde"), request, response);
+
+        view.setDisableCaching(false);
+        view.setUpdateContentLength(false);
+        view.render(model, request, response);
+
+        view.setRenderedAttributes(new HashSet<String>(Collections.singletonList("abc")));
+        view.render(Collections.singletonMap("abc", "cde"), request, response);
+
+    }
+
+    public void test_1() throws Exception {
+
+        FastJsonJsonView view = new FastJsonJsonView();
+
+        Assert.assertNotNull(view.getFastJsonConfig());
+        view.setFastJsonConfig(new FastJsonConfig());
+
+        Map<String, Object> model = new HashMap<String, Object>();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        view.render(model, request, response);
+
+        view.setRenderedAttributes(null);
+        view.render(model, request, response);
+
+        view.setUpdateContentLength(true);
+        view.render(model, request, response);
+
+        view.setExtractValueFromSingleKeyModel(true);
+        Assert.assertEquals(true, view.isExtractValueFromSingleKeyModel());
+
+        view.setDisableCaching(true);
+        view.render(Collections.singletonMap("abc", "cde"), request, response);
+
+    }
+
+    @Test
+    public void test_jsonp() throws Exception {
+        FastJsonJsonView view = new FastJsonJsonView();
+
+        Assert.assertNotNull(view.getFastJsonConfig());
+        view.setFastJsonConfig(new FastJsonConfig());
+        view.setExtractValueFromSingleKeyModel(true);
+        view.setDisableCaching(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("callback", "queryName");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+
+        Assert.assertEquals(true, view.isExtractValueFromSingleKeyModel());
+
+
+        view.render(Collections.singletonMap("abc", "cde中文"), request, response);
+        String contentAsString = response.getContentAsString();
+        int contentLength = response.getContentLength();
+
+        Assert.assertEquals(contentLength, contentAsString.getBytes(view.getFastJsonConfig().getCharset().name()).length);
+    }
+
+    @Test
+    public void test_jsonp_invalidParam() throws Exception {
+        FastJsonJsonView view = new FastJsonJsonView();
+
+        Assert.assertNotNull(view.getFastJsonConfig());
+        view.setFastJsonConfig(new FastJsonConfig());
+        view.setExtractValueFromSingleKeyModel(true);
+        view.setDisableCaching(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addParameter("callback", "-methodName");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        Assert.assertEquals(true, view.isExtractValueFromSingleKeyModel());
+
+        view.render(Collections.singletonMap("doesn't matter", Collections.singletonMap("abc", "cde中文")), request, response);
+        String contentAsString = response.getContentAsString();
+        Assert.assertTrue(contentAsString.startsWith("{\"abc\":\"cde中文\"}"));
+    }
+}


### PR DESCRIPTION
Support Springframework 5.x for MessageConverter & JsonView. 

Fix https://github.com/alibaba/fastjson2/issues/7. 

PTAL @wenshao @oldratlee .

Configuration examples as follows:
```java
@Bean
public HttpMessageConverter fastJsonHttpMessageConverter(){
    FastJsonHttpMessageConverter fastJsonHttpMessageConverter = new FastJsonHttpMessageConverter();
    FastJsonConfig fastJsonConfig = new FastJsonConfig();
    fastJsonConfig.setWriterFeatures(JSONWriter.Feature.PrettyFormat);
    fastJsonHttpMessageConverter.setFastJsonConfig(fastJsonConfig);
    return fastJsonHttpMessageConverter;
}
```