### PR TITLE
fix ObjectReader6 readObject

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader6.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader6.java
@@ -224,7 +224,7 @@ final class ObjectReader6<T> extends ObjectReaderBean<T> {
         Object object = defaultCreator.get();
         for (int i = 0; ; ++i) {
             if (jsonReader.nextIfMatch('}')) {
-                jsonReader.next();
+//                jsonReader.next();
                 break;
             }
 


### PR DESCRIPTION
在使用parseObject转换复杂对象时，ObjectReader6会多跳过数据导致解析异常。