### PR TITLE
fix randomIndex throw exception when use JSONPath.of(JSONReader)

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/jsonpath/JSONPahRandomIndex.java
+++ b/core/src/test/java/com/alibaba/fastjson2/jsonpath/JSONPahRandomIndex.java
@@ -2,6 +2,8 @@ package com.alibaba.fastjson2.jsonpath;
 
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONPath;
+import com.alibaba.fastjson2.JSONReader;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -13,8 +15,39 @@ public class JSONPahRandomIndex {
         JSONPath jsonPath = JSONPath.of("$[randomIndex()]");
         for (int i = 0; i < 100; ++i) {
             assertNotNull(
-                    jsonPath.eval(array)
+                jsonPath.eval(array)
             );
+        }
+    }
+
+    @Test
+    public void testEvalRandomIndexField() {
+        JSONPath path = JSONPath.of("$.data[randomIndex()].name");
+        Object value = path.eval("{\"data\": [{\"id\": 1, \"name\": \"a\"}, {\"id\": 2, \"name\": \"b\"}]}");
+        assertNotNull(value);
+    }
+
+    @Test
+    public void testExtractRandomIndex() {
+        for (int i = 0; i < 50; i++) {
+            JSONPath path = JSONPath.of("$.data[randomIndex()]");
+            JSONReader reader = JSONReader.of(
+                "{\"data\": [{\"id\": 1, \"name\": \"a\"}, {\"id\": 2, \"name\": \"b\"}]}");
+            Object value = path.extract(reader);
+            System.out.println(value);
+            assertNotNull(value);
+        }
+    }
+
+    @Test
+    public void testExtractRandomIndexField() {
+        for (int i = 0; i < 50; i++) {
+            JSONPath path = JSONPath.of("$.data[randomIndex()].name");
+            JSONReader reader = JSONReader.of(
+                "{\"data\": [{\"id\": 1, \"name\": \"a\"}, {\"id\": 2, \"name\": \"b\"}]}");
+            Object value = path.extract(reader);
+            System.out.println(value);
+            assertNotNull(value);
         }
     }
 }


### PR DESCRIPTION
fix 2 bugs:

1. JSONPath.eval() does not support get field after randomIndex(), throws TODO . Exception
2. JSONPath.extract() does not support randomIndex()