### PR TITLE
fix issue #828

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
@@ -1902,6 +1902,12 @@ class JSONWriterUTF16
 
         boolean first = true;
         for (Iterator<Map.Entry<String, Object>> it = map.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<String, Object> next = it.next();
+            Object value = next.getValue();
+            if (value == null && (context.features & Feature.WriteMapNullValue.mask) == 0) {
+                continue;
+            }
+
             if (!first) {
                 if (off == chars.length) {
                     int minCapacity = off + 1;
@@ -1918,12 +1924,6 @@ class JSONWriterUTF16
                     chars = Arrays.copyOf(chars, newCapacity);
                 }
                 chars[off++] = ',';
-            }
-
-            Map.Entry<String, Object> next = it.next();
-            Object value = next.getValue();
-            if (value == null && (context.features & Feature.WriteMapNullValue.mask) == 0) {
-                continue;
             }
 
             first = false;

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue828.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue828.java
@@ -1,0 +1,68 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Rongzhen Yan
+ */
+public class Issue828 {
+    @Test
+    public void test() {
+        // test case1 with no feature
+        JSONObject jsonObject1 = new JSONObject();
+        jsonObject1.put("a", "a value");
+        jsonObject1.put("b", null);
+        jsonObject1.put("c", "c value");
+        String json1A = jsonObject1.toJSONString();
+        System.out.println(json1A);
+
+        A object = new A("a value", null, "c value");
+        String json1B = JSON.toJSONString(object);
+        Assert.assertEquals(json1A, json1B);
+
+        // test case2 with no feature
+        JSONObject jsonObject2 = new JSONObject();
+        jsonObject2.put("a", null);
+        jsonObject2.put("b", null);
+        jsonObject2.put("c", "c value");
+        String json2 = jsonObject2.toJSONString();
+        System.out.println(json2);
+        Assert.assertEquals("{\"c\":\"c value\"}", json2);
+
+        // test case3 with (WriteMapNullValue) feature
+        JSONObject jsonObject3 = new JSONObject();
+        jsonObject3.put("a", null);
+        jsonObject3.put("b", null);
+        jsonObject3.put("c", "c value");
+        String json3 = jsonObject3.toJSONString(JSONWriter.Feature.WriteMapNullValue);
+
+        System.out.println(json3);
+        Assert.assertEquals("{\"a\":null,\"b\":null,\"c\":\"c value\"}", json3);
+
+        // test case4 with (WriteMapNullValue) feature
+        JSONObject jsonObject4 = new JSONObject();
+        jsonObject4.put("a", null);
+        jsonObject4.put("b", "b value");
+        jsonObject4.put("c", null);
+        String json4 = jsonObject4.toJSONString(JSONWriter.Feature.WriteMapNullValue);
+
+        System.out.println(json4);
+        Assert.assertEquals("{\"a\":null,\"b\":\"b value\",\"c\":null}", json4);
+    }
+
+    @Data
+    @AllArgsConstructor
+    static class A {
+        private String a;
+
+        private String b;
+
+        private String c;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
修复issue #828, JsonObject中加入null值后, 出现冗余逗号的问题
原逻辑是如果不是第一个元素, 就先加一个逗号, 再判断WriteMapNullValue决定是否跳过, 这里如果用户没有WriteMapNullValue的Feature, 则会出现一个空逗号

### Summary of your change
将判断Feature的逻辑前置, 不满足条件直接跳过该字段, 避免空逗号问题