### PR TITLE
deprecate `toJavaObject` and rename it to `to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ byte[] bytes = JSONB.toBytes(user, JSONWriter.Feature.BeanToArray);
 
 ```java
 byte[] bytes = ...
-User user = JSONB.parseObject(bytes, Product.class);
-User user = JSONB.parseObject(bytes, Product.class, JSONReader.Feature.SupportBeanArrayMapping);
+User user = JSONB.parseObject(bytes, User.class);
+User user = JSONB.parseObject(bytes, User.class, JSONReader.Feature.SupportBeanArrayMapping);
 ```
 
 ### 3.2 使用`JSONPath`

--- a/README_EN.md
+++ b/README_EN.md
@@ -289,8 +289,8 @@ byte[] bytes = JSONB.toBytes(user, JSONWriter.Feature.BeanToArray);
 
 ```java
 byte[] bytes = ...
-User user = JSONB.parseObject(bytes, Product.class);
-User user = JSONB.parseObject(bytes, Product.class, JSONReader.Feature.SupportBeanArrayMapping);
+User user = JSONB.parseObject(bytes, User.class);
+User user = JSONB.parseObject(bytes, User.class, JSONReader.Feature.SupportBeanArrayMapping);
 ```
 
 ### 3.2 Use `JSONPath`

--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -109,6 +109,7 @@ public interface JSON {
      * @param features features to be enabled in parsing
      * @return JSONObject
      */
+    @SuppressWarnings("unchecked")
     static JSONObject parseObject(InputStream input, JSONReader.Feature... features) {
         try (JSONReader reader = JSONReader.of(input, StandardCharsets.UTF_8)) {
             reader.getContext().config(features);
@@ -447,7 +448,6 @@ public interface JSON {
      * @param type     specify the {@link Type} to be converted
      * @param features features to be enabled in parsing
      */
-    @SuppressWarnings("unchecked")
     static <T> T parseObject(URL url, Type type, JSONReader.Feature... features) {
         if (url == null) {
             return null;
@@ -467,7 +467,6 @@ public interface JSON {
      * @param function specify the {@link Function} to be converted
      * @param features features to be enabled in parsing
      */
-    @SuppressWarnings("unchecked")
     static <T> T parseObject(URL url, Function<JSONObject, T> function, JSONReader.Feature... features) {
         if (url == null) {
             return null;
@@ -1320,18 +1319,32 @@ public interface JSON {
     /**
      * Convert the Object to the target type
      *
-     * @param object Java Object to be converted
      * @param clazz  converted goal class
+     * @param object Java Object to be converted
+     * @since 2.0.4
      */
-    static <T> T toJavaObject(Object object, Class<T> clazz) {
+    static <T> T to(Class<T> clazz, Object object) {
         if (object == null) {
             return null;
         }
+
         if (object instanceof JSONObject) {
-            return ((JSONObject) object).toJavaObject(clazz);
+            return ((JSONObject) object).to(clazz);
         }
 
         return TypeUtils.cast(object, clazz);
+    }
+
+    /**
+     * Convert the Object to the target type
+     *
+     * @param object Java Object to be converted
+     * @param clazz  converted goal class
+     * @deprecated since 2.0.4, please use {@link #to(Class, Object)}
+     */
+    @Deprecated
+    static <T> T toJavaObject(Object object, Class<T> clazz) {
+        return to(clazz, object);
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -149,7 +149,7 @@ public class JSONArray extends ArrayList<Object> {
             return null;
         }
 
-        Class valueClass = value.getClass();
+        Class<?> valueClass = value.getClass();
         if (valueClass.isArray()) {
             int length = Array.getLength(value);
             JSONArray jsonArray = new JSONArray(length);
@@ -800,7 +800,7 @@ public class JSONArray extends ArrayList<Object> {
         }
 
         if (value instanceof Boolean) {
-            return ((Boolean) value).booleanValue() ? BigDecimal.ONE : BigDecimal.ZERO;
+            return (boolean) value ? BigDecimal.ONE : BigDecimal.ZERO;
         }
 
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigDecimal");
@@ -886,6 +886,7 @@ public class JSONArray extends ArrayList<Object> {
      * @param features features to be enabled in serialization
      * @return JSON {@link String}
      */
+    @SuppressWarnings("unchecked")
     public String toString(JSONWriter.Feature... features) {
         try (JSONWriter writer = JSONWriter.of(features)) {
             if (arrayWriter == null) {
@@ -911,6 +912,7 @@ public class JSONArray extends ArrayList<Object> {
      * @param features features to be enabled in serialization
      * @return JSONB bytes
      */
+    @SuppressWarnings("unchecked")
     public byte[] toJSONBBytes(JSONWriter.Feature... features) {
         try (JSONWriter writer = JSONWriter.ofJSONB(features)) {
             if (arrayWriter == null) {
@@ -923,31 +925,48 @@ public class JSONArray extends ArrayList<Object> {
 
     /**
      * Convert this {@link JSONArray} to the specified Object
-     * <p>
-     * {@code List<User> users = jsonArray.toJavaObject(new TypeReference<ArrayList<User>>(){}.getType());}
+     *
+     * <pre>{@code
+     * JSONArray array = ...
+     * List<User> users = array.to(new TypeReference<ArrayList<User>>(){}.getType());
+     * }</pre>
      *
      * @param type specify the {@link Type} to be converted
+     * @since 2.0.4
      */
     @SuppressWarnings("unchecked")
-    public <T> T toJavaObject(Type type) {
+    public <T> T to(Type type) {
         ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
         ObjectReader<T> objectReader = provider.getObjectReader(type);
         return objectReader.createInstance(this);
     }
 
     /**
+     * Convert this {@link JSONArray} to the specified Object
+     *
+     * @param type specify the {@link Type} to be converted
+     * @deprecated since 2.0.4, please use {@link #to(Type)}
+     */
+    @Deprecated
+    public <T> T toJavaObject(Type type) {
+        return to(type);
+    }
+
+    /**
      * Convert all the members of this {@link JSONArray} into the specified Object.
      * Warning that each member of the {@link JSONArray} must implement the {@link Map} interface.
      *
-     * <pre>{@code String json = "[{\"id\": 1, \"name\": \"fastjson\"}, {\"id\": 2, \"name\": \"fastjson2\"}]";
+     * <pre>{@code
+     * String json = "[{\"id\": 1, \"name\": \"fastjson\"}, {\"id\": 2, \"name\": \"fastjson2\"}]";
      * JSONArray array = JSON.parseArray(json);
-     * List<User> users = array.toJavaList(User.class);
+     * List<User> users = array.toList(User.class);
      * }</pre>
      *
      * @param clazz specify the {@code Class<T>} to be converted
+     * @param features features to be enabled in parsing
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public <T> List<T> toJavaList(Class<T> clazz, JSONReader.Feature... features) {
+    public <T> List<T> toList(Class<T> clazz, JSONReader.Feature... features) {
         boolean fieldBased = false;
         long featuresValue = 0;
         for (JSONReader.Feature feature : features) {
@@ -978,6 +997,18 @@ public class JSONArray extends ArrayList<Object> {
         }
 
         return list;
+    }
+
+    /**
+     * Convert all the members of this {@link JSONArray} into the specified Object.
+     *
+     * @param clazz specify the {@code Class<T>} to be converted
+     * @param features features to be enabled in parsing
+     * @deprecated since 2.0.4, please use {@link #toList(Class, JSONReader.Feature...)}
+     */
+    @Deprecated
+    public <T> List<T> toJavaList(Class<T> clazz, JSONReader.Feature... features) {
+        return toList(clazz, features);
     }
 
     /**
@@ -1123,6 +1154,9 @@ public class JSONArray extends ArrayList<Object> {
         return object;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public <T> T getObject(int index, Function<JSONObject, T> creator) {
         JSONObject object = getJSONObject(index);
         if (object == null) {
@@ -1145,36 +1179,57 @@ public class JSONArray extends ArrayList<Object> {
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public JSONArray fluentClear() {
         clear();
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public JSONArray fluentRemove(int index) {
         remove(index);
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public JSONArray fluentSet(int index, Object element) {
         set(index, element);
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public JSONArray fluentRemove(Object o) {
         remove(o);
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public JSONArray fluentRemoveAll(Collection<?> c) {
         removeAll(c);
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public JSONArray fluentAddAll(Collection<?> c) {
         addAll(c);
         return this;
     }
 
+    /**
+     * @since 2.0.3
+     */
     public void validate(JSONSchema schema) {
         schema.validate(this);
     }

--- a/core/src/main/java/com/alibaba/fastjson2/TypeReference.java
+++ b/core/src/main/java/com/alibaba/fastjson2/TypeReference.java
@@ -130,23 +130,6 @@ public abstract class TypeReference<T> {
     }
 
     /**
-     * See {@link JSONObject#to} for details
-     *
-     * <pre>{@code
-     * JSONObject object = ...
-     * Map<String, User> users = new TypeReference<HashMap<String, User>>(){}.parseObject(object);
-     * }</pre>
-     *
-     * @param object specify the {@link JSONObject} to convert
-     * @since 2.0.2
-     * @deprecated since 2.0.3, please use {@link #toJavaObject(JSONObject, JSONReader.Feature...)}
-     */
-    @Deprecated
-    public T parseObject(JSONObject object) {
-        return object.toJavaObject(type);
-    }
-
-    /**
      * See {@link JSON#parseArray(String, JSONReader.Feature...)} for details
      *
      * <pre>{@code
@@ -179,51 +162,57 @@ public abstract class TypeReference<T> {
     }
 
     /**
-     * See {@link JSONArray#toJavaObject} for details
+     * See {@link JSONArray#to(Type)} for details
      *
      * <pre>{@code
      * JSONArray array = ...
-     * List<User> users = new TypeReference<ArrayList<User>>(){}.parseArray(array);
+     * List<User> users = new TypeReference<ArrayList<User>>(){}.to(array);
      * }</pre>
      *
      * @param array specify the {@link JSONArray} to convert
-     * @since 2.0.2
-     * @deprecated since 2.0.3, please use {@link #toJavaObject(JSONArray)}
+     * @since 2.0.4
      */
-    @Deprecated
-    public T parseArray(JSONArray array) {
-        return array.toJavaObject(type);
+    public T to(JSONArray array) {
+        return array.to(type);
     }
 
     /**
-     * See {@link JSONObject#toJavaObject(Type, JSONReader.Feature...)} for details
+     * See {@link JSONObject#to(Type, JSONReader.Feature...)} for details
      *
      * <pre>{@code
      * JSONObject object = ...
-     * Map<String, User> users = new TypeReference<HashMap<String, User>>(){}.toJavaObject(object);
+     * Map<String, User> users = new TypeReference<HashMap<String, User>>(){}.to(object);
      * }</pre>
      *
      * @param object   specify the {@link JSONObject} to convert
      * @param features features to be enabled in parsing
-     * @since 2.0.3
+     * @since 2.0.4
      */
-    public T toJavaObject(JSONObject object, JSONReader.Feature... features) {
-        return object.toJavaObject(type, features);
+    public T to(JSONObject object, JSONReader.Feature... features) {
+        return object.to(type, features);
     }
 
     /**
      * See {@link JSONArray#toJavaObject(Type)} for details
      *
-     * <pre>{@code
-     * JSONArray array = ...
-     * List<User> users = new TypeReference<ArrayList<User>>(){}.toJavaObject(array);
-     * }</pre>
-     *
      * @param array specify the {@link JSONArray} to convert
-     * @since 2.0.3
+     * @deprecated since 2.0.4, please use {@link #to(JSONArray)}
      */
+    @Deprecated
     public T toJavaObject(JSONArray array) {
-        return array.toJavaObject(type);
+        return array.to(type);
+    }
+
+    /**
+     * See {@link JSONObject#to(Type, JSONReader.Feature...)} for details
+     *
+     * @param object   specify the {@link JSONObject} to convert
+     * @param features features to be enabled in parsing
+     * @deprecated since 2.0.4, please use {@link #to(JSONObject, JSONReader.Feature...)}
+     */
+    @Deprecated
+    public T toJavaObject(JSONObject object, JSONReader.Feature... features) {
+        return object.to(type, features);
     }
 
     /**

--- a/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONArray.kt
+++ b/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONArray.kt
@@ -4,6 +4,21 @@ package com.alibaba.fastjson2
  * E.g.
  * ```
  *   val data = "...".parseArray()
