### PR TITLE
add new `from` and `fromJavaObject` methods

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -1473,7 +1473,6 @@ public class JSONArray
         return JSON.parseArray(input, type);
     }
 
-
     /**
      * See {@link JSON#toJSON} for details
      */

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -1486,18 +1486,4 @@ public class JSONArray
     public static JSONArray from(Object obj, JSONWriter.Feature... writeFeatures) {
         return (JSONArray) JSON.toJSON(obj, writeFeatures);
     }
-
-    /**
-     * See {@link JSON#toJSON} for details
-     */
-    public static JSONArray fromJavaObject(Object obj) {
-        return from(obj);
-    }
-
-    /**
-     * See {@link JSON#toJSON} for details
-     */
-    public static JSONArray fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
-        return from(obj, writeFeatures);
-    }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -1472,4 +1472,33 @@ public class JSONArray
     static <T> List<T> parseArray(String input, Class<T> type) {
         return JSON.parseArray(input, type);
     }
+
+
+    /**
+     * See {@link JSON#toJSON} for details
+     */
+    public static JSONArray from(Object obj) {
+        return (JSONArray) JSON.toJSON(obj);
+    }
+
+    /**
+     * See {@link JSON#toJSON} for details
+     */
+    public static JSONArray from(Object obj, JSONWriter.Feature... writeFeatures) {
+        return (JSONArray) JSON.toJSON(obj, writeFeatures);
+    }
+
+    /**
+     * See {@link JSON#toJSON} for details
+     */
+    public static JSONArray fromJavaObject(Object obj) {
+        return from(obj);
+    }
+
+    /**
+     * See {@link JSON#toJSON} for details
+     */
+    public static JSONArray fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
+        return from(obj, writeFeatures);
+    }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1956,18 +1956,4 @@ public class JSONObject
     public static JSONObject from(Object obj, JSONWriter.Feature... writeFeatures) {
         return (JSONObject) JSON.toJSON(obj, writeFeatures);
     }
-
-    /**
-     * See {@link JSON#toJSON} for details
-     */
-    public static JSONObject fromJavaObject(Object obj) {
-        return from(obj);
-    }
-
-    /**
-     * See {@link JSON#toJSON} for details
-     */
-    public static JSONObject fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
-        return from(obj, writeFeatures);
-    }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1944,94 +1944,30 @@ public class JSONObject
     }
 
     /**
-     * Convert Java Object to JSONObject.
-     *
-     * @param obj Java Object
-     * @return JSONObject
+     * See {@link JSON#toJSON} for details
      */
     public static JSONObject from(Object obj) {
-        return JSONObject.parseObject(JSONObject.toJSONString(obj));
+        return (JSONObject) JSON.toJSON(obj);
     }
 
     /**
-     * Convert Java Object to JSONObject with readFeatures.
-     *
-     * @param obj Java Object
-     * @param readFeatures JSONReader.Feature...
-     * @return JSONObject
-     */
-    public static JSONObject from(Object obj, JSONReader.Feature... readFeatures) {
-        return JSONObject.parse(JSONObject.toJSONString(obj), readFeatures);
-    }
-
-    /**
-     * Convert Java Object to JSONObject with writeFeatures.
-     *
-     * @param obj Java Object
-     * @param writeFeatures JSONWriter.Feature...
-     * @return JSONObject
+     * See {@link JSON#toJSON} for details
      */
     public static JSONObject from(Object obj, JSONWriter.Feature... writeFeatures) {
-        return JSONObject.parseObject(JSONObject.toJSONString(obj, writeFeatures));
+        return (JSONObject) JSON.toJSON(obj, writeFeatures);
     }
 
     /**
-     * Convert Java Object to JSONObject with readFeatures and writeFeatures. (jdk8+ required)
-     *
-     * @param obj Java Object
-     * @param readFeatures List of JSONReader.Feature
-     * @param writeFeatures List of JSONWriter.Feature
-     * @return JSONObject
-     */
-    public static JSONObject from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
-        if (readFeatures.size() > 0) {
-            return JSONObject.parse(JSONObject.toJSONString(obj, writeFeatures.stream().toArray(JSONWriter.Feature[]::new)), readFeatures.stream().toArray(JSONReader.Feature[]::new));
-        } else {
-            return from(obj, writeFeatures.stream().toArray(JSONWriter.Feature[]::new));
-        }
-    }
-
-    /**
-     * A synonym of from(Object obj).
-     *
-     * @param obj Java Object
-     * @return JSONObject
+     * See {@link JSON#toJSON} for details
      */
     public static JSONObject fromJavaObject(Object obj) {
         return from(obj);
     }
 
     /**
-     * A synonym of from(Object obj, JSONReader.Feature... readFeatures).
-     *
-     * @param obj Java Object
-     * @param readFeatures List of JSONReader.Feature
-     * @return JSONObject
-     */
-    public static JSONObject fromJavaObject(Object obj, JSONReader.Feature... readFeatures) {
-        return from(obj, readFeatures);
-    }
-
-    /**
-     * A synonym of from(Object obj, JSONWriter.Feature... writeFeatures)
-     *
-     * @param obj Java Object
-     * @param writeFeatures List of JSONWriter.Feature
-     * @return JSONObject
+     * See {@link JSON#toJSON} for details
      */
     public static JSONObject fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
         return from(obj, writeFeatures);
