### PR TITLE
add support for castToBigInteger in TypeUtils

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/util/TypeUtils.java
@@ -32,6 +32,7 @@ import java.io.Reader;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -583,6 +584,10 @@ public class TypeUtils {
 
     public static BigDecimal castToBigDecimal(Object value) {
         return com.alibaba.fastjson2.util.TypeUtils.toBigDecimal(value);
+    }
+
+    public static BigInteger castToBigInteger(Object value) {
+        return com.alibaba.fastjson2.util.TypeUtils.toBigInteger(value);
     }
 
     public static Timestamp castToTimestamp(final Object value) {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/util/TypeUtilsTest.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/util/TypeUtilsTest.java
@@ -50,6 +50,7 @@ public class TypeUtilsTest {
         assertNull(TypeUtils.castToLong(null));
         assertNull(TypeUtils.castToDouble(null));
         assertNull(TypeUtils.castToBigDecimal(null));
+        assertNull(TypeUtils.castToBigInteger(null));
         assertNull(TypeUtils.castToTimestamp(null));
         assertNull(TypeUtils.castToSqlDate(null));
         assertNull(TypeUtils.castToJavaBean(null, null));


### PR DESCRIPTION
### What this PR does / why we need it?

应用升级到该兼容包时，由于缺少castToBigInteger 方法导致无法编译。

### Summary of your change

为TypeUtil增加castToBigInteger方法。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
