### PR TITLE
adjust the set method logic of JSONArray

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -80,18 +80,17 @@ public class JSONArray extends ArrayList<Object> {
             );
         }
 
-        int range = index - size;
-        if (range > 0) {
-            while (--range != -1) {
-                super.add(null);
-            }
-            super.add(element);
-            return null;
+        if (index < size) {
+            return super.set(
+                index, element
+            );
         }
 
-        return super.set(
-            index, element
-        );
+        while (index-- != size) {
+            super.add(null);
+        }
+        super.add(element);
+        return null;
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -50,26 +50,48 @@ public class JSONArray extends ArrayList<Object> {
     public JSONArray(Object... items) {
         super(items.length);
         for (Object item : items) {
-            add(item);
+            super.add(item);
         }
     }
 
+    /**
+     * Replaces the element at the specified position with the specified element
+     *
+     * <pre>{@code
+     *    JSONArray array = new JSONArray();
+     *    array.add(-1); // [-1]
+     *    array.add(2); // [-1,2]
+     *    array.set(0, 1); // [1,2]
+     *    array.set(4, 3); // [1,2,null,null,3]
+     *    array.set(-1, -1); // [1,2,null,null,-1]
+     * }</pre>
+     *
+     * @param index   index of the element to replace
+     * @param element element to be stored at the specified position
+     * @return the element previously at the specified position
+     * @throws ArrayIndexOutOfBoundsException if the index is out of range {@code (index < -size()}
+     */
     @Override
     public Object set(int index, Object element) {
-        if (index == -1) {
-            add(element);
-            return null;
+        int size = super.size();
+        if (index < 0) {
+            return super.set(
+                index + size, element
+            );
         }
 
-        if (size() <= index) {
-            for (int i = size(); i < index; ++i) {
-                add(null);
+        int range = index - size;
+        if (range > 0) {
+            while (--range != -1) {
+                super.add(null);
             }
-            add(element);
+            super.add(element);
             return null;
         }
 
-        return super.set(index, element);
+        return super.set(
+            index, element
+        );
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -69,14 +69,18 @@ public class JSONArray extends ArrayList<Object> {
      * @param index   index of the element to replace
      * @param element element to be stored at the specified position
      * @return the element previously at the specified position
-     * @throws ArrayIndexOutOfBoundsException if the index is out of range {@code (index < -size()}
      */
     @Override
     public Object set(int index, Object element) {
         int size = super.size();
         if (index < 0) {
+            index += size;
+            if (index < 0) {
+                super.add(element);
+                return null;
+            }
             return super.set(
-                index + size, element
+                index, element
             );
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
@@ -1096,6 +1096,33 @@ public class JSONArrayTest {
         );
     }
 
+    @Test
+    public void test_set_index() {
+        JSONArray array = new JSONArray();
+        array.add(-1);
+        array.add(2);
+
+        array.set(0, 1);
+        assertEquals(
+            "[1,2]", array.toString()
+        );
+
+        array.set(4, 3);
+        assertEquals(
+            "[1,2,null,null,3]", array.toString()
+        );
+
+        array.set(-1, -1);
+        assertEquals(
+            "[1,2,null,null,-1]", array.toString()
+        );
+
+        array.set(-2, -2);
+        assertEquals(
+            "[1,2,null,-2,-1]", array.toString()
+        );
+    }
+
     public static class Bean {
 
     }

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
@@ -1099,10 +1099,14 @@ public class JSONArrayTest {
     @Test
     public void test_set_index() {
         JSONArray array = new JSONArray();
-        array.add(-1);
-        array.add(2);
+        array.set(-1, -1);
+        assertEquals(
+            "[-1]", array.toString()
+        );
 
         array.set(0, 1);
+        array.add(2);
+
         assertEquals(
             "[1,2]", array.toString()
         );


### PR DESCRIPTION
### What this PR does / why we need it?

adjust the set method logic of JSONArray

### Summary of your change

`array.set(-1, object); `  no longer call `add(object)`, indicates reverse order replacement

```java
JSONArray array = new JSONArray();
array.add(-1); // [-1]
array.add(2); // [-1,2]
array.set(0, 1); // [1,2]
array.set(4, 3); // [1,2,null,null,3]
array.set(-1, -1); // [1,2,null,null,-1]
```

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
