### PR TITLE
Change the Reader and Writer of JSONArray and JSONObject

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -16,9 +16,8 @@ public class JSONArray extends ArrayList<Object> {
 
     private static final long serialVersionUID = 1L;
 
-    static ObjectWriter<JSONArray> arrayWriter;
-    static ObjectReader<JSONArray> arrayReader;
-    static ObjectReader<JSONObject> objectReader;
+    public static final ObjectReader<JSONArray> READER = ObjectReader.getInstance(JSONArray.class);
+    public static final ObjectWriter<JSONArray> WRITER = ObjectWriter.getInstance(JSONArray.class);
 
     /**
      * default
@@ -76,10 +75,7 @@ public class JSONArray extends ArrayList<Object> {
             }
 
             JSONReader reader = JSONReader.of(str);
-            if (arrayReader == null) {
-                arrayReader = reader.getObjectReader(JSONArray.class);
-            }
-            return arrayReader.readObject(reader, 0);
+            return READER.readObject(reader, 0);
         }
 
         if (value instanceof Collection) {
@@ -111,10 +107,7 @@ public class JSONArray extends ArrayList<Object> {
             }
 
             JSONReader reader = JSONReader.of(str);
-            if (objectReader == null) {
-                objectReader = reader.getObjectReader(JSONObject.class);
-            }
-            return objectReader.readObject(reader, 0);
+            return JSONObject.READER.readObject(reader, 0);
         }
 
         if (value instanceof Map) {
@@ -782,10 +775,7 @@ public class JSONArray extends ArrayList<Object> {
     @Override
     public String toString() {
         try (JSONWriter writer = JSONWriter.of()) {
-            if (arrayWriter == null) {
-                arrayWriter = writer.getObjectWriter(JSONArray.class, JSONArray.class);
-            }
-            arrayWriter.write(writer, this, null, null, 0);
+            WRITER.write(writer, this, null, null, 0);
             return writer.toString();
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -22,9 +22,8 @@ public class JSONObject extends LinkedHashMap<String, Object> implements Invocat
 
     private static final long serialVersionUID = 1L;
 
-    static ObjectReader<JSONArray> arrayReader;
-    static ObjectWriter<JSONObject> objectWriter;
-    static ObjectReader<JSONObject> objectReader;
+    public static final ObjectReader<JSONObject> READER = ObjectReader.getInstance(JSONObject.class);
+    public static final ObjectWriter<JSONObject> WRITER = ObjectWriter.getInstance(JSONObject.class);
 
     /**
      * default
@@ -150,10 +149,7 @@ public class JSONObject extends LinkedHashMap<String, Object> implements Invocat
             }
 
             JSONReader reader = JSONReader.of(str);
-            if (arrayReader == null) {
-                arrayReader = reader.getObjectReader(JSONArray.class);
-            }
-            return arrayReader.readObject(reader, 0);
+            return JSONArray.READER.readObject(reader, 0);
         }
 
         if (value instanceof Collection) {
@@ -184,10 +180,7 @@ public class JSONObject extends LinkedHashMap<String, Object> implements Invocat
             }
 
             JSONReader reader = JSONReader.of(str);
-            if (objectReader == null) {
-                objectReader = reader.getObjectReader(JSONObject.class);
-            }
-            return objectReader.readObject(reader, 0);
+            return READER.readObject(reader, 0);
         }
 
         if (value instanceof Map) {
@@ -838,10 +831,7 @@ public class JSONObject extends LinkedHashMap<String, Object> implements Invocat
     @Override
     public String toString() {
         try (JSONWriter writer = JSONWriter.of()) {
-            if (objectWriter == null) {
-                objectWriter = writer.getObjectWriter(JSONObject.class);
-            }
-            objectWriter.write(writer, this, null, null, 0);
+            WRITER.write(writer, this, null, null, 0);
             return writer.toString();
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
@@ -6,6 +6,7 @@ import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.util.Fnv;
 import com.alibaba.fastjson2.util.TypeUtils;
 
+import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.Function;
 
@@ -173,7 +174,7 @@ public interface ObjectReader<T> {
             if (hash == 0) {
                 continue;
             }
-            
+
             FieldReader fieldReader = getFieldReader(hash);
             if (fieldReader == null && jsonReader.isSupportSmartMatch(features | this.getFeatures())) {
                 long nameHashCodeLCase = jsonReader.getNameHashCodeLCase();
@@ -304,5 +305,23 @@ public interface ObjectReader<T> {
         }
 
         return (T) object;
+    }
+
+    /**
+     * Specify {@link Type} to get its {@link ObjectReader} instance, not singleton mode
+     *
+     * @since 2.0.2
+     */
+    static <T> ObjectReader<T> getInstance(Type type) {
+        return JSONFactory.getDefaultObjectReaderProvider().getObjectReader(type, false);
+    }
+
+    /**
+     * Specify {@link Type} to get its {@link ObjectReader} instance, not singleton mode
+     *
+     * @since 2.0.2
+     */
+    static <T> ObjectReader<T> getInstance(Type type, boolean fieldBased) {
+        return JSONFactory.getDefaultObjectReaderProvider().getObjectReader(type, fieldBased);
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriter.java
@@ -1,15 +1,14 @@
 package com.alibaba.fastjson2.writer;
 
+import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.PropertyFilter;
 import com.alibaba.fastjson2.filter.PropertyPreFilter;
 import com.alibaba.fastjson2.filter.ValueFilter;
 
 import java.lang.reflect.Type;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public interface ObjectWriter<T> {
     default long getFeatures() {
@@ -127,5 +126,23 @@ public interface ObjectWriter<T> {
 
     default void writeWithFilter(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Specify {@link Class} to get its {@link ObjectWriter} instance, not singleton mode
+     *
+     * @since 2.0.2
+     */
+    static <T> ObjectWriter<T> getInstance(Class<T> clazz) {
+        return JSONFactory.getDefaultObjectWriterProvider().getObjectWriter(clazz, clazz, false);
+    }
+
+    /**
+     * Specify {@link Class} to get its {@link ObjectWriter} instance, not singleton mode
+     *
+     * @since 2.0.2
+     */
+    static <T> ObjectWriter<T> getInstance(Class<T> clazz, boolean fieldBased) {
+        return JSONFactory.getDefaultObjectWriterProvider().getObjectWriter(clazz, clazz, fieldBased);
     }
 }


### PR DESCRIPTION
目前 `getObjectReader` 和 `getObjectWriter` 方法中创建实例时没有加锁
获取 Reader 和 Writer 时候可能会出现线程不安全而重复创建
考虑到 JSONArray and JSONObject 的 Reader 和 Writer 使用频率不低, 将其更改为饿汉模式