### PR TITLE
Support Spring Data Redis Serializer

### DIFF
--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -72,6 +72,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <version>2.3.9.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <version>5.2.20.RELEASE</version>

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/data/redis/FastJsonRedisSerializer.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/data/redis/FastJsonRedisSerializer.java
@@ -1,0 +1,58 @@
+package com.alibaba.fastjson2.support.spring.data.redis;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+/**
+ * Fastjson for Spring Data Redis Serializer.
+ *
+ * @author lihengming
+ * @author Victor.Zxy
+ * @see RedisSerializer
+ * @since 2.0.2
+ */
+public class FastJsonRedisSerializer<T> implements RedisSerializer<T> {
+
+    private FastJsonConfig fastJsonConfig = new FastJsonConfig();
+    private Class<T> type;
+
+    public FastJsonRedisSerializer(Class<T> type) {
+        this.type = type;
+    }
+
+    public FastJsonConfig getFastJsonConfig() {
+        return fastJsonConfig;
+    }
+
+    public void setFastJsonConfig(FastJsonConfig fastJsonConfig) {
+        this.fastJsonConfig = fastJsonConfig;
+    }
+
+    @Override
+    public byte[] serialize(T t) throws SerializationException {
+        if (t == null) {
+            return new byte[0];
+        }
+        try {
+            return JSON.toJSONBytes(t, fastJsonConfig.getWriterFilters(), fastJsonConfig.getWriterFeatures());
+
+        } catch (Exception ex) {
+            throw new SerializationException("Could not serialize: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public T deserialize(byte[] bytes) throws SerializationException {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        try {
+            return (T) JSON.parseObject(bytes, type, fastJsonConfig.getReaderFeatures());
+
+        } catch (Exception ex) {
+            throw new SerializationException("Could not deserialize: " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/data/redis/GenericFastJsonRedisSerializer.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/data/redis/GenericFastJsonRedisSerializer.java
@@ -1,0 +1,50 @@
+package com.alibaba.fastjson2.support.spring.data.redis;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+/**
+ * Fastjson for Spring Data Redis Serializer(Generic implement).
+ *
+ * @author lihengming
+ * @author Victor.Zxy
+ * @see RedisSerializer
+ * @since 2.0.2
+ */
+public class GenericFastJsonRedisSerializer implements RedisSerializer<Object> {
+
+    private FastJsonConfig fastJsonConfig = new FastJsonConfig();
+
+    public GenericFastJsonRedisSerializer() {
+        fastJsonConfig.setReaderFeatures(JSONReader.Feature.SupportAutoType);
+        fastJsonConfig.setWriterFeatures(JSONWriter.Feature.WriteClassName);
+    }
+
+    @Override
+    public byte[] serialize(Object object) throws SerializationException {
+        if (object == null) {
+            return new byte[0];
+        }
+        try {
+            return JSON.toJSONBytes(object, fastJsonConfig.getWriterFeatures());
+        } catch (Exception ex) {
+            throw new SerializationException("Could not serialize: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public Object deserialize(byte[] bytes) throws SerializationException {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        try {
+            return JSON.parseObject(bytes, Object.class, fastJsonConfig.getReaderFeatures());
+        } catch (Exception ex) {
+            throw new SerializationException("Could not deserialize: " + ex.getMessage(), ex);
+        }
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonRedisSerializerTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/FastJsonRedisSerializerTest.java
@@ -1,0 +1,117 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.data.redis.FastJsonRedisSerializer;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNull;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.redis.serializer.SerializationException;
+
+import java.util.Arrays;
+
+
+public class FastJsonRedisSerializerTest {
+
+    private FastJsonRedisSerializer<User> serializer;
+
+    @Before
+    public void setUp() {
+        this.serializer = new FastJsonRedisSerializer<User>(User.class);
+    }
+
+    @Test
+    public void test_1() {
+        User user = serializer.deserialize(serializer.serialize(new User(1, "土豆", 25)));
+        Assert.assertTrue(user.getId().equals(1));
+        Assert.assertTrue(user.getName().equals("土豆"));
+        Assert.assertTrue(user.getAge().equals(25));
+    }
+
+    @Test
+    public void test_2() {
+        Assert.assertThat(serializer.serialize(null), Is.is(new byte[0]));
+    }
+
+    @Test
+    public void test_3() {
+        Assert.assertThat(serializer.deserialize(new byte[0]), IsNull.nullValue());
+    }
+
+    @Test
+    public void test_4() {
+        Assert.assertThat(serializer.deserialize(null), IsNull.nullValue());
+    }
+
+    @Test
+    public void test_5() {
+        User user = new User(1, "土豆", 25);
+        byte[] serializedValue = serializer.serialize(user);
+        Arrays.sort(serializedValue); // corrupt serialization result
+        Assert.assertThrows(SerializationException.class, () -> serializer.deserialize(serializedValue));
+    }
+
+    /**
+     * for issue #2147
+     */
+    @Test
+    public void test_6() {
+
+        FastJsonConfig fastJsonConfig = new FastJsonConfig();
+        fastJsonConfig.setReaderFeatures(JSONReader.Feature.SupportAutoType);
+        fastJsonConfig.setWriterFeatures(JSONWriter.Feature.WriteClassName);
+
+        FastJsonRedisSerializer fastJsonRedisSerializer = new FastJsonRedisSerializer(Object.class);
+        Assert.assertNotNull(fastJsonRedisSerializer.getFastJsonConfig());
+        fastJsonRedisSerializer.setFastJsonConfig(fastJsonConfig);
+
+        User userSer = new User(1, "土豆", 25);
+
+        byte[] serializedValue = fastJsonRedisSerializer.serialize(userSer);
+        User userDes = (User) fastJsonRedisSerializer.deserialize(serializedValue);
+
+        Assert.assertEquals(userDes.getName(), "土豆");
+    }
+
+    static class User {
+        private Integer id;
+        private String name;
+        private Integer age;
+
+        public User() {
+        }
+
+        public User(Integer id, String name, Integer age) {
+            this.id = id;
+            this.name = name;
+            this.age = age;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/spring/GenericFastJsonRedisSerializerTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/spring/GenericFastJsonRedisSerializerTest.java
@@ -1,0 +1,157 @@
+package com.alibaba.fastjson2.spring;
+
+import com.alibaba.fastjson2.support.spring.data.redis.GenericFastJsonRedisSerializer;
+import org.hamcrest.core.Is;
+import org.hamcrest.core.IsNull;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.data.redis.serializer.SerializationException;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+public class GenericFastJsonRedisSerializerTest {
+
+    private GenericFastJsonRedisSerializer serializer;
+
+    @Before
+    public void setUp() {
+        this.serializer = new GenericFastJsonRedisSerializer();
+    }
+
+    @Test
+    public void test_1() {
+        User user = (User) serializer.deserialize(serializer.serialize(new User(1, "土豆", 25)));
+        Assert.assertTrue(user.getId().equals(1));
+        Assert.assertTrue(user.getName().equals("土豆"));
+        Assert.assertTrue(user.getAge().equals(25));
+    }
+
+    @Test
+    public void test_2() {
+        Assert.assertThat(serializer.serialize(null), Is.is(new byte[0]));
+    }
+
+    @Test
+    public void test_3() {
+        Assert.assertThat(serializer.deserialize(new byte[0]), IsNull.nullValue());
+    }
+
+    @Test
+    public void test_4() {
+        Assert.assertThat(serializer.deserialize(null), IsNull.nullValue());
+    }
+
+    @Test(expected = SerializationException.class)
+    public void test_5() {
+        User user = new User(1, "土豆", 25);
+        byte[] serializedValue = serializer.serialize(user);
+        Arrays.sort(serializedValue); // corrupt serialization result
+        serializer.deserialize(serializedValue);
+    }
+
+    @Test
+    public void test_6() {
+
+        BaseResult<List<String>> baseResult = new BaseResult<List<String>>();
+        baseResult.setCode("1000");
+        baseResult.setMsg("success");
+        baseResult.setData(Arrays.asList("测试1", "测试2", "测试3"));
+
+        GenericFastJsonRedisSerializer genericFastJsonRedisSerializer = new GenericFastJsonRedisSerializer();
+        byte[] bytes = genericFastJsonRedisSerializer.serialize(baseResult);
+        BaseResult<List<String>> baseResult2 = (BaseResult<List<String>>) genericFastJsonRedisSerializer.deserialize(bytes);
+
+        Assert.assertEquals(baseResult2.getCode(), "1000");
+        Assert.assertEquals(baseResult2.getData().size(), 3);
+
+        String json = "{\n" +
+                "\"@type\": \"com.alibaba.fastjson2.spring.GenericFastJsonRedisSerializerTest$BaseResult\",\n" +
+                "\"code\": \"1000\",\n" +
+                "\"data\": [\n" +
+                "\"按手动控制按钮\",\n" +
+                "\"不停机\",\n" +
+                "\"不转动\",\n" +
+                "\"传动轴振动大\",\n" +
+                "\"第一推进器\",\n" +
+                "\"电机不运行\",\n" +
+                "],\n" +
+                "\"msg\": \"success\"\n" +
+                "}";
+
+        BaseResult<List<String>> baseResult3 = (BaseResult<List<String>>) genericFastJsonRedisSerializer.deserialize(json.getBytes());
+        Assert.assertEquals(baseResult3.getCode(), "1000");
+        Assert.assertEquals(baseResult3.getData().size(), 6);
+    }
+
+    static class User {
+        private Integer id;
+        private String name;
+        private Integer age;
+
+        public User() {
+        }
+
+        public User(Integer id, String name, Integer age) {
+            this.id = id;
+            this.name = name;
+            this.age = age;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Integer getAge() {
+            return age;
+        }
+
+        public void setAge(Integer age) {
+            this.age = age;
+        }
+    }
+
+    static class BaseResult<T> {
+        public String getMsg() {
+            return msg;
+        }
+
+        public void setMsg(String msg) {
+            this.msg = msg;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+
+        public T getData() {
+            return data;
+        }
+
+        public void setData(T data) {
+            this.data = data;
+        }
+
+        private String msg;
+        private String code;
+        private T data;
+    }
+}


### PR DESCRIPTION
Fastjson extension to support spring data redis serializer. Close https://github.com/alibaba/fastjson2/issues/25.

See `com.alibaba.fastjson2.support.spring.data.redis.FastJsonRedisSerializer<T>.java` and `com.alibaba.fastjson2.support.spring.data.redis.GenericFastJsonRedisSerializer.java`.