### PR TITLE
fix: serialization of boolean type (Getter) in kotlin #587

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -619,21 +619,17 @@ public abstract class BeanUtils {
             }
 
             final int methodNameLength = methodName.length();
-
-            boolean nameMatch;
-            if (returnClass == boolean.class) {
-                nameMatch = methodName.startsWith("is") && methodNameLength > 2;
+            boolean nameMatch = methodNameLength > 3 && methodName.startsWith("get");
+            if (nameMatch) {
+                char firstChar = methodName.charAt(3);
+                if (firstChar >= 'a' && firstChar <= 'z' && methodNameLength == 4) {
+                    nameMatch = false;
+                }
+            } else if (returnClass == boolean.class) {
+                nameMatch = methodNameLength > 2 && methodName.startsWith("is");
                 if (nameMatch) {
                     char firstChar = methodName.charAt(2);
                     if (firstChar >= 'a' && firstChar <= 'z' && methodNameLength == 3) {
-                        nameMatch = false;
-                    }
-                }
-            } else {
-                nameMatch = methodName.startsWith("get") && methodNameLength > 3;
-                if (nameMatch) {
-                    char firstChar = methodName.charAt(3);
-                    if (firstChar >= 'a' && firstChar <= 'z' && methodNameLength == 4) {
                         nameMatch = false;
                     }
                 }

--- a/kotlin/src/test/kotlin/com/alibaba/fastjson2/issues/Issue587.kt
+++ b/kotlin/src/test/kotlin/com/alibaba/fastjson2/issues/Issue587.kt
@@ -1,0 +1,32 @@
+package com.alibaba.fastjson2.issues
+
+import com.alibaba.fastjson2.toJSONString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * @author kraity
+ */
+class Issue587 {
+
+    @Test
+    fun test0() {
+        data class BackupMMKV(
+            val mmkvKey: String,
+            val mmkvValue: Boolean
+        )
+
+        val mmkvList = mutableListOf<BackupMMKV>()
+        mmkvList.add(BackupMMKV("test1", true))
+        mmkvList.add(BackupMMKV("test2", false))
+
+        assertEquals(
+            """{"mmkvKey":"test1","mmkvValue":true}""",
+            BackupMMKV("test1", true).toJSONString()
+        )
+        assertEquals(
+            """[{"mmkvKey":"test1","mmkvValue":true},{"mmkvKey":"test2","mmkvValue":false}]""",
+            mmkvList.toJSONString()
+        )
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

fix: serialization of boolean type (Getter) in kotlin #587

### Summary of your change



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
