### PR TITLE
Bruceyan/issue#832

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -914,8 +914,7 @@ public abstract class BeanUtils {
                 char[] chars = new char[methodNameLength - prefixLength];
                 methodName.getChars(prefixLength, methodNameLength, chars, 0);
                 char c0 = chars[0];
-                boolean c1UCase = chars.length > 1 && chars[1] >= 'A' && chars[1] <= 'Z';
-                if (c0 >= 'A' && c0 <= 'Z' && !c1UCase) {
+                if (c0 >= 'A' && c0 <= 'Z') {
                     chars[0] = (char) (c0 + 32);
                 }
                 return new String(chars);

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue832.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue832.java
@@ -1,8 +1,6 @@
 package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSON;
-import lombok.Data;
-import lombok.experimental.Accessors;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -10,39 +8,28 @@ import org.junit.Test;
  * @author Rongzhen Yan
  */
 public class Issue832 {
-
     @Test
     public void testCase() {
         A case1 = new A();  // getAAbc(); expect field name: aAbc
         case1.setAAbc("value");
         String fastJson1A = com.alibaba.fastjson.JSON.toJSONString(case1);
         String fastJson2A = JSON.toJSONString(case1);
-
         Assert.assertEquals("{\"aAbc\":\"value\"}", fastJson2A);
         Assert.assertEquals(fastJson1A, fastJson2A);
-
-
         B case2 = new B();  // getAabc(); expect field name: aabc
         case2.setAabc("value");
-
         String fastJson1B = com.alibaba.fastjson.JSON.toJSONString(case2);
         String fastJson2B = JSON.toJSONString(case2);
-
         Assert.assertEquals("{\"aabc\":\"value\"}", fastJson2B);
         Assert.assertEquals(fastJson1B, fastJson2B);
-
         C case3 = new C();  // getaAbc(); expect field name: aAbc
         case3.setaAbc("value");
-
         String fastJson1C = com.alibaba.fastjson.JSON.toJSONString(case3);
         String fastJson2C = JSON.toJSONString(case3);
-
         Assert.assertEquals("{\"aAbc\":\"value\"}", fastJson2C);
         Assert.assertEquals(fastJson1C, fastJson2C);
     }
-
     static class A {
-
         private String aAbc;
 
         public String getAAbc() {
@@ -53,9 +40,7 @@ public class Issue832 {
             this.aAbc = aAbc;
         }
     }
-
     static class B {
-
         private String aabc;
 
         public String getAabc() {
@@ -66,9 +51,7 @@ public class Issue832 {
             this.aabc = aabc;
         }
     }
-
     static class C {
-
         private String aAbc;
 
         public String getaAbc() {

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue832.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue832.java
@@ -1,0 +1,61 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSON;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Rongzhen Yan
+ */
+public class Issue832 {
+
+    @Test
+    public void testCase() {
+        A case1 = new A();  // getAAbc(); expect: aAbc
+        case1.setAAbc("aAbc");
+        String fastJson1A = com.alibaba.fastjson.JSON.toJSONString(case1);
+        String fastJson2A = JSON.toJSONString(case1);
+
+        Assert.assertEquals("{\"aAbc\":\"aAbc\"}", fastJson2A);
+        Assert.assertEquals(fastJson1A, fastJson2A);
+
+
+        B case2 = new B();  // getAabc(); expect: aabc
+        case2.setAabc("aabc");
+
+        String fastJson1B = com.alibaba.fastjson.JSON.toJSONString(case2);
+        String fastJson2B = JSON.toJSONString(case2);
+
+        Assert.assertEquals("{\"aabc\":\"aabc\"}", fastJson2B);
+        Assert.assertEquals(fastJson1B, fastJson2B);
+    }
+}
+
+
+class A {
+
+    private String aAbc;
+
+    public String getAAbc() {
+        return aAbc;
+    }
+
+    public void setAAbc(String aAbc) {
+        this.aAbc = aAbc;
+    }
+}
+
+class B {
+
+    private String aabc;
+
+    public String getAabc() {
+        return aabc;
+    }
+
+    public void setAabc(String aabc) {
+        this.aabc = aabc;
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue832.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue832.java
@@ -13,49 +13,70 @@ public class Issue832 {
 
     @Test
     public void testCase() {
-        A case1 = new A();  // getAAbc(); expect: aAbc
-        case1.setAAbc("aAbc");
+        A case1 = new A();  // getAAbc(); expect field name: aAbc
+        case1.setAAbc("value");
         String fastJson1A = com.alibaba.fastjson.JSON.toJSONString(case1);
         String fastJson2A = JSON.toJSONString(case1);
 
-        Assert.assertEquals("{\"aAbc\":\"aAbc\"}", fastJson2A);
+        Assert.assertEquals("{\"aAbc\":\"value\"}", fastJson2A);
         Assert.assertEquals(fastJson1A, fastJson2A);
 
 
-        B case2 = new B();  // getAabc(); expect: aabc
-        case2.setAabc("aabc");
+        B case2 = new B();  // getAabc(); expect field name: aabc
+        case2.setAabc("value");
 
         String fastJson1B = com.alibaba.fastjson.JSON.toJSONString(case2);
         String fastJson2B = JSON.toJSONString(case2);
 
-        Assert.assertEquals("{\"aabc\":\"aabc\"}", fastJson2B);
+        Assert.assertEquals("{\"aabc\":\"value\"}", fastJson2B);
         Assert.assertEquals(fastJson1B, fastJson2B);
-    }
-}
 
+        C case3 = new C();  // getaAbc(); expect field name: aAbc
+        case3.setaAbc("value");
 
-class A {
+        String fastJson1C = com.alibaba.fastjson.JSON.toJSONString(case3);
+        String fastJson2C = JSON.toJSONString(case3);
 
-    private String aAbc;
-
-    public String getAAbc() {
-        return aAbc;
-    }
-
-    public void setAAbc(String aAbc) {
-        this.aAbc = aAbc;
-    }
-}
-
-class B {
-
-    private String aabc;
-
-    public String getAabc() {
-        return aabc;
+        Assert.assertEquals("{\"aAbc\":\"value\"}", fastJson2C);
+        Assert.assertEquals(fastJson1C, fastJson2C);
     }
 
-    public void setAabc(String aabc) {
-        this.aabc = aabc;
+    static class A {
+
+        private String aAbc;
+
+        public String getAAbc() {
+            return aAbc;
+        }
+
+        public void setAAbc(String aAbc) {
+            this.aAbc = aAbc;
+        }
+    }
+
+    static class B {
+
+        private String aabc;
+
+        public String getAabc() {
+            return aabc;
+        }
+
+        public void setAabc(String aabc) {
+            this.aabc = aabc;
+        }
+    }
+
+    static class C {
+
+        private String aAbc;
+
+        public String getaAbc() {
+            return aAbc;
+        }
+
+        public void setaAbc(String aAbc) {
+            this.aAbc = aAbc;
+        }
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?
修复fastjson2 ISSUE #832 中的当第一个字母小写, 第二个字母大写时, 出现的序列化字段名称错误的问题(fastjson1和fastjson2序列化字段名不一致)
当使用lombok等工具生成getter方法的时候, aAbc(第一个字母小写, 第二个字母小写), 会生成getAAbc的方法
而原BeanUtils类中917, 918行代码, 如果第二个字符(A)不是大写时才会将第一个字符改为小写, 但第二个字符是不是大写是无法判断这个场景的
(getAAbc => aAbc)
(getAabc => aabc)

### Summary of your change
com.alibaba.fastjson2.util.BeanUtils#getterName(java.lang.String, java.lang.String)  917行, 918行
去除判断第二个字符的逻辑

