### PR TITLE
Fix optimize codes

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -1194,7 +1194,7 @@ public abstract class JSONReader implements Closeable {
     public List readArray() {
         next();
 
-        List list = new JSONArray();
+        List<Object> list = new JSONArray();
 
         _for:
         for (; ; ) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -14,7 +14,6 @@ import com.alibaba.fastjson2.modules.ObjectReaderAnnotationProcessor;
 import com.alibaba.fastjson2.modules.ObjectReaderModule;
 import com.alibaba.fastjson2.support.money.MoneySupport;
 import com.alibaba.fastjson2.util.*;
-import com.alibaba.fastjson2.writer.ObjectWriter;
 
 import java.io.Closeable;
 import java.io.Serializable;
@@ -2925,7 +2924,7 @@ public class ObjectReaderBaseModule implements ObjectReaderModule {
 
     static class GenericArrayImpl implements ObjectReader {
         final Type itemType;
-        final Class componentClass;
+        final Class<?> componentClass;
         ObjectReader itemObjectReader = null;
 
         public GenericArrayImpl(Type itemType) {
@@ -2988,7 +2987,7 @@ public class ObjectReaderBaseModule implements ObjectReaderModule {
                 throw new JSONException("format error");
             }
 
-            ArrayList list = new ArrayList();
+            List<Object> list = new ArrayList<>();
             if (ch != '[') {
                 throw new JSONException("format error : " + ch);
             }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -170,7 +170,7 @@ class ObjectWriterBaseModule implements ObjectWriterModule {
         @Override
         public void getFieldInfo(FieldInfo fieldInfo, Class objectType, Field field) {
             Class mixInSource = provider.mixInCache.get(objectType);
-            if (objectType == null) {
+            if (objectType != null) {
                 String typeName = objectType.getName();
                 switch (typeName) {
                     case "org.apache.commons.lang3.tuple.ImmutablePair":

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -3,9 +3,6 @@ package com.alibaba.fastjson2.writer;
 import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.modules.ObjectWriterModule;
-import com.alibaba.fastjson2.reader.ObjectReaderCreator;
-import com.alibaba.fastjson2.reader.ObjectReaderCreatorASM;
-import com.alibaba.fastjson2.reader.ObjectReaderCreatorLambda;
 import com.alibaba.fastjson2.util.GuavaSupport;
 import com.alibaba.fastjson2.util.TypeUtils;
 
@@ -87,9 +84,7 @@ public class ObjectWriterProvider {
     }
 
     public ObjectWriter getObjectWriter(Type objectType, Class objectClass, boolean fieldBased) {
-        ObjectWriter objectWriter;
-
-        objectWriter = fieldBased
+        ObjectWriter objectWriter = fieldBased
                 ? cacheFieldBased.get(objectType)
                 : cache.get(objectType);
 
@@ -167,7 +162,7 @@ public class ObjectWriterProvider {
     static final int[] NOT_REFERENCES_TYPE_HASH_CODES;
 
     static {
-        Class[] classes = new Class[]{
+        Class<?>[] classes = new Class[]{
                 boolean.class,
                 Boolean.class,
                 Character.class,


### PR DESCRIPTION
对 ObjectWriterBaseModule 中的空指针改为判断为非空，之前如果为 null，则会导致 getName 方法出现 NPE