### PR TITLE
fix Enums toUtf8Bytes errors

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterEnum.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterEnum.java
@@ -9,6 +9,7 @@ import com.alibaba.fastjson2.util.IOUtils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 class FieldWriterEnum
@@ -236,10 +237,13 @@ class FieldWriterEnum
             byte[] bytes = valueNameCacheUTF8[ordinal];
 
             if (bytes == null) {
-                String name = enumConstants[ordinal].name();
-                bytes = Arrays.copyOf(nameWithColonUTF8, nameWithColonUTF8.length + name.length() + 2);
+                byte[] nameUft8Bytes = enumConstants[ordinal].name().getBytes(StandardCharsets.UTF_8);
+                bytes = Arrays.copyOf(nameWithColonUTF8, nameWithColonUTF8.length + nameUft8Bytes.length + 2);
                 bytes[nameWithColonUTF8.length] = '"';
-                name.getBytes(0, name.length(), bytes, nameWithColonUTF8.length + 1);
+                int index = nameWithColonUTF8.length + 1;
+                for (byte b : nameUft8Bytes) {
+                    bytes[index++] = b;
+                }
                 bytes[bytes.length - 1] = '"';
                 valueNameCacheUTF8[ordinal] = bytes;
             }

--- a/core/src/test/java/com/alibaba/fastjson2/primitves/EnumNonAsciiTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/primitves/EnumNonAsciiTest.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson2.primitves;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * @author liuhaoxing
+ * @date 2023-02-27
+ **/
+public class EnumNonAsciiTest {
+    @Test
+    public void testEnum() {
+        Bean bean = new Bean();
+        bean.setTestEnum(TestEnum.第二);
+        bean.setName("zhangsan");
+        byte[] bytes = JSON.toJSONBytes(bean, JSONWriter.Feature.WriteEnumsUsingName);
+        Bean bean1 = JSONObject.parseObject(new String(bytes, StandardCharsets.UTF_8), Bean.class);
+
+        assertEquals(bean1.getName(), bean.getName());
+        assertEquals(bean1.getTestEnum(), bean.getTestEnum());
+    }
+
+    @Data
+    static class Bean {
+        private TestEnum testEnum;
+        private String name;
+    }
+
+    @SuppressWarnings("all")
+    enum TestEnum {
+        第一,
+        第二,
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
一个对象中如果有属性是枚举类型，且枚举值为中文命名，对其进行toJSONBytes序列化时，并不能得到期望的值。测试代码如下所示：
``` java
@Test
public void testEnum() {
     Bean bean = new Bean();
     bean.setTestEnum(TestEnum.第二);
     bean.setName("zhangsan");
     byte[] bytes = JSON.toJSONBytes(bean, JSONWriter.Feature.WriteEnumsUsingName);
     System.out.println(new String(bytes, StandardCharsets.UTF_8));
}

@Data
static class Bean {
    private TestEnum testEnum;
    private String name;
}

@SuppressWarnings("all")
enum TestEnum {
    第一,
    第二,
}

```
期望的结果：``{"name":"zhangsan","testEnum":"第二"}``
实际的结果：``{"name":"zhangsan","testEnum":",�"}``

经排查，com.alibaba.fastjson2.writer.FieldWriterEnum中使用了过时的getBytes方法复制bytes导致，此方法并不能真正意义上的对字节数组进行复制

### Summary of your change



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
