### PR TITLE
重命名保持名字和类型一致

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -1420,8 +1420,8 @@ public interface JSON {
         return JSONFactory.getDefaultObjectReaderProvider().register(objectReaderModule);
     }
 
-    static boolean register(ObjectWriterModule objectReaderModule) {
-        return JSONFactory.getDefaultObjectWriterProvider().register(objectReaderModule);
+    static boolean register(ObjectWriterModule objectWriterModule) {
+        return JSONFactory.getDefaultObjectWriterProvider().register(objectWriterModule);
     }
 
     /**


### PR DESCRIPTION
保持和`ObjectWriterModule`的类型一致