### PR TITLE
Add reader filters to FastJsonConfig

### DIFF
--- a/docs/spring_support_cn.md
+++ b/docs/spring_support_cn.md
@@ -37,6 +37,7 @@ charset | Charset | 指定的字符集，默认UTF-8
 dateFormat | String | 指定的日期格式，默认yyyy-MM-dd HH:mm:ss
 writerFilters | Filter[] | 配置序列化过滤器
 writerFeatures | JSONWriter.Feature[] | 配置序列化的指定行为，更多配置请见：[Features](features_cn.md)
+readerFilters | Filter[] | 配置反序列化过滤器
 readerFeatures | JSONReader.Feature[] | 配置反序列化的指定行为，更多配置请见：[Features](features_cn.md)
 jsonb | boolean | 是否采用JSONB进行序列化和反序列化，默认false
 symbolTable | JSONB.SymbolTable | JSONB序列化和反序列化的符号表，只有使用JSONB时生效

--- a/docs/spring_support_en.md
+++ b/docs/spring_support_en.md
@@ -38,6 +38,7 @@ charset | Charset | The specified character set, default UTF-8
 dateFormat | String | The specified date format, default yyyy-MM-dd HH:mm:ss
 writerFilters | Filter[] | Configure serialization filters
 writerFeatures | JSONWriter.Feature[] | Configure the specified behavior of serialization. For more configuration, see [Features](features_en.md)
+readerFilters | Filter[] | Configure deserialization filters
 readerFeatures | JSONReader.Feature[] | Configure the specified behavior of deserialization. For more configuration, see [Features](features_en.md)
 jsonb | boolean | Use JSONB for serialization and deserialization, the default is false
 symbolTable | JSONB.SymbolTable | JSONB serialization and deserialization symbol table, only valid when using JSONB

