### PR TITLE
extend set method ofJSONArray again

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -64,11 +64,14 @@ public class JSONArray extends ArrayList<Object> {
      *    array.set(0, 1); // [1,2]
      *    array.set(4, 3); // [1,2,null,null,3]
      *    array.set(-1, -1); // [1,2,null,null,-1]
+     *    array.set(-2, -2); // [1,2,null,-2,-1]
+     *    array.set(-6, -6); // [-6,1,2,null,-2,-1]
      * }</pre>
      *
      * @param index   index of the element to replace
      * @param element element to be stored at the specified position
      * @return the element previously at the specified position
+     * @since 2.0.3
      */
     @Override
     public Object set(int index, Object element) {
@@ -76,7 +79,9 @@ public class JSONArray extends ArrayList<Object> {
         if (index < 0) {
             index += size;
             if (index < 0) {
-                super.add(element);
+                super.add(
+                    0, element
+                );
                 return null;
             }
             return super.set(

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -79,9 +79,8 @@ public class JSONArray extends ArrayList<Object> {
         if (index < 0) {
             index += size;
             if (index < 0) {
-                super.add(
-                    0, element
-                );
+                // left join elem
+                super.add(0, element);
                 return null;
             }
             return super.set(
@@ -95,10 +94,13 @@ public class JSONArray extends ArrayList<Object> {
             );
         }
 
-        while (index-- != size) {
-            super.add(null);
+        // max expansion (size + 4096)
+        if (index < size + 4096) {
+            while (index-- != size) {
+                super.add(null);
+            }
+            super.add(element);
         }
-        super.add(element);
         return null;
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
@@ -1131,6 +1131,21 @@ public class JSONArrayTest {
         assertEquals(
             "[-6,1,2,null,-2,-1]", array.toString()
         );
+
+        // size = 6
+        // Integer.MAX_VALUE out of range (6 + 4096 = 4102)
+        array.set(
+            Integer.MAX_VALUE, Integer.MAX_VALUE
+        );
+        assertEquals(
+            "[-6,1,2,null,-2,-1]", array.toString()
+        );
+        array.set(
+            4102, 4102
+        );
+        assertEquals(
+            "[-6,1,2,null,-2,-1]", array.toString()
+        );
     }
 
     public static class Bean {

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
@@ -1125,6 +1125,12 @@ public class JSONArrayTest {
         assertEquals(
             "[1,2,null,-2,-1]", array.toString()
         );
+
+        // out of range
+        array.set(-6, -6);
+        assertEquals(
+            "[-6,1,2,null,-2,-1]", array.toString()
+        );
     }
 
     public static class Bean {


### PR DESCRIPTION
### What this PR does / why we need it?

extend set method ofJSONArray again

### Summary of your change

```java
JSONArray array = new JSONArray();
array.add(-1); // [-1]
array.add(2); // [-1,2]
array.set(0, 1); // [1,2]
array.set(4, 3); // [1,2,null,null,3]
```

```java
array.set(-1, -1); // [1,2,null,null,-1]
array.set(-2, -2); // [1,2,null,-2,-1]

// out of range
array.set(-6, -6); // [-6,1,2,null,-2,-1]
```

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
