### PR TITLE
Support Spring Messaging Json Converter

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -66,6 +66,13 @@
 
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-messaging</artifactId>
+            <version>5.2.20.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>5.2.20.RELEASE</version>
             <scope>test</scope>

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/messaging/converter/MappingFastJsonMessageConverter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/messaging/converter/MappingFastJsonMessageConverter.java
@@ -1,0 +1,94 @@
+package com.alibaba.fastjson2.support.spring.messaging.converter;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.AbstractMessageConverter;
+import org.springframework.util.MimeType;
+
+import java.nio.charset.Charset;
+
+/**
+ * Fastjson for Spring Messaging Json Converter.
+ *
+ * @author KimmKing
+ * @author Victor.Zxy
+ * @see AbstractMessageConverter
+ * @since 2.0.2
+ */
+public class MappingFastJsonMessageConverter extends AbstractMessageConverter {
+
+    /**
+     * with fastJson config
+     */
+    private FastJsonConfig fastJsonConfig = new FastJsonConfig();
+
+    /**
+     * @return the fastJsonConfig.
+     */
+    public FastJsonConfig getFastJsonConfig() {
+        return fastJsonConfig;
+    }
+
+    /**
+     * @param fastJsonConfig the fastJsonConfig to set.
+     */
+    public void setFastJsonConfig(FastJsonConfig fastJsonConfig) {
+        this.fastJsonConfig = fastJsonConfig;
+    }
+
+    public MappingFastJsonMessageConverter() {
+        super(new MimeType("application", "json", Charset.forName("UTF-8")));
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return true;
+    }
+
+    @Override
+    protected boolean canConvertFrom(Message<?> message, Class<?> targetClass) {
+        return supports(targetClass);
+    }
+
+    @Override
+    protected boolean canConvertTo(Object payload, MessageHeaders headers) {
+        return supports(payload.getClass());
+    }
+
+    @Override
+    protected Object convertFromInternal(Message<?> message, Class<?> targetClass, Object conversionHint) {
+        // parse byte[] or String payload to Java Object
+        Object payload = message.getPayload();
+        Object obj = null;
+        if (payload instanceof byte[]) {
+            obj = JSON.parseObject((byte[]) payload, targetClass, fastJsonConfig.getReaderFeatures());
+        } else if (payload instanceof String) {
+            obj = JSON.parseObject((String) payload, targetClass, fastJsonConfig.getReaderFeatures());
+        }
+
+        return obj;
+    }
+
+    @Override
+    protected Object convertToInternal(Object payload, MessageHeaders headers, Object conversionHint) {
+        // encode payload to json string or byte[]
+        Object obj;
+        if (byte[].class == getSerializedPayloadClass()) {
+            if (payload instanceof String && JSON.isValid((String) payload)) {
+                obj = ((String) payload).getBytes(fastJsonConfig.getCharset());
+            } else {
+                obj = JSON.toJSONBytes(payload, fastJsonConfig.getWriterFilters(), fastJsonConfig.getWriterFeatures());
+            }
+        } else {
+            if (payload instanceof String && JSON.isValid((String) payload)) {
+                obj = payload;
+            } else {
+                obj = JSON.toJSONString(payload, fastJsonConfig.getWriterFilters(), fastJsonConfig.getWriterFeatures());
+            }
+        }
+
+        return obj;
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/MappingFastJsonMessageConverterTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/MappingFastJsonMessageConverterTest.java
@@ -1,0 +1,90 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.messaging.converter.MappingFastJsonMessageConverter;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+
+
+public class MappingFastJsonMessageConverterTest {
+
+    @Test
+    public void test_1() throws Exception {
+
+        MappingFastJsonMessageConverter converter = new MappingFastJsonMessageConverter();
+
+        Assert.assertNotNull(converter.getFastJsonConfig());
+        converter.setFastJsonConfig(new FastJsonConfig());
+
+        VO p = new VO();
+        p.setId(1);
+
+        String pstr = JSON.toJSONString(p);
+
+        System.out.println(pstr);
+
+        TestMessage message = new TestMessage(pstr);
+
+        // test fromMessage/convertFromInternal
+        VO vo = (VO) converter.fromMessage(message, VO.class);
+        Assert.assertEquals(1, vo.getId());
+
+        // test toMessage/convertToInternal
+        Message message1 = converter.toMessage(vo, null);
+        System.out.println(message1.getPayload());
+        Assert.assertEquals("{\"id\":1}", new String((byte[]) message1.getPayload()));
+
+//		// test toMessage/convertToInternal
+        Message message2 = converter.toMessage("{\"id\":1}", null);
+        System.out.println(message2.getPayload());
+        Assert.assertEquals("{\"id\":1}", new String((byte[]) message2.getPayload()));
+
+        converter.setSerializedPayloadClass(String.class);
+
+        // test toMessage/convertToInternal
+        Message message3 = converter.toMessage(vo, null);
+        System.out.println(message3.getPayload());
+        Assert.assertEquals("{\"id\":1}", message3.getPayload());
+
+//		// test toMessage/convertToInternal
+        Message message4 = converter.toMessage("{\"id\":1}", null);
+        System.out.println(message4.getPayload());
+        Assert.assertEquals("{\"id\":1}", message4.getPayload());
+    }
+
+    public static class TestMessage<T> implements Message<T> {
+
+        private T payload;
+
+        public TestMessage(T payload) {
+            this.payload = payload;
+        }
+
+        @Override
+        public T getPayload() {
+            return (T) payload;
+        }
+
+        @Override
+        public MessageHeaders getHeaders() {
+            return null;
+        }
+    }
+
+    public static class VO {
+
+        private int id;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+    }
+}


### PR DESCRIPTION
Fastjson extension to support spring messaging converter. Close https://github.com/alibaba/fastjson2/issues/24.

See `com.alibaba.fastjson2.support.spring.messaging.converter.MappingFastJsonMessageConverter.java`