+ *   val users = data.to<List<User>>()
+ * ```
+ *
+ * @receiver JSONArray
+ * @return [T]?
+ * @since 2.0.3
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> JSONArray.to() =
+    to<T>(reference<T>().getType())
+
+/**
+ * E.g.
+ * ```
+ *   val data = "...".parseArray()
  *   val user = data.toList<User>()
  * ```
  *
@@ -15,7 +30,7 @@ package com.alibaba.fastjson2
 @Suppress("HasPlatformType")
 inline fun <reified T> JSONArray.toList(
     vararg features: JSONReader.Feature
-) = toJavaList(
+) = toList(
     T::class.java, *features
 )
 

--- a/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONObject.kt
+++ b/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONObject.kt
@@ -4,7 +4,7 @@ package com.alibaba.fastjson2
  * E.g.
  * ```
  *   val data = "...".parseObject()
- *   val user = data.toObject<User>()
+ *   val user = data.to<User>()
  * ```
  *
  * @receiver JSONObject
@@ -13,9 +13,9 @@ package com.alibaba.fastjson2
  * @since 2.0.3
  */
 @Suppress("HasPlatformType")
-inline fun <reified T> JSONObject.toObject(
+inline fun <reified T> JSONObject.to(
     vararg features: JSONReader.Feature
-) = toJavaObject(
+) = to(
     T::class.java, *features
 )
 

--- a/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONObjectTest.kt
+++ b/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONObjectTest.kt
@@ -23,7 +23,7 @@ class JSONObjectTest {
             put("name", "kraity")
         }
 
-        val user = data.toObject<User>()
+        val user = data.to<User>()
         assertEquals(1, user.id)
         assertEquals("kraity", user.name)
     }


### PR DESCRIPTION
### What this PR does / why we need it?

deprecate `toJavaObject` and rename it to `to`

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