--- a/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
@@ -39,6 +39,11 @@ public class FastJsonConfig {
     private JSONWriter.Feature[] writerFeatures;
 
     /**
+     * JSONReader Filters
+     */
+    private Filter[] readerFilters;
+
+    /**
      * JSONWriter Filters
      */
     private Filter[] writerFilters;
@@ -66,6 +71,7 @@ public class FastJsonConfig {
         this.charset = StandardCharsets.UTF_8;
         this.readerFeatures = new JSONReader.Feature[0];
         this.writerFeatures = new JSONWriter.Feature[0];
+        this.readerFilters = new Filter[0];
         this.writerFilters = new Filter[0];
         this.writeContentLength = true;
     }
@@ -140,6 +146,24 @@ public class FastJsonConfig {
      */
     public void setWriterFeatures(JSONWriter.Feature... writerFeatures) {
         this.writerFeatures = writerFeatures;
+    }
+
+    /**
+     * Get reader filters filter [ ].
+     *
+     * @return the filter [ ]
+     */
+    public Filter[] getReaderFilters() {
+        return readerFilters;
+    }
+
+    /**
+     * Sets reader filters.
+     *
+     * @param readerFilters the reader filters
+     */
+    public void setReaderFilters(Filter... readerFilters) {
+        this.readerFilters = readerFilters;
     }
 
     /**

--- a/extension/src/main/java/com/alibaba/fastjson2/support/retrofit/Retrofit2ConverterFactory.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/retrofit/Retrofit2ConverterFactory.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.support.retrofit;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.support.config.FastJsonConfig;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
@@ -80,7 +81,11 @@ public class Retrofit2ConverterFactory
         @Override
         public T convert(ResponseBody value) throws IOException {
             try {
-                return JSON.parseObject(value.bytes(), type, config.getDateFormat(), config.getReaderFeatures());
+                if (config.isJSONB()) {
+                    return JSONB.parseObject(value.bytes(), type, config.getSymbolTable(), config.getReaderFilters(), config.getReaderFeatures());
+                } else {
+                    return JSON.parseObject(value.bytes(), type, config.getDateFormat(), config.getReaderFilters(), config.getReaderFeatures());
+                }
             } catch (Exception e) {
                 throw new IOException("JSON parse error: " + e.getMessage(), e);
             } finally {
@@ -97,7 +102,12 @@ public class Retrofit2ConverterFactory
         @Override
         public RequestBody convert(T value) throws IOException {
             try {
-                byte[] content = JSON.toJSONBytes(value, config.getDateFormat(), config.getWriterFilters(), config.getWriterFeatures());
+                byte[] content;
+                if (config.isJSONB()) {
+                    content = JSONB.toBytes(value, config.getSymbolTable(), config.getWriterFilters(), config.getWriterFeatures());
+                } else {
+                    content = JSON.toJSONBytes(value, config.getDateFormat(), config.getWriterFilters(), config.getWriterFeatures());
+                }
                 return RequestBody.create(MEDIA_TYPE, content);
             } catch (Exception e) {
                 throw new IOException("Could not write JSON: " + e.getMessage(), e);

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/data/redis/FastJsonRedisSerializer.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/data/redis/FastJsonRedisSerializer.java
@@ -38,10 +38,9 @@ public class FastJsonRedisSerializer<T>
         }
         try {
             if (config.isJSONB()) {
-                return JSONB.toBytes(t, config.getSymbolTable(), config.getWriterFeatures());
+                return JSONB.toBytes(t, config.getSymbolTable(), config.getWriterFilters(), config.getWriterFeatures());
             } else {
-                return JSON.toJSONBytes(t, config.getDateFormat(),
-                        config.getWriterFilters(), config.getWriterFeatures());
+                return JSON.toJSONBytes(t, config.getDateFormat(), config.getWriterFilters(), config.getWriterFeatures());
             }
         } catch (Exception ex) {
             throw new SerializationException("Could not serialize: " + ex.getMessage(), ex);
@@ -55,10 +54,9 @@ public class FastJsonRedisSerializer<T>
         }
         try {
             if (config.isJSONB()) {
-                return JSONB.parseObject(bytes, type, config.getSymbolTable(), config.getReaderFeatures());
+                return JSONB.parseObject(bytes, type, config.getSymbolTable(), config.getReaderFilters(), config.getReaderFeatures());
             } else {
-                return JSON.parseObject(bytes, type,
-                        config.getDateFormat(), config.getReaderFeatures());
+                return JSON.parseObject(bytes, type, config.getDateFormat(), config.getReaderFilters(), config.getReaderFeatures());
             }
         } catch (Exception ex) {
             throw new SerializationException("Could not deserialize: " + ex.getMessage(), ex);

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -105,7 +105,7 @@ public class FastJsonHttpMessageConverter
             }
             byte[] bytes = baos.toByteArray();
 
-            return JSON.parseObject(bytes, type, config.getDateFormat(), config.getReaderFeatures());
+            return JSON.parseObject(bytes, type, config.getDateFormat(), config.getReaderFilters(), config.getReaderFeatures());
         } catch (JSONException ex) {
             throw new HttpMessageNotReadableException("JSON parse error: " + ex.getMessage(), ex, inputMessage);
         } catch (IOException ex) {

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/messaging/converter/MappingFastJsonMessageConverter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/messaging/converter/MappingFastJsonMessageConverter.java
@@ -62,11 +62,11 @@ public class MappingFastJsonMessageConverter
         Object payload = message.getPayload();
 
         if (payload instanceof byte[] && config.isJSONB()) {
-            obj = JSONB.parseObject((byte[]) payload, type, config.getSymbolTable(), config.getReaderFeatures());
+            obj = JSONB.parseObject((byte[]) payload, type, config.getSymbolTable(), config.getReaderFilters(), config.getReaderFeatures());
         } else if (payload instanceof byte[] && !config.isJSONB()) {
-            obj = JSON.parseObject((byte[]) payload, type, config.getDateFormat(), config.getReaderFeatures());
+            obj = JSON.parseObject((byte[]) payload, type, config.getDateFormat(), config.getReaderFilters(), config.getReaderFeatures());
         } else if (payload instanceof String && JSON.isValid((String) payload)) {
-            obj = JSON.parseObject((String) payload, type, config.getDateFormat(), config.getReaderFeatures());
+            obj = JSON.parseObject((String) payload, type, config.getDateFormat(), config.getReaderFilters(), config.getReaderFeatures());
         }
         return obj;
     }
@@ -82,7 +82,7 @@ public class MappingFastJsonMessageConverter
             } else if (payload instanceof String && !config.isJSONB()) {
                 obj = ((String) payload).getBytes(config.getCharset());
             } else if (config.isJSONB()) {
-                obj = JSONB.toBytes(payload, config.getSymbolTable(), config.getWriterFeatures());
+                obj = JSONB.toBytes(payload, config.getSymbolTable(), config.getWriterFilters(), config.getWriterFeatures());
             } else {
                 obj = JSON.toJSONBytes(payload, config.getDateFormat(), config.getWriterFilters(), config.getWriterFeatures());
             }

--- a/extension/src/main/java/com/alibaba/fastjson2/support/spring/websocket/sockjs/FastjsonSockJsMessageCodec.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/spring/websocket/sockjs/FastjsonSockJsMessageCodec.java
@@ -21,12 +21,12 @@ public class FastjsonSockJsMessageCodec
 
     @Override
     public String[] decode(String content) {
-        return JSON.parseObject(content, String[].class);
+        return JSON.parseObject(content, String[].class, config.getReaderFeatures());
     }
 
     @Override
     public String[] decodeInputStream(InputStream content) {
-        return JSON.parseObject(content, String[].class);
+        return JSON.parseObject(content, String[].class, config.getReaderFeatures());
     }
 
     @Override

--- a/extension/src/test/java/com/alibaba/fastjson2/config/FastJsonConfigTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/config/FastJsonConfigTest.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson2.config;
 
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
 import com.alibaba.fastjson2.filter.SimplePropertyPreFilter;
 import com.alibaba.fastjson2.support.config.FastJsonConfig;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,10 @@ public class FastJsonConfigTest {
         assertEquals(fastJsonConfig.getReaderFeatures()[0], JSONReader.Feature.FieldBased);
         fastJsonConfig.setWriterFeatures(JSONWriter.Feature.FieldBased);
         assertEquals(fastJsonConfig.getWriterFeatures()[0], JSONWriter.Feature.FieldBased);
+        fastJsonConfig.setReaderFilters(new ContextAutoTypeBeforeHandler(new String[]{
+                "org.springframework.security.core.context.SecurityContextImpl"
+        }));
+        assertEquals(fastJsonConfig.getReaderFilters().length > 0, true);
         fastJsonConfig.setWriterFilters(new SimplePropertyPreFilter());
         assertEquals(fastJsonConfig.getWriterFilters().length > 0, true);
         fastJsonConfig.setSymbolTable("id");

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/support/spring/GenericFastJsonRedisSerializer.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/support/spring/GenericFastJsonRedisSerializer.java
@@ -46,7 +46,6 @@ public class GenericFastJsonRedisSerializer
         if (bytes == null || bytes.length == 0) {
             return null;
         }
-
         try {
             return JSON.parseObject(bytes, Object.class, contextFilter, Feature.SupportAutoType);
         } catch (Exception ex) {


### PR DESCRIPTION
### What this PR does / why we need it?

Add reader filters to FastJsonConfig.

### Summary of your change

Refactor springframework support, add reader filters for json deserialization.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
