### PR TITLE
Add OpenApiJsonWriter for Issue 387

### DIFF
--- a/extension/src/main/java/com/alibaba/fastjson2/support/springdoc/OpenApiJsonWriter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/springdoc/OpenApiJsonWriter.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson2.support.springdoc;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+
+import java.lang.reflect.Type;
+
+/**
+ * OpenApiJsonWriter: SpringDoc的Json处理，解决json对象转成了json字符串，导致接口文档无法显示
+ *
+ * @author Victor.Zxy
+ * @since 2.0.6
+ */
+public class OpenApiJsonWriter
+        implements ObjectWriter<Object> {
+    public static final OpenApiJsonWriter INSTANCE = new OpenApiJsonWriter();
+
+    @Override
+    public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+        if (object == null) {
+            jsonWriter.writeNull();
+        } else {
+            String value = object.toString();
+            jsonWriter.writeAny(JSON.parse(value));
+        }
+    }
+}

--- a/extension/src/main/java/com/alibaba/fastjson2/support/springfox/SwaggerJsonWriter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/springfox/SwaggerJsonWriter.java
@@ -1,10 +1,12 @@
 package com.alibaba.fastjson2.support.springfox;
 
+import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 import springfox.documentation.spring.web.json.Json;
 
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 /**
  * SwaggerJsonWriter: Swagger的Json处理，解决/v2/api-docs获取不到内容导致获取不到API页面内容的问题
@@ -23,7 +25,7 @@ public class SwaggerJsonWriter
         } else if (object instanceof Json) {
             Json json = (Json) object;
             String value = json.value();
-            jsonWriter.writeString(value);
+            jsonWriter.writeAny(JSON.parse(value));
         }
     }
 }

--- a/extension/src/main/java/com/alibaba/fastjson2/support/springfox/SwaggerJsonWriter.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/springfox/SwaggerJsonWriter.java
@@ -6,7 +6,6 @@ import com.alibaba.fastjson2.writer.ObjectWriter;
 import springfox.documentation.spring.web.json.Json;
 
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 
 /**
  * SwaggerJsonWriter: Swagger的Json处理，解决/v2/api-docs获取不到内容导致获取不到API页面内容的问题

--- a/extension/src/test/java/com/alibaba/fastjson2/springdoc/OpenApiJsonWriterTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/springdoc/OpenApiJsonWriterTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson2.springdoc;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.support.springdoc.OpenApiJsonWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OpenApiJsonWriterTest {
+    String jsonStr = "{\"openapi\":\"3.0.1\",\"info\":{\"title\":\"OpenAPI definition\",\"version\":\"v0\"},\"servers\":[{\"url\":\"http://localhost:8099\",\"description\":\"Generated server url\"}],\"paths\":{},\"components\":{}}";
+
+    @Test
+    public void test() {
+        OpenApiJsonWriter writer = OpenApiJsonWriter.INSTANCE;
+        writer.write(JSONWriter.of(), null);
+        writer.write(JSONWriter.of(), jsonStr);
+    }
+
+    @Test
+    public void test1() {
+        JSON.register(String.class, OpenApiJsonWriter.INSTANCE);
+        assertEquals(jsonStr, JSON.toJSONString(jsonStr));
+    }
+}

--- a/extension/src/test/java/com/alibaba/fastjson2/springdoc/OpenApiJsonWriterTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/springdoc/OpenApiJsonWriterTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.springdoc;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.support.springdoc.OpenApiJsonWriter;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,8 @@ public class OpenApiJsonWriterTest {
 
     @Test
     public void test1() {
-        JSON.register(String.class, OpenApiJsonWriter.INSTANCE);
+        JSONFactory.getDefaultObjectWriterProvider().register(String.class, OpenApiJsonWriter.INSTANCE);
         assertEquals(jsonStr, JSON.toJSONString(jsonStr));
+        JSONFactory.getDefaultObjectWriterProvider().unregister(String.class, OpenApiJsonWriter.INSTANCE);
     }
 }

--- a/extension/src/test/java/com/alibaba/fastjson2/springfox/SwaggerJsonWriterTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/springfox/SwaggerJsonWriterTest.java
@@ -24,6 +24,5 @@ public class SwaggerJsonWriterTest {
         JSONFactory.getDefaultObjectWriterProvider().register(Json.class, SwaggerJsonWriter.INSTANCE);
         assertEquals(jsonStr, JSON.toJSONString(new Json(jsonStr)));
         JSONFactory.getDefaultObjectWriterProvider().unregister(Json.class, SwaggerJsonWriter.INSTANCE);
-
     }
 }

--- a/extension/src/test/java/com/alibaba/fastjson2/springfox/SwaggerJsonWriterTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/springfox/SwaggerJsonWriterTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.springfox;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.support.springfox.SwaggerJsonWriter;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,9 @@ public class SwaggerJsonWriterTest {
 
     @Test
     public void test1() {
-        JSON.register(Json.class, SwaggerJsonWriter.INSTANCE);
+        JSONFactory.getDefaultObjectWriterProvider().register(Json.class, SwaggerJsonWriter.INSTANCE);
         assertEquals(jsonStr, JSON.toJSONString(new Json(jsonStr)));
+        JSONFactory.getDefaultObjectWriterProvider().unregister(Json.class, SwaggerJsonWriter.INSTANCE);
+
     }
 }

--- a/extension/src/test/java/com/alibaba/fastjson2/springfox/SwaggerJsonWriterTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/springfox/SwaggerJsonWriterTest.java
@@ -1,15 +1,26 @@
 package com.alibaba.fastjson2.springfox;
 
+import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.support.springfox.SwaggerJsonWriter;
 import org.junit.jupiter.api.Test;
 import springfox.documentation.spring.web.json.Json;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class SwaggerJsonWriterTest {
+    String jsonStr = "{\"abc\":\"cde中文\"}";
+
     @Test
     public void test() {
         SwaggerJsonWriter writer = SwaggerJsonWriter.INSTANCE;
         writer.write(JSONWriter.of(), null);
-        writer.write(JSONWriter.of(), new Json("{\"abc\":\"cde中文\"}"));
+        writer.write(JSONWriter.of(), new Json(jsonStr));
+    }
+
+    @Test
+    public void test1() {
+        JSON.register(Json.class, SwaggerJsonWriter.INSTANCE);
+        assertEquals(jsonStr, JSON.toJSONString(new Json(jsonStr)));
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

Fix issue #387 .

### Summary of your change

Add `OpenApiJsonWriter` for SpringDoc String type writer.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
