### PR TITLE
add `into` methods for kt-module

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -964,6 +964,7 @@ public class JSONArray extends ArrayList<Object> {
      *
      * @param clazz specify the {@code Class<T>} to be converted
      * @param features features to be enabled in parsing
+     * @since 2.0.4
      */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public <T> List<T> toList(Class<T> clazz, JSONReader.Feature... features) {
@@ -1013,8 +1014,11 @@ public class JSONArray extends ArrayList<Object> {
 
     /**
      * Returns the result of the {@link Type} converter conversion of the element at the specified position in this {@link JSONArray}.
-     * <p>
-     * {@code User user = jsonArray.getObject(0, User.class);}
+     *
+     * <pre>{@code
+     * JSONArray array = ...
+     * User user = array.getObject(0, TypeReference<HashMap<String ,User>>(){}.getType());
+     * }</pre>
      *
      * @param index index of the element to return
      * @param type  specify the {@link Type} to be converted
@@ -1159,9 +1163,11 @@ public class JSONArray extends ArrayList<Object> {
      */
     public <T> T getObject(int index, Function<JSONObject, T> creator) {
         JSONObject object = getJSONObject(index);
+
         if (object == null) {
             return null;
         }
+
         return creator.apply(object);
     }
 

--- a/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSON.kt
+++ b/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSON.kt
@@ -20,8 +20,27 @@ import java.nio.charset.Charset
  * @since 2.0.3
  */
 @Suppress("HasPlatformType")
-inline fun <reified T> String.to() =
+inline fun <reified T> String?.to() =
     JSON.parseObject(this, T::class.java)
+
+/**
+ * Parse JSON [String] into [T]
+ * Implemented using [TypeReference]
+ *
+ * E.g.
+ * ```
+ *   val text = "..."
+ *   val data = text.to<User>()
+ * ```
+ *
+ * @return [T]?
+ * @since 2.0.3
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> String?.into() =
+    JSON.parseObject<T>(
+        this, reference<T>().getType()
+    )
 
 /**
  * Parse JSON [ByteArray] into [T]
@@ -38,6 +57,25 @@ inline fun <reified T> String.to() =
 @Suppress("HasPlatformType")
 inline fun <reified T> ByteArray.to() =
     JSON.parseObject(this, T::class.java)
+
+/**
+ * Parse JSON [ByteArray] into [T]
+ * Implemented using [TypeReference]
+ *
+ * E.g.
+ * ```
+ *   val text = "..."
+ *   val data = text.into<Map<String, User>()
+ * ```
+ *
+ * @return [T]?
+ * @since 2.0.3
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> ByteArray.into() =
+    JSON.parseObject<T>(
+        this, reference<T>().getType()
+    )
 
 /**
  * Verify the [String] is JSON `Object`

--- a/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONArray.kt
+++ b/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONArray.kt
@@ -4,7 +4,7 @@ package com.alibaba.fastjson2
  * E.g.
  * ```
  *   val data = "...".parseArray()
- *   val users = data.to<List<User>>()
+ *   val users = data.to<Users>()
  * ```
  *
  * @receiver JSONArray
@@ -12,8 +12,63 @@ package com.alibaba.fastjson2
  * @since 2.0.3
  */
 @Suppress("HasPlatformType")
-inline fun <reified T : Any> JSONArray.to() =
+inline fun <reified T> JSONArray.to() =
+    to<T>(T::class.java)
+
+/**
+ * Implemented using [TypeReference]
+ *
+ * E.g.
+ * ```
+ *   val data = "...".parseArray()
+ *   val users = data.into<List<User>>()
+ * ```
+ *
+ * @receiver JSONArray
+ * @return [T]?
+ * @since 2.0.3
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> JSONArray.into() =
     to<T>(reference<T>().getType())
+
+/**
+ * E.g.
+ * ```
+ *   val data = "...".parseArray()
+ *   val users = data.to<User>(6)
+ * ```
+ *
+ * @return [T]?
+ * @since 2.0.4
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T> JSONArray.to(
+    index: Int,
+    vararg features: JSONReader.Feature
+) = getObject(
+    index, T::class.java, *features
+)
+
+/**
+ * Implemented using [TypeReference]
+ *
+ * E.g.
+ * ```
+ *   val data = "...".parseArray()
+ *   val users = data.into<Map<String, User>>(6)
+ * ```
+ *
+ * @return [T]?
+ * @since 2.0.4
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> JSONArray.into(
+    index: Int,
+    vararg features: JSONReader.Feature
+) = getObject<T>(
+    index, reference<T>().getType(), *features
+)
 
 /**
  * E.g.
@@ -32,26 +87,4 @@ inline fun <reified T> JSONArray.toList(
     vararg features: JSONReader.Feature
 ) = toList(
     T::class.java, *features
-)
-
-/**
- * E.g.
- * ```
- *   // JSONArray
- *   val data = "...".parseArray()
- *   val user = data.getObject<User>(0)
- * ```
- *
- * @receiver JSONArray
- * @param index index of the element to return
- * @param features features to be enabled in parsing
- * @return [T]?
- * @since 2.0.3
- */
-@Suppress("HasPlatformType")
-inline fun <reified T> JSONArray.getObject(
-    index: Int,
-    vararg features: JSONReader.Feature
-) = getObject(
-    index, T::class.java, *features
 )

--- a/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONObject.kt
+++ b/kotlin/src/main/kotlin/com/alibaba/fastjson2/JSONObject.kt
@@ -20,23 +20,64 @@ inline fun <reified T> JSONObject.to(
 )
 
 /**
+ * Implemented using [TypeReference]
+ *
+ * E.g.
+ * ```
+ *   val data = "...".parseObject()
+ *   val user = data.into<User>()
+ * ```
+ *
+ * @receiver JSONObject
+ * @param features features to be enabled in parsing
+ * @return [T]?
+ * @since 2.0.4
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> JSONObject.into(
+    vararg features: JSONReader.Feature
+) = to<T>(
+    reference<T>().getType(), *features
+)
+
+/**
  * E.g.
  * ```
  *  // JSONObject
  *   val data = "...".parseObject()
- *   val user = data.getObject<User>("key")
+ *   val user = data.to<User>("key")
  * ```
  *
  * @receiver JSONObject
  * @param key the key whose associated value is to be returned
  * @param features features to be enabled in parsing
  * @return [T]?
- * @since 2.0.3
+ * @since 2.0.4
  */
 @Suppress("HasPlatformType")
-inline fun <reified T> JSONObject.getObject(
+inline fun <reified T> JSONObject.to(
     key: String,
     vararg features: JSONReader.Feature
 ) = getObject(
     key, T::class.java, *features
+)
+
+/**
+ * Implemented using [TypeReference]
+ *
+ * E.g.
+ * ```
+ *   val data = "...".parseObject()
+ *   val users = data.into<List<User>>("key")
+ * ```
+ *
+ * @return [T]?
+ * @since 2.0.4
+ */
+@Suppress("HasPlatformType")
+inline fun <reified T : Any> JSONObject.into(
+    key: String,
+    vararg features: JSONReader.Feature
+) = getObject<T>(
+    key, reference<T>().getType(), *features
 )

--- a/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONArrayTest.kt
+++ b/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONArrayTest.kt
@@ -9,7 +9,7 @@ class JSONArrayTest {
         // JSONArray
         val data = """[{"id":1,"name":"kraity"}]""".parseArray()
 
-        val user = data.getObject<User>(0)
+        val user = data.to<User>(0)
         assertEquals(1, user.id)
         assertEquals("kraity", user.name)
     }

--- a/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONObjectTest.kt
+++ b/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONObjectTest.kt
@@ -10,7 +10,7 @@ class JSONObjectTest {
         // JSONObject
         val data = """{"key":{"id":1,"name":"kraity"}}""".parseObject()
 
-        val user = data.getObject<User>("key")
+        val user = data.to<User>("key")
         assertEquals(1, user.id)
         assertEquals("kraity", user.name)
     }
@@ -24,6 +24,24 @@ class JSONObjectTest {
         }
 
         val user = data.to<User>()
+        assertEquals(1, user.id)
+        assertEquals("kraity", user.name)
+    }
+
+    @Test
+    fun test_toObject2() {
+        // JSONObject
+        val data = JSONObject().apply {
+            put("user", JSONObject().apply {
+                put("id", 1)
+                put("name", "kraity")
+            })
+        }
+
+        // Use TypeReference
+        val users = data.into<Map<String, User>>()
+        val user = users["user"]!!
+
         assertEquals(1, user.id)
         assertEquals("kraity", user.name)
     }

--- a/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONTest.kt
+++ b/kotlin/src/test/kotlin/com/alibaba/fastjson2/JSONTest.kt
@@ -7,6 +7,26 @@ import java.io.ByteArrayInputStream
 class JSONTest {
 
     @Test
+    fun test_into1() {
+        val users = """[{"id":1,"name":"kraity"}]""".into<List<User>>()
+        assertEquals(1, users.size)
+
+        val user = users[0]
+        assertEquals(1, user.id)
+        assertEquals("kraity", user.name)
+    }
+
+    @Test
+    fun test_into2() {
+        val users = """{"user":{"id":1,"name":"kraity"}}""".into<Map<String, User>>()
+        assertEquals(1, users.size)
+
+        val user = users["user"]!!
+        assertEquals(1, user.id)
+        assertEquals("kraity", user.name)
+    }
+
+    @Test
     fun test_parseObject1() {
         val text = """{"id":1,"name":"kraity"}"""
         val data = text.to<User>()


### PR DESCRIPTION
### What this PR does / why we need it?

add `into` methods for kt-module

### Summary of your change

Call `to` to use `Class`, and call `into` to use `TypeReference`

wrong way:
```kotlin
val users = """{"user":{"id":1,"name":"kraity"}}""".to<Map<String, User>>()  // call to
```

correct way:
```kotlin
val users = """{"user":{"id":1,"name":"kraity"}}""".into<Map<String, User>>()   // call into
```

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