-    }
-
-    /**
-     * A synonym of method from with same parameters
-     *
-     * @param obj Java Object
-     * @param readFeatures List of JSONReader.Feature
-     * @param writeFeatures List of JSONWriter.Feature
-     * @return JSONObject
-     */
-    public static JSONObject fromJavaObject(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
-        return from(obj, readFeatures, writeFeatures);
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1943,7 +1943,6 @@ public class JSONObject
         return JSON.parseObject(text, features);
     }
 
-
     /**
      * Convert Java Object to JSONObject.
      *
@@ -2035,5 +2034,4 @@ public class JSONObject
     private static JSONObject fromJavaObject(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
         return from(obj, readFeatures, writeFeatures);
     }
-
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1949,7 +1949,7 @@ public class JSONObject
      * @param obj Java Object
      * @return JSONObject
      */
-    private static JSONObject from(Object obj) {
+    public static JSONObject from(Object obj) {
         return JSONObject.parseObject(JSONObject.toJSONString(obj));
     }
 
@@ -1960,7 +1960,7 @@ public class JSONObject
      * @param readFeatures JSONReader.Feature...
      * @return JSONObject
      */
-    private static JSONObject from(Object obj, JSONReader.Feature... readFeatures) {
+    public static JSONObject from(Object obj, JSONReader.Feature... readFeatures) {
         return JSONObject.parse(JSONObject.toJSONString(obj), readFeatures);
     }
 
@@ -1971,7 +1971,7 @@ public class JSONObject
      * @param writeFeatures JSONWriter.Feature...
      * @return JSONObject
      */
-    private static JSONObject from(Object obj, JSONWriter.Feature... writeFeatures) {
+    public static JSONObject from(Object obj, JSONWriter.Feature... writeFeatures) {
         return JSONObject.parseObject(JSONObject.toJSONString(obj, writeFeatures));
     }
 
@@ -1983,7 +1983,7 @@ public class JSONObject
      * @param writeFeatures List<JSONWriter.Feature>
      * @return JSONObject
      */
-    private static JSONObject from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
+    public static JSONObject from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
         if (readFeatures.size() > 0) {
             return JSONObject.parse(JSONObject.toJSONString(obj, writeFeatures.stream().toArray(JSONWriter.Feature[]::new)), readFeatures.stream().toArray(JSONReader.Feature[]::new));
         } else {
@@ -1997,7 +1997,7 @@ public class JSONObject
      * @param obj Java Object
      * @return JSONObject
      */
-    private static JSONObject fromJavaObject(Object obj) {
+    public static JSONObject fromJavaObject(Object obj) {
         return from(obj);
     }
 
@@ -2008,7 +2008,7 @@ public class JSONObject
      * @param readFeatures List<JSONReader.Feature>
      * @return JSONObject
      */
-    private static JSONObject fromJavaObject(Object obj, JSONReader.Feature... readFeatures) {
+    public static JSONObject fromJavaObject(Object obj, JSONReader.Feature... readFeatures) {
         return from(obj, readFeatures);
     }
 
@@ -2019,7 +2019,7 @@ public class JSONObject
      * @param writeFeatures List<JSONWriter.Feature>
      * @return JSONObject
      */
-    private static JSONObject fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
+    public static JSONObject fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
         return from(obj, writeFeatures);
     }
 
@@ -2031,7 +2031,7 @@ public class JSONObject
      * @param writeFeatures List<JSONWriter.Feature>
      * @return JSONObject
      */
-    private static JSONObject fromJavaObject(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
+    public static JSONObject fromJavaObject(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
         return from(obj, readFeatures, writeFeatures);
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -2024,7 +2024,7 @@ public class JSONObject
     }
 
     /**
-     * A synonym of from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures).
+     * A synonym of method from with same parameters
      *
      * @param obj Java Object
      * @param readFeatures List of JSONReader.Feature

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1942,4 +1942,98 @@ public class JSONObject
     public static JSONObject parse(String text, JSONReader.Feature... features) {
         return JSON.parseObject(text, features);
     }
+
+
+    /**
+     * Convert Java Object to JSONObject.
+     *
+     * @param obj Java Object
+     * @return JSONObject
+     */
+    private static JSONObject from(Object obj) {
+        return JSONObject.parseObject(JSONObject.toJSONString(obj));
+    }
+
+    /**
+     * Convert Java Object to JSONObject with readFeatures.
+     *
+     * @param obj          Java Object
+     * @param readFeatures JSONReader.Feature...
+     * @return JSONObject
+     */
+    private static JSONObject from(Object obj, JSONReader.Feature... readFeatures) {
+        return JSONObject.parse(JSONObject.toJSONString(obj), readFeatures);
+    }
+
+    /**
+     * Convert Java Object to JSONObject with writeFeatures.
+     *
+     * @param obj           Java Object
+     * @param writeFeatures JSONWriter.Feature...
+     * @return JSONObject
+     */
+    private static JSONObject from(Object obj, JSONWriter.Feature... writeFeatures) {
+        return JSONObject.parseObject(JSONObject.toJSONString(obj, writeFeatures));
+    }
+
+    /**
+     * Convert Java Object to JSONObject with readFeatures & writeFeatures. (jdk8+ required)
+     *
+     * @param obj           Java Object
+     * @param readFeatures  List<JSONReader.Feature>
+     * @param writeFeatures List<JSONWriter.Feature>
+     * @return JSONObject
+     */
+    private static JSONObject from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
+        if (readFeatures.size() > 0) {
+            return JSONObject.parse(JSONObject.toJSONString(obj, writeFeatures.stream().toArray(JSONWriter.Feature[]::new)), readFeatures.stream().toArray(JSONReader.Feature[]::new));
+        } else {
+            return from(obj, writeFeatures.stream().toArray(JSONWriter.Feature[]::new));
+        }
+    }
+
+    /**
+     * A synonym of from(Object obj).
+     *
+     * @param obj Java Object
+     * @return JSONObject
+     */
+    private static JSONObject fromJavaObject(Object obj) {
+        return from(obj);
+    }
+
+    /**
+     * A synonym of from(Object obj, JSONReader.Feature... readFeatures).
+     *
+     * @param obj          Java Object
+     * @param readFeatures List<JSONReader.Feature>
+     * @return JSONObject
+     */
+    private static JSONObject fromJavaObject(Object obj, JSONReader.Feature... readFeatures) {
+        return from(obj, readFeatures);
+    }
+
+    /**
+     * A synonym of from(Object obj, JSONWriter.Feature... writeFeatures)
+     *
+     * @param obj           Java Object
+     * @param writeFeatures List<JSONWriter.Feature>
+     * @return JSONObject
+     */
+    private static JSONObject fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
+        return from(obj, writeFeatures);
+    }
+
+    /**
+     * A synonym of from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures).
+     *
+     * @param obj           Java Object
+     * @param readFeatures  List<JSONReader.Feature>
+     * @param writeFeatures List<JSONWriter.Feature>
+     * @return JSONObject
+     */
+    private static JSONObject fromJavaObject(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
+        return from(obj, readFeatures, writeFeatures);
+    }
+
 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1956,7 +1956,7 @@ public class JSONObject
     /**
      * Convert Java Object to JSONObject with readFeatures.
      *
-     * @param obj          Java Object
+     * @param obj Java Object
      * @param readFeatures JSONReader.Feature...
      * @return JSONObject
      */
@@ -1967,7 +1967,7 @@ public class JSONObject
     /**
      * Convert Java Object to JSONObject with writeFeatures.
      *
-     * @param obj           Java Object
+     * @param obj Java Object
      * @param writeFeatures JSONWriter.Feature...
      * @return JSONObject
      */
@@ -1976,11 +1976,11 @@ public class JSONObject
     }
 
     /**
-     * Convert Java Object to JSONObject with readFeatures & writeFeatures. (jdk8+ required)
+     * Convert Java Object to JSONObject with readFeatures and writeFeatures. (jdk8+ required)
      *
-     * @param obj           Java Object
-     * @param readFeatures  List<JSONReader.Feature>
-     * @param writeFeatures List<JSONWriter.Feature>
+     * @param obj Java Object
+     * @param readFeatures List of JSONReader.Feature
+     * @param writeFeatures List of JSONWriter.Feature
      * @return JSONObject
      */
     public static JSONObject from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {
@@ -2004,8 +2004,8 @@ public class JSONObject
     /**
      * A synonym of from(Object obj, JSONReader.Feature... readFeatures).
      *
-     * @param obj          Java Object
-     * @param readFeatures List<JSONReader.Feature>
+     * @param obj Java Object
+     * @param readFeatures List of JSONReader.Feature
      * @return JSONObject
      */
     public static JSONObject fromJavaObject(Object obj, JSONReader.Feature... readFeatures) {
@@ -2015,8 +2015,8 @@ public class JSONObject
     /**
      * A synonym of from(Object obj, JSONWriter.Feature... writeFeatures)
      *
-     * @param obj           Java Object
-     * @param writeFeatures List<JSONWriter.Feature>
+     * @param obj Java Object
+     * @param writeFeatures List of JSONWriter.Feature
      * @return JSONObject
      */
     public static JSONObject fromJavaObject(Object obj, JSONWriter.Feature... writeFeatures) {
@@ -2026,9 +2026,9 @@ public class JSONObject
     /**
      * A synonym of from(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures).
      *
-     * @param obj           Java Object
-     * @param readFeatures  List<JSONReader.Feature>
-     * @param writeFeatures List<JSONWriter.Feature>
+     * @param obj Java Object
+     * @param readFeatures List of JSONReader.Feature
+     * @param writeFeatures List of JSONWriter.Feature
      * @return JSONObject
      */
     public static JSONObject fromJavaObject(Object obj, List<JSONReader.Feature> readFeatures, List<JSONWriter.Feature> writeFeatures) {

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest_from.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest_from.java
@@ -2,7 +2,7 @@ package com.alibaba.fastjson2;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -10,7 +10,7 @@ public class JSONArrayTest_from {
     @Test
     public void test_0() {
         assertEquals(0,
-                JSONArray.from(new Integer[]{0,1,2,3,4,5}).get(0));
+                JSONArray.from(new Integer[]{0, 1, 2, 3, 4, 5}).get(0));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest_from.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest_from.java
@@ -1,0 +1,24 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONArrayTest_from {
+    @Test
+    public void test_0() {
+        assertEquals(0,
+                JSONArray.from(new Integer[]{0,1,2,3,4,5}).get(0));
+    }
+
+    @Test
+    public void test_1() {
+        ArrayList<Integer> nums = new ArrayList<>();
+        nums.add(0);
+        nums.add(1);
+        assertEquals(0,
+                JSONArray.from(nums).get(0));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/JSONObjectTest_from.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONObjectTest_from.java
@@ -1,0 +1,60 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONObjectTest_from {
+    @Test
+    public void test_0() {
+        assertEquals(101, JSONObject.from(new Item(101)).get("itemId"));
+    }
+
+    @Test
+    public void test_1() {
+        Bean bean = new Bean();
+        bean.setItems(Arrays.asList(new Item(101), new Item(102)));
+        assertEquals(bean.getItems().get(0).itemId,
+                JSONObject.from(bean).to(Bean.class).items.get(0).itemId);
+    }
+
+    @Test
+    public void test_2() {
+        Bean1 bean = new Bean1();
+        {
+            HashMap<String, Item> itemMap = new HashMap<>();
+            itemMap.put("101", new Item(101));
+            itemMap.put("102", new Item(102));
+            bean.items = itemMap;
+        }
+        assertEquals(bean.items.get("101").itemId,
+                JSONObject.from(bean).to(Bean1.class).items.get("101").itemId);
+    }
+
+
+    public static class Bean {
+        private List<Item> items;
+
+        public List<Item> getItems() {
+            return items;
+        }
+
+        public void setItems(List<Item> items) {
+            this.items = items;
+        }
+    }
+
+    public static class Bean1 {
+        public Map<String, Item> items;
+    }
+
+    public static class Item {
+        public int itemId;
+
+        public Item(int itemId) {
+            this.itemId = itemId;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/JSONObjectTest_from.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONObjectTest_from.java
@@ -2,7 +2,10 @@ package com.alibaba.fastjson2;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -32,7 +35,6 @@ public class JSONObjectTest_from {
         assertEquals(bean.items.get("101").itemId,
                 JSONObject.from(bean).to(Bean1.class).items.get("101").itemId);
     }
-
 
     public static class Bean {
         private List<Item> items;


### PR DESCRIPTION
… to JSONObject, corresponding to the `to` and `toJavaObject` apis.

### What this PR does / why we need it?
After analyzing the conversion relationship between JSONObject types, we find that there is a JSONObject toJavaObject API (to/toJavaObject), but there is no reverse. Currently, PR is designed to submit the reverse correlation APIs to implement the closed-loop link between JSONObject and JavaObject.


### Summary of your change
Add new from and fromJavaObject methods for converting JavaObject to JSONObject, corresponding to the To and ToJavaObject apis.
