### PR TITLE
Combination annotations are supported for JSONBuilder, JSONCreator, JSONField and JSONType

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1543,8 +1543,8 @@ public class JSONObject
         Annotation[] annotations = method.getAnnotations();
         for (Annotation annotation : annotations) {
             Class<? extends Annotation> annotationType = annotation.annotationType();
-            if (annotationType == JSONField.class) {
-                JSONField jsonField = (JSONField) annotation;
+            JSONField jsonField = AnnotationUtils.findAnnotation(annotation, JSONField.class);
+            if (Objects.nonNull(jsonField)) {
                 name = jsonField.name();
                 if (name.isEmpty()) {
                     name = null;

--- a/core/src/main/java/com/alibaba/fastjson2/annotation/JSONCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/annotation/JSONCreator.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR })
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.ANNOTATION_TYPE })
 public @interface JSONCreator {
     String[] parameterNames() default {};
 }

--- a/core/src/main/java/com/alibaba/fastjson2/annotation/JSONField.java
+++ b/core/src/main/java/com/alibaba/fastjson2/annotation/JSONField.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  * the conversion process may not meet expectations. {@link JSONField} can not only solve this problem but also implement custom requirements.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
 public @interface JSONField {
     /**
      * The order of the fields during

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -10,9 +10,7 @@ import com.alibaba.fastjson2.modules.ObjectReaderModule;
 import com.alibaba.fastjson2.support.money.MoneySupport;
 import com.alibaba.fastjson2.util.*;
 
-import java.io.Closeable;
-import java.io.File;
-import java.io.Serializable;
+import java.io.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.math.BigDecimal;
@@ -369,8 +367,9 @@ public class ObjectReaderBaseModule
             JSONType jsonType = null;
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
-                if (annotationType == JSONType.class) {
-                    jsonType = (JSONType) annotation;
+                JSONType foundJsonType = AnnotationUtils.findAnnotation(annotation, JSONType.class);
+                if (Objects.nonNull(foundJsonType)) {
+                    jsonType = foundJsonType;
                 }
 
                 if (annotationType == JSONReadable.class) {
@@ -560,7 +559,7 @@ public class ObjectReaderBaseModule
             if (builderClass != void.class && builderClass != Void.class) {
                 beanInfo.builder = builderClass;
 
-                JSONBuilder jsonBuilder = builderClass.getAnnotation(JSONBuilder.class);
+                JSONBuilder jsonBuilder = AnnotationUtils.findAnnotation(builderClass, JSONBuilder.class);
                 if (jsonBuilder != null) {
                     String buildMethodName = jsonBuilder.buildMethod();
                     beanInfo.buildMethod = BeanUtils.buildMethod(builderClass, buildMethodName);
@@ -670,8 +669,9 @@ public class ObjectReaderBaseModule
             Annotation[] annotations = method.getAnnotations();
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
-                if (annotationType == JSONField.class) {
-                    jsonField = (JSONField) annotation;
+                JSONField foundJsonField = AnnotationUtils.findAnnotation(annotation, JSONField.class);
+                if (Objects.nonNull(foundJsonField)) {
+                    jsonField = foundJsonField;
                 }
 
                 boolean useJacksonAnnotation = JSONFactory.isUseJacksonAnnotation();
@@ -765,8 +765,9 @@ public class ObjectReaderBaseModule
             JSONField jsonField = null;
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
-                if (annotationType == JSONField.class) {
-                    jsonField = (JSONField) annotation;
+                JSONField foundJsonField = AnnotationUtils.findAnnotation(annotation, JSONField.class);
+                if (Objects.nonNull(foundJsonField)) {
+                    jsonField = foundJsonField;
                 }
 
                 boolean useJacksonAnnotation = JSONFactory.isUseJacksonAnnotation();
@@ -1119,8 +1120,9 @@ public class ObjectReaderBaseModule
         JSONCreator jsonCreator = null;
         for (Annotation annotation : annotations) {
             Class<? extends Annotation> annotationType = annotation.annotationType();
-            if (annotationType == JSONCreator.class) {
-                jsonCreator = (JSONCreator) annotation;
+            JSONCreator foundJsonCreator = AnnotationUtils.findAnnotation(annotation, JSONCreator.class);
+            if (Objects.nonNull(foundJsonCreator)) {
+                jsonCreator = foundJsonCreator;
                 continue;
             }
 
@@ -1183,10 +1185,12 @@ public class ObjectReaderBaseModule
         JSONCreator jsonCreator = null;
         for (Annotation annotation : annotations) {
             Class<? extends Annotation> annotationType = annotation.annotationType();
-            if (annotationType == JSONCreator.class) {
-                jsonCreator = (JSONCreator) annotation;
+            JSONCreator foundJsonCreator = AnnotationUtils.findAnnotation(annotation, JSONCreator.class);
+            if (Objects.nonNull(foundJsonCreator)) {
+                jsonCreator = foundJsonCreator;
                 continue;
             }
+
             switch (annotationType.getName()) {
                 case "com.alibaba.fastjson.annotation.JSONCreator":
                     creatorMethod = true;

--- a/core/src/main/java/com/alibaba/fastjson2/util/AnnotationUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/AnnotationUtils.java
@@ -1,0 +1,175 @@
+package com.alibaba.fastjson2.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Inherited;
+import java.lang.reflect.AnnotatedElement;
+import java.util.*;
+
+/**
+ * Annotation utils transformed from {@code org.junit.platform.commons.util.AnnotationUtils}
+ *
+ * @author lzhpo
+ */
+public final class AnnotationUtils {
+    private AnnotationUtils() {
+    }
+
+    /**
+     * Find the first annotation of {@code annotationType} that is either
+     * <em>directly present</em>, <em>meta-present</em>, or <em>indirectly
+     * present</em> on the supplied {@code element}.
+     *
+     * <p>If the element is a class and the annotation is neither <em>directly
+     * present</em> nor <em>meta-present</em> on the class, this method will additionally search on
+     * interfaces implemented by the class before finding an annotation that is <em>indirectly
+     * present</em> on the class.
+     *
+     * @param element the element on which to search for the annotation
+     * @param annotationType the annotation type of need to search
+     * @param <A> the annotation
+     * @return the searched annotation type
+     */
+    public static <A extends Annotation> A findAnnotation(AnnotatedElement element, Class<A> annotationType) {
+        Objects.requireNonNull(annotationType, "annotationType must not be null");
+        boolean inherited = annotationType.isAnnotationPresent(Inherited.class);
+        return findAnnotation(element, annotationType, inherited, new HashSet<>());
+    }
+
+    /**
+     * If the {@code annotation}'s annotationType is not {@code annotationType}, then to find the
+     * first annotation of {@code annotationType} that is either
+     * <em>directly present</em>, <em>meta-present</em>, or <em>indirectly
+     * present</em> on the supplied {@code element}.
+     *
+     * @param annotation annotation
+     * @param annotationType the annotation type of need to search
+     * @param <A> the searched annotation type
+     * @return the searched annotation
+     */
+    @SuppressWarnings("unchecked")
+    public static <A extends Annotation> A findAnnotation(Annotation annotation, Class<A> annotationType) {
+        Objects.requireNonNull(annotation, "annotation must not be null");
+        Objects.requireNonNull(annotationType, "annotationType must not be null");
+
+        Class<? extends Annotation> annotationTypeClass = annotation.annotationType();
+        if (annotationTypeClass == annotationType) {
+            return (A) annotation;
+        }
+
+        boolean inherited = annotationType.isAnnotationPresent(Inherited.class);
+        return findAnnotation(annotationTypeClass, annotationType, inherited, new HashSet<>());
+    }
+
+    /**
+     * Find the existed annotation of {@code annotationType} that is either
+     * <em>directly present</em>, <em>meta-present</em>, or <em>indirectly
+     * present</em> on the supplied {@code element}.
+     *
+     * <p>If the element is a class and the annotation is neither <em>directly
+     * present</em> nor <em>meta-present</em> on the class, this method will additionally search on
+     * interfaces implemented by the class before finding an annotation that is <em>indirectly
+     * present</em> on the class.
+     *
+     * @param element the element on which to search for the annotation
+     * @param annotationType the annotation type of need to search
+     * @param <A> the annotation type
+     * @return the searched annotation
+     */
+    public static <A extends Annotation> boolean hasAnnotation(AnnotatedElement element, Class<A> annotationType) {
+        return Objects.nonNull(findAnnotation(element, annotationType));
+    }
+
+    /**
+     * Find the first annotation of {@code annotationType} that is either
+     * <em>directly present</em>, <em>meta-present</em>, or <em>indirectly
+     * present</em> on the supplied {@code element}.
+     *
+     * <p>If the element is a class and the annotation is neither <em>directly
+     * present</em> nor <em>meta-present</em> on the class, this method will additionally search on
+     * interfaces implemented by the class before finding an annotation that is <em>indirectly
+     * present</em> on the class.
+     *
+     * @param element the element on which to search for the annotation
+     * @param annotationType the annotation type of need to search
+     * @param inherited whether has {@link Inherited}
+     * @param visited this annotation whether visited
+     * @param <A> the annotation type
+     * @return the searched annotation
+     */
+    private static <A extends Annotation> A findAnnotation(AnnotatedElement element,
+            Class<A> annotationType, boolean inherited, Set<Annotation> visited) {
+        if (Objects.isNull(element) || Objects.isNull(annotationType)) {
+            return null;
+        }
+
+        A annotation = element.getDeclaredAnnotation(annotationType);
+        if (Objects.nonNull(annotation)) {
+            return annotation;
+        }
+
+        Annotation[] declaredAnnotations = element.getDeclaredAnnotations();
+        A directMetaAnnotation = findMetaAnnotation(annotationType, declaredAnnotations, inherited, visited);
+        if (Objects.nonNull(directMetaAnnotation)) {
+            return directMetaAnnotation;
+        }
+
+        if (element instanceof Class) {
+            Class<?> clazz = (Class<?>) element;
+
+            for (Class<?> ifc : clazz.getInterfaces()) {
+                if (ifc != Annotation.class) {
+                    A annotationOnInterface = findAnnotation(ifc, annotationType, inherited, visited);
+                    if (Objects.nonNull(annotationOnInterface)) {
+                        return annotationOnInterface;
+                    }
+                }
+            }
+
+            if (inherited) {
+                Class<?> superclass = clazz.getSuperclass();
+                if (Objects.nonNull(superclass) && superclass != Object.class) {
+                    A annotationOnSuperclass = findAnnotation(superclass, annotationType, inherited, visited);
+                    if (Objects.nonNull(annotationOnSuperclass)) {
+                        return annotationOnSuperclass;
+                    }
+                }
+            }
+        }
+
+        return findMetaAnnotation(annotationType, element.getAnnotations(), inherited, visited);
+    }
+
+    /**
+     * Find meta-present on indirectly present annotations.
+     *
+     * @param annotationType the annotation type of need to search
+     * @param candidates annotations for candidates
+     * @param inherited whether has {@link Inherited}
+     * @param visited this annotation whether visited
+     * @param <A> the annotation type
+     * @return the searched annotation
+     */
+    private static <A extends Annotation> A findMetaAnnotation(Class<A> annotationType,
+            Annotation[] candidates, boolean inherited, Set<Annotation> visited) {
+        for (Annotation candidateAnnotation : candidates) {
+            Class<? extends Annotation> candidateAnnotationType = candidateAnnotation.annotationType();
+            if (!isInJavaLangAnnotationPackage(candidateAnnotationType) && visited.add(candidateAnnotation)) {
+                A metaAnnotation = findAnnotation(candidateAnnotationType, annotationType, inherited, visited);
+                if (Objects.nonNull(metaAnnotation)) {
+                    return metaAnnotation;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determine whether {@code annotationType} is in Java lang annotation package.
+     *
+     * @param annotationType annotationType
+     * @return whether is in Java lang annotation package
+     */
+    private static boolean isInJavaLangAnnotationPackage(Class<? extends Annotation> annotationType) {
+        return Objects.nonNull(annotationType) && annotationType.getName().startsWith("java.lang.annotation");
+    }
+}

--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -387,8 +387,9 @@ public abstract class BeanUtils {
                 boolean unwrapped = false;
                 for (Annotation annotation : annotations) {
                     Class<? extends Annotation> annotationType = annotation.annotationType();
-                    if (annotationType == JSONField.class) {
-                        if (((JSONField) annotation).unwrapped()) {
+                    JSONField jsonField = AnnotationUtils.findAnnotation(annotation, JSONField.class);
+                    if (Objects.nonNull(jsonField)) {
+                        if (jsonField.unwrapped()) {
                             unwrapped = true;
                             break;
                         }
@@ -681,7 +682,8 @@ public abstract class BeanUtils {
                     }
                 }
 
-                if (setterFound && unsetFound && getterFound && !method.isAnnotationPresent(JSONField.class)) {
+                if (setterFound && unsetFound && getterFound
+                        && !AnnotationUtils.hasAnnotation(method, JSONField.class)) {
                     continue;
                 }
             }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -2,9 +2,7 @@ package com.alibaba.fastjson2.writer;
 
 import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONWriter;
-import com.alibaba.fastjson2.annotation.JSONField;
-import com.alibaba.fastjson2.annotation.JSONType;
-import com.alibaba.fastjson2.annotation.JSONWritable;
+import com.alibaba.fastjson2.annotation.*;
 import com.alibaba.fastjson2.codec.BeanInfo;
 import com.alibaba.fastjson2.codec.FieldInfo;
 import com.alibaba.fastjson2.filter.Filter;
@@ -65,8 +63,9 @@ public class ObjectWriterBaseModule
             Annotation[] annotations = objectClass.getAnnotations();
             for (Annotation annotation : annotations) {
                 Class annotationType = annotation.annotationType();
-                if (annotationType == JSONType.class) {
-                    jsonType = (JSONType) annotation;
+                JSONType foundJsonType = AnnotationUtils.findAnnotation(annotation, JSONType.class);
+                if (Objects.nonNull(foundJsonType)) {
+                    jsonType = foundJsonType;
                     continue;
                 }
 
@@ -125,8 +124,9 @@ public class ObjectWriterBaseModule
                     Annotation[] mixInAnnotations = mixInSource.getAnnotations();
                     for (Annotation annotation : mixInAnnotations) {
                         Class<? extends Annotation> annotationType = annotation.annotationType();
-                        if (annotationType == JSONType.class) {
-                            jsonType = (JSONType) annotation;
+                        JSONType foundJsonType = AnnotationUtils.findAnnotation(annotation, JSONType.class);
+                        if (Objects.nonNull(foundJsonType)) {
+                            jsonType = foundJsonType;
                             continue;
                         }
 
@@ -266,9 +266,11 @@ public class ObjectWriterBaseModule
             Annotation[] annotations = field.getAnnotations();
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
-                if (annotationType == JSONField.class) {
-                    jsonField = (JSONField) annotation;
+                JSONField foundJsonField = AnnotationUtils.findAnnotation(annotation, JSONField.class);
+                if (Objects.nonNull(foundJsonField)) {
+                    jsonField = foundJsonField;
                 }
+
                 String annotationTypeName = annotationType.getName();
                 boolean useJacksonAnnotation = JSONFactory.isUseJacksonAnnotation();
                 switch (annotationTypeName) {
@@ -653,8 +655,9 @@ public class ObjectWriterBaseModule
         private void processAnnotations(FieldInfo fieldInfo, Annotation[] annotations) {
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
-                if (annotationType == JSONField.class) {
-                    loadFieldInfo(fieldInfo, (JSONField) annotation);
+                JSONField jsonField = AnnotationUtils.findAnnotation(annotation, JSONField.class);
+                if (Objects.nonNull(jsonField)) {
+                    loadFieldInfo(fieldInfo, jsonField);
                     continue;
                 }
 

--- a/core/src/test/java/com/alibaba/fastjson2/annotation/JSONBuilderCombinationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/annotation/JSONBuilderCombinationTest.java
@@ -1,0 +1,43 @@
+package com.alibaba.fastjson2.annotation;
+
+import com.alibaba.fastjson2.util.AnnotationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link JSONBuilder}
+ *
+ * @author lzhpo
+ */
+class JSONBuilderCombinationTest {
+    @Test
+    void testDirectlyGet() {
+        Class<DirectlyJSONBuilderPojo> clazz = DirectlyJSONBuilderPojo.class;
+        JSONBuilder jsonType = AnnotationUtils.findAnnotation(clazz, JSONBuilder.class);
+        assertNotNull(jsonType);
+    }
+
+    @Test
+    void testCombinationGet() {
+        Class<CombinationJSONBuilderPojo> clazz = CombinationJSONBuilderPojo.class;
+        JSONBuilder jsonType = AnnotationUtils.findAnnotation(clazz, JSONBuilder.class);
+        assertNotNull(jsonType);
+    }
+
+    @JSONBuilder
+    public static class DirectlyJSONBuilderPojo {
+    }
+
+    @JSONBuilderCombination
+    public static class CombinationJSONBuilderPojo {
+    }
+
+    @JSONBuilder
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface JSONBuilderCombination {
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/annotation/JSONCreatorCombinationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/annotation/JSONCreatorCombinationTest.java
@@ -1,0 +1,112 @@
+package com.alibaba.fastjson2.annotation;
+
+import com.alibaba.fastjson2.util.AnnotationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.*;
+import java.lang.reflect.Constructor;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link JSONCreator}
+ *
+ * @author lzhpo
+ */
+class JSONCreatorCombinationTest {
+    @Test
+    void testDirectlyGetFromClass() {
+        Class<DirectlyJSONCreatorPojo> clazz = DirectlyJSONCreatorPojo.class;
+        Constructor<?>[] constructors = clazz.getConstructors();
+
+        assertExistJSONCreator(constructors);
+    }
+
+    @Test
+    void testDirectlyGetFromAnnotationType() {
+        Class<DirectlyJSONCreatorPojo> clazz = DirectlyJSONCreatorPojo.class;
+        Constructor<?>[] constructors = clazz.getConstructors();
+
+        List<Annotation> annotations = new ArrayList<>();
+        for (Constructor<?> constructor : constructors) {
+            annotations.addAll(Arrays.asList(constructor.getAnnotations()));
+        }
+
+        assertExistJSONCreator(annotations);
+    }
+
+    @Test
+    void testCombinationGetFromClass() {
+        Class<CombinationJSONCreatorPojo> clazz = CombinationJSONCreatorPojo.class;
+        Constructor<?>[] constructors = clazz.getConstructors();
+
+        assertExistJSONCreator(constructors);
+    }
+
+    @Test
+    void testCombinationGetFromAnnotationType() {
+        Class<CombinationJSONCreatorPojo> clazz = CombinationJSONCreatorPojo.class;
+        Constructor<?>[] constructors = clazz.getConstructors();
+
+        List<Annotation> annotations = new ArrayList<>();
+        for (Constructor<?> constructor : constructors) {
+            annotations.addAll(Arrays.asList(constructor.getAnnotations()));
+        }
+
+        assertExistJSONCreator(annotations);
+    }
+
+    private static void assertExistJSONCreator(Constructor<?>[] constructors) {
+        Optional<JSONCreator> jsonCreator = Arrays.stream(constructors)
+                .map(constructor -> AnnotationUtils.findAnnotation(constructor, JSONCreator.class))
+                .filter(Objects::nonNull)
+                .findAny();
+
+        assertTrue(jsonCreator.isPresent());
+    }
+
+    private static void assertExistJSONCreator(List<Annotation> annotations) {
+        Optional<JSONCreator> jsonCreator = annotations.stream()
+                .map(annotation -> {
+                    Class<? extends Annotation> annotationType = annotation.annotationType();
+                    if (annotationType != JSONCreator.class) {
+                        return AnnotationUtils.findAnnotation(annotationType, JSONCreator.class);
+                    } else {
+                        return (JSONCreator) annotation;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .findAny();
+
+        assertTrue(jsonCreator.isPresent());
+    }
+
+    public static class DirectlyJSONCreatorPojo {
+        private String nickName;
+        private int age;
+
+        @JSONCreator(parameterNames = {"nickName", "age"})
+        public DirectlyJSONCreatorPojo(String nickName, int age) {
+            this.nickName = nickName;
+            this.age = age;
+        }
+    }
+
+    public static class CombinationJSONCreatorPojo {
+        private String nickName;
+        private int age;
+
+        @JSONCreatorCombination
+        public CombinationJSONCreatorPojo(String nickName, int age) {
+            this.nickName = nickName;
+            this.age = age;
+        }
+    }
+
+    @JSONCreator(parameterNames = {"nickName", "age"})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.ANNOTATION_TYPE})
+    public @interface JSONCreatorCombination {
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/annotation/JSONFieldCombinationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/annotation/JSONFieldCombinationTest.java
@@ -1,0 +1,69 @@
+package com.alibaba.fastjson2.annotation;
+
+import com.alibaba.fastjson2.util.AnnotationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.*;
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link JSONField}
+ *
+ * @author lzhpo
+ */
+class JSONFieldCombinationTest {
+    @Test
+    void testDirectlyGetFromMethod() {
+        Class<DirectlyJSONField> clazz = DirectlyJSONField.class;
+        Method[] declaredMethods = clazz.getDeclaredMethods();
+        assertExistJSONField(declaredMethods);
+    }
+
+    @Test
+    void testCombinationGetFromMethod() {
+        Class<CombinationJSONFieldPojo> clazz = CombinationJSONFieldPojo.class;
+        Method[] declaredMethods = clazz.getDeclaredMethods();
+        assertExistJSONField(declaredMethods);
+    }
+
+    private static void assertExistJSONField(Method[] declaredMethods) {
+        Optional<JSONField> jsonField = Arrays.stream(declaredMethods)
+                .map(method -> AnnotationUtils.findAnnotation(method, JSONField.class))
+                .filter(Objects::nonNull)
+                .findAny();
+        assertTrue(jsonField.isPresent());
+    }
+
+    public static class DirectlyJSONField {
+        @JSONField
+        public String nickName;
+
+        private int age;
+
+        @JSONField
+        public int getAge() {
+            return age;
+        }
+    }
+
+    public static class CombinationJSONFieldPojo {
+        @CombinationJSONField
+        public String nickName;
+
+        private int age;
+
+        @CombinationJSONField
+        public int getAge() {
+            return age;
+        }
+    }
+
+    @JSONField
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.FIELD})
+    public @interface CombinationJSONField {
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/annotation/JSONTypeCombinationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/annotation/JSONTypeCombinationTest.java
@@ -1,0 +1,58 @@
+package com.alibaba.fastjson2.annotation;
+
+import com.alibaba.fastjson2.util.AnnotationUtils;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link JSONType}
+ *
+ * @author lzhpo
+ */
+class JSONTypeCombinationTest {
+    @Test
+    void testDirectlyGetFromClassAndAnnotation() {
+        Class<DirectlyJSONTypePojo> clazz = DirectlyJSONTypePojo.class;
+        JSONType jsonTypeFromClass = AnnotationUtils.findAnnotation(clazz, JSONType.class);
+        assertNotNull(jsonTypeFromClass);
+
+        Annotation[] annotations = clazz.getAnnotations();
+        Optional<JSONType> jsonTypeFromAnnotation = Arrays.stream(annotations)
+                .map(annotation -> AnnotationUtils.findAnnotation(annotation, JSONType.class))
+                .filter(Objects::nonNull)
+                .findAny();
+        assertTrue(jsonTypeFromAnnotation.isPresent());
+    }
+
+    @Test
+    void testCombinationGetJSONBuilderFromClassAndAnnotation() {
+        Class<CombinationJSONTypePojo> clazz = CombinationJSONTypePojo.class;
+        JSONType jsonTypeFromClass = AnnotationUtils.findAnnotation(clazz, JSONType.class);
+        assertNotNull(jsonTypeFromClass);
+
+        Annotation[] annotations = clazz.getAnnotations();
+        Optional<JSONType> jsonTypeFromAnnotation = Arrays.stream(annotations)
+                .map(annotation -> AnnotationUtils.findAnnotation(annotation, JSONType.class))
+                .filter(Objects::nonNull)
+                .findAny();
+        assertTrue(jsonTypeFromAnnotation.isPresent());
+    }
+
+    @JSONType
+    public static class DirectlyJSONTypePojo {
+    }
+
+    @JSONTypeCombination
+    public static class CombinationJSONTypePojo {
+    }
+
+    @JSONType
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface JSONTypeCombination {
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

If we support  `@JSONBuilder`, `@JSONCreator`, `@JSONField` and `@JSONType` of combination annotation:
1. These can reduce the workload and duplication of code.
2. These can let's better expand based on fastjson.

### Summary of your change

Adjust the way to get `@JSONBuilder`, `@JSONCreator`, `@JSONField` and `@JSONType` and add test cases.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
