### PR TITLE
1205 question is fastjson extension support spring webflux

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -48,7 +48,7 @@
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2:2.0.25'
 }
 ```
 
@@ -66,7 +66,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -74,7 +74,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba:fastjson:2.0.24'
+    implementation 'com.alibaba:fastjson:2.0.25'
 }
 ```
 
@@ -88,7 +88,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 
 <!-- 有些场景需要依赖kotlin-reflect -->
@@ -103,7 +103,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.24")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.25")
 }
 ```
 
@@ -117,7 +117,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -125,7 +125,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.25'
 }
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -46,7 +46,7 @@ Related Documents:
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -54,7 +54,7 @@ Related Documents:
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2:2.0.25'
 }
 ```
 
@@ -72,7 +72,7 @@ If you are using `fastjson 1.2.x`, you can use the compatibility package. The co
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -80,7 +80,7 @@ If you are using `fastjson 1.2.x`, you can use the compatibility package. The co
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba:fastjson:2.0.24'
+    implementation 'com.alibaba:fastjson:2.0.25'
 }
 ```
 
@@ -94,7 +94,7 @@ If your project uses `kotlin`, you can use the `Fastjson-Kotlin` module, and use
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -102,7 +102,7 @@ If your project uses `kotlin`, you can use the `Fastjson-Kotlin` module, and use
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.24")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.25")
 }
 ```
 
@@ -116,7 +116,7 @@ If your project uses a framework such as `SpringFramework`, you can use the `fas
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -124,7 +124,7 @@ If your project uses a framework such as `SpringFramework`, you can use the `fas
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.25'
 }
 ```
 

--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>fastjson2-parent</artifactId>
         <groupId>com.alibaba.fastjson2</groupId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
     </parent>
 
     <artifactId>fastjson2-adapter</artifactId>

--- a/adapter/pom.xml
+++ b/adapter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>fastjson2-parent</artifactId>
         <groupId>com.alibaba.fastjson2</groupId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
     </parent>
 
     <artifactId>fastjson2-adapter</artifactId>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -36,7 +36,7 @@ public interface JSON {
     /**
      * FASTJSON2 version name
      */
-    String VERSION = "2.0.25";
+    String VERSION = "2.0.26";
 
     /**
      * Parse JSON {@link String} into {@link JSONArray} or {@link JSONObject}

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentName.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentName.java
@@ -525,6 +525,7 @@ class JSONPathSegmentName
                 if (jsonReader.isEnd()) {
                     return;
                 }
+                jsonReader.nextIfMatch(',');
                 // return object;
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -1852,7 +1852,7 @@ public abstract class JSONReader
 
         List list = new ArrayList();
         if (!nextIfMatch('[')) {
-            throw new JSONException("syntax error : " + ch);
+            throw new JSONException(info("syntax error : " + ch));
         }
 
         boolean fieldBased = (context.features & Feature.FieldBased.mask) != 0;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -1223,7 +1223,7 @@ public abstract class JSONReader
                 zdt = ZonedDateTime.ofLocal(ldt, context.getZoneId(), null);
             } else if (len >= 20) {
                 zdt = readZonedDateTimeX(len);
-                if (zdt == null && len == 34) {
+                if (zdt == null && (len >= 32 && len <= 35)) {
                     String str = readString();
                     zdt = DateUtils.parseZonedDateTime(str, null);
                 }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -633,7 +633,7 @@ class JSONReaderJSONB
                         zoneId = SHANGHAI_ZONE_ID;
                     } else {
                         String zoneIdStr = readString();
-                        zoneId = ZoneId.of(zoneIdStr);
+                        zoneId = DateUtils.getZoneId(zoneIdStr, SHANGHAI_ZONE_ID);
                     }
                 }
                 LocalDateTime ldt = LocalDateTime.of(year, month, dayOfMonth, hour, minute, second, nano);
@@ -4565,7 +4565,7 @@ class JSONReaderJSONB
                     if (contextZondId.getId().equals(zoneIdStr)) {
                         zoneId = contextZondId;
                     } else {
-                        zoneId = ZoneId.of(zoneIdStr);
+                        zoneId = DateUtils.getZoneId(zoneIdStr, SHANGHAI_ZONE_ID);
                     }
                 }
                 return ZonedDateTime.ofLocal(ldt, zoneId, null);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -5651,6 +5651,8 @@ class JSONReaderUTF16
             return null;
         }
 
+        String zoneIdStr = null;
+
         char c0 = chars[offset];
         char c1 = chars[offset + 1];
         char c2 = chars[offset + 2];
@@ -6292,6 +6294,45 @@ class JSONReaderUTF16
             S8 = '0';
             zoneIdBegin = 28;
             isTimeZone = c28 == '|';
+        } else if (len == 28 && c3 == ' ' && c7 == ' ' && c10 == ' ' && c13 == ':' && c16 == ':' && c19 == ' ' && c23 == ' ') {
+            int month = DateUtils.month(c4, c5, c6);
+            if (month > 0) {
+                m0 = (char) ('0' + month / 10);
+                m1 = (char) ('0' + (month % 10));
+            } else {
+                m0 = '0';
+                m1 = '0';
+            }
+
+            d0 = c8;
+            d1 = c9;
+
+            h0 = c11;
+            h1 = c12;
+
+            i0 = c14;
+            i1 = c15;
+
+            s0 = c17;
+            s1 = c18;
+
+            y0 = c24;
+            y1 = c25;
+            y2 = c26;
+            y3 = c27;
+
+            S0 = '0';
+            S1 = '0';
+            S2 = '0';
+            S3 = '0';
+            S4 = '0';
+            S5 = '0';
+            S6 = '0';
+            S7 = '0';
+            S8 = '0';
+            zoneIdBegin = 19;
+            zoneIdStr = new String(chars, 21, 3);
+            isTimeZone = false;
         } else if (len == 28 && c3 == ',' && c4 == ' ' && c6 == ' ' && c10 == ' ' && c15 == ' ' && c18 == ':' && c21 == ':' && c24 == ' ') {
             // RFC 1123
             y0 = c11;
@@ -6426,16 +6467,17 @@ class JSONReaderUTF16
             if (first == 'Z') {
                 zoneId = UTC;
             } else {
-                String zoneIdStr;
-                if (first == '+' || first == '-') {
-                    zoneIdStr = new String(chars, this.offset + zoneIdBegin, len - zoneIdBegin);
-                } else if (first == ' ') {
-                    zoneIdStr = new String(chars, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 1);
-                } else { // '[
-                    if (zoneIdBegin < len) {
-                        zoneIdStr = new String(chars, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 2);
-                    } else {
-                        zoneIdStr = null;
+                if (zoneIdStr == null) {
+                    if (first == '+' || first == '-') {
+                        zoneIdStr = new String(chars, this.offset + zoneIdBegin, len - zoneIdBegin);
+                    } else if (first == ' ') {
+                        zoneIdStr = new String(chars, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 1);
+                    } else { // '[
+                        if (zoneIdBegin < len) {
+                            zoneIdStr = new String(chars, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 2);
+                        } else {
+                            zoneIdStr = null;
+                        }
                     }
                 }
                 zoneId = DateUtils.getZoneId(zoneIdStr, context.zoneId);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -4530,6 +4530,8 @@ class JSONReaderUTF8
             return null;
         }
 
+        String zoneIdStr = null;
+
         char c0 = (char) bytes[offset + 0];
         char c1 = (char) bytes[offset + 1];
         char c2 = (char) bytes[offset + 2];
@@ -5169,6 +5171,45 @@ class JSONReaderUTF8
             S8 = '0';
             zoneIdBegin = 28;
             isTimeZone = c28 == '|';
+        } else if (len == 28 && c3 == ' ' && c7 == ' ' && c10 == ' ' && c13 == ':' && c16 == ':' && c19 == ' ' && c23 == ' ') {
+            int month = DateUtils.month(c4, c5, c6);
+            if (month > 0) {
+                m0 = (char) ('0' + month / 10);
+                m1 = (char) ('0' + (month % 10));
+            } else {
+                m0 = '0';
+                m1 = '0';
+            }
+
+            d0 = c8;
+            d1 = c9;
+
+            h0 = c11;
+            h1 = c12;
+
+            i0 = c14;
+            i1 = c15;
+
+            s0 = c17;
+            s1 = c18;
+
+            y0 = c24;
+            y1 = c25;
+            y2 = c26;
+            y3 = c27;
+
+            S0 = '0';
+            S1 = '0';
+            S2 = '0';
+            S3 = '0';
+            S4 = '0';
+            S5 = '0';
+            S6 = '0';
+            S7 = '0';
+            S8 = '0';
+            zoneIdBegin = 19;
+            zoneIdStr = new String(bytes, 21, 3);
+            isTimeZone = false;
         } else if (len == 28 && c3 == ',' && c4 == ' ' && c6 == ' ' && c10 == ' ' && c15 == ' ' && c18 == ':' && c21 == ':' && c24 == ' ') {
             // RFC 1123
             y0 = c11;
@@ -5303,16 +5344,17 @@ class JSONReaderUTF8
             if (first == 'Z') {
                 zoneId = ZoneOffset.UTC;
             } else {
-                String zoneIdStr;
-                if (first == '+' || first == '-') {
-                    zoneIdStr = new String(bytes, this.offset + zoneIdBegin, len - zoneIdBegin, StandardCharsets.US_ASCII);
-                } else if (first == ' ') {
-                    zoneIdStr = new String(bytes, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 1, StandardCharsets.US_ASCII);
-                } else { // '[
-                    if (zoneIdBegin < len) {
-                        zoneIdStr = new String(bytes, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 2, StandardCharsets.US_ASCII);
-                    } else {
-                        zoneIdStr = null;
+                if (zoneIdStr == null) {
+                    if (first == '+' || first == '-') {
+                        zoneIdStr = new String(bytes, this.offset + zoneIdBegin, len - zoneIdBegin, StandardCharsets.US_ASCII);
+                    } else if (first == ' ') {
+                        zoneIdStr = new String(bytes, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 1, StandardCharsets.US_ASCII);
+                    } else { // '[
+                        if (zoneIdBegin < len) {
+                            zoneIdStr = new String(bytes, this.offset + zoneIdBegin + 1, len - zoneIdBegin - 2, StandardCharsets.US_ASCII);
+                        } else {
+                            zoneIdStr = null;
+                        }
                     }
                 }
                 zoneId = DateUtils.getZoneId(zoneIdStr, context.zoneId);

--- a/core/src/main/java/com/alibaba/fastjson2/annotation/JSONType.java
+++ b/core/src/main/java/com/alibaba/fastjson2/annotation/JSONType.java
@@ -72,4 +72,9 @@ public @interface JSONType {
      * @since 2.0.8
      */
     String locale() default "";
+
+    /**
+     * @since 2.0.25
+     */
+    Class<? extends JSONReader.AutoTypeBeforeHandler> autoTypeBeforeHandler() default JSONReader.AutoTypeBeforeHandler.class;
 }

--- a/core/src/main/java/com/alibaba/fastjson2/codec/BeanInfo.java
+++ b/core/src/main/java/com/alibaba/fastjson2/codec/BeanInfo.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson2.codec;
 
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.filter.Filter;
 
 import java.lang.reflect.Constructor;
@@ -44,6 +45,7 @@ public class BeanInfo {
     public boolean alphabetic = true;
     public String objectWriterFieldName;
     public String objectReaderFieldName;
+    public Class<? extends JSONReader.AutoTypeBeforeHandler> autoTypeBeforeHandler;
 
     public void required(String fieldName) {
         if (schema == null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -582,6 +582,14 @@ public class ObjectReaderBaseModule
                             }
                             break;
                         }
+                        case "autoTypeBeforeHandler":
+                        case "autoTypeCheckHandler": {
+                            Class<?> autoTypeCheckHandler = (Class) result;
+                            if (JSONReader.AutoTypeBeforeHandler.class.isAssignableFrom(autoTypeCheckHandler)) {
+                                beanInfo.autoTypeBeforeHandler = (Class<JSONReader.AutoTypeBeforeHandler>) autoTypeCheckHandler;
+                            }
+                            break;
+                        }
                         default:
                             break;
                     }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
@@ -31,7 +31,16 @@ public abstract class ObjectReaderBean<T>
 
     protected final JSONSchema schema;
 
-    protected ObjectReaderBean(Class objectClass, Supplier<T> creator, String typeName, long features, JSONSchema schema, Function buildFunction) {
+    protected JSONReader.AutoTypeBeforeHandler autoTypeBeforeHandler;
+
+    protected ObjectReaderBean(
+            Class objectClass,
+            Supplier<T> creator,
+            String typeName,
+            long features,
+            JSONSchema schema,
+            Function buildFunction
+    ) {
         if (typeName == null) {
             if (objectClass != null) {
                 typeName = TypeUtils.getTypeName(objectClass);
@@ -54,10 +63,12 @@ public abstract class ObjectReaderBean<T>
         return objectClass;
     }
 
-    protected T processObjectInputSingleItemArray(JSONReader jsonReader,
-                                                  Type fieldType,
-                                                  Object fieldName,
-                                                  long features) {
+    protected T processObjectInputSingleItemArray(
+            JSONReader jsonReader,
+            Type fieldType,
+            Object fieldName,
+            long features
+    ) {
         String message = "expect {, but [, class " + this.typeName;
         if (fieldName != null) {
             message += ", parent fieldName " + fieldName;
@@ -244,7 +255,11 @@ public abstract class ObjectReaderBean<T>
 
             JSONReader.Context context = jsonReader.getContext();
             long features3, hash = jsonReader.readFieldNameHashCode();
-            JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
+            JSONReader.AutoTypeBeforeHandler autoTypeFilter = this.autoTypeBeforeHandler;
+            if (autoTypeFilter == null) {
+                autoTypeFilter = context.getContextAutoTypeBeforeHandler();
+            }
+
             if (i == 0
                     && hash == getTypeKeyHash()
                     && ((((features3 = (features | getFeatures() | context.getFeatures())) & JSONReader.Feature.SupportAutoType.mask) != 0) || autoTypeFilter != null)
@@ -331,5 +346,13 @@ public abstract class ObjectReaderBean<T>
     }
 
     protected void initStringFieldAsEmpty(Object object) {
+    }
+
+    public JSONReader.AutoTypeBeforeHandler getAutoTypeBeforeHandler() {
+        return autoTypeBeforeHandler;
+    }
+
+    public void setAutoTypeBeforeHandler(JSONReader.AutoTypeBeforeHandler autoTypeBeforeHandler) {
+        this.autoTypeBeforeHandler = autoTypeBeforeHandler;
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
@@ -27,6 +27,7 @@ import java.util.function.*;
 
 import static com.alibaba.fastjson2.codec.FieldInfo.JSON_AUTO_WIRED_ANNOTATED;
 import static com.alibaba.fastjson2.util.JDKUtils.UNSAFE_SUPPORT;
+import static com.alibaba.fastjson2.util.TypeUtils.isFunction;
 
 public class ObjectReaderCreator {
     public static final boolean JIT = !JDKUtils.ANDROID && !JDKUtils.GRAAL;
@@ -1384,7 +1385,7 @@ public class ObjectReaderCreator {
         Class fieldClass = method.getParameterTypes()[0];
 
         // skip function
-        if (fieldClass.getName().startsWith("java.util.function.")) {
+        if (isFunction(fieldClass)) {
             return;
         }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplList.java
@@ -41,6 +41,11 @@ public final class ObjectReaderImplList
     volatile boolean instanceError;
 
     public static ObjectReader of(Type type, Class listClass, long features) {
+        if (listClass == type && "".equals(listClass.getSimpleName())) {
+            type = listClass.getGenericSuperclass();
+            listClass = listClass.getSuperclass();
+        }
+
         Type itemType = Object.class;
         Type rawType;
         if (type instanceof ParameterizedType) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMap.java
@@ -39,6 +39,14 @@ public final class ObjectReaderImplMap
     public static ObjectReader of(Type fieldType, Class mapType, long features) {
         Function builder = null;
         Class instanceType = mapType;
+
+        if ("".equals(instanceType.getSimpleName())) {
+            instanceType = mapType.getSuperclass();
+            if (fieldType == null) {
+                fieldType = mapType.getGenericSuperclass();
+            }
+        }
+
         if (mapType == Map.class
                 || mapType == AbstractMap.class
                 || mapType == CLASS_SINGLETON_MAP

--- a/core/src/main/java/com/alibaba/fastjson2/util/DateUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/DateUtils.java
@@ -25,6 +25,7 @@ public class DateUtils {
     public static final ZoneRules SHANGHAI_ZONE_RULES = SHANGHAI_ZONE_ID.getRules();
 
     static DateTimeFormatter DATE_TIME_FORMATTER_34;
+    static DateTimeFormatter DATE_TIME_FORMATTER_RFC_2822;
 
     static final int LOCAL_EPOCH_DAY;
     static {
@@ -3203,6 +3204,13 @@ public class DateUtils {
                 formatter = DATE_TIME_FORMATTER_34 = DateTimeFormatter.ofPattern("EEE MMM dd HH:mm:ss O yyyy");
             }
             return ZonedDateTime.parse(str, formatter);
+        } else if (len == 31 && str.charAt(3) == ',') {
+            DateTimeFormatter formatter;
+            formatter = DATE_TIME_FORMATTER_RFC_2822;
+            if (formatter == null) {
+                formatter = DATE_TIME_FORMATTER_RFC_2822 = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z");
+            }
+            return ZonedDateTime.parse(str, formatter);
         } else {
             throw new DateTimeParseException("illegal input " + str, str, 0);
         }
@@ -3276,6 +3284,8 @@ public class DateUtils {
         int p0, p1;
         if ("000".equals(zoneIdStr)) {
             zoneId = ZoneOffset.UTC;
+        } else if ("CST".equals(zoneIdStr)) {
+            zoneId = SHANGHAI_ZONE_ID;
         } else if ((p0 = zoneIdStr.indexOf('[')) > 0 && (p1 = zoneIdStr.indexOf(']', p0)) > 0) {
             String str = zoneIdStr.substring(p0 + 1, p1);
             zoneId = ZoneId.of(str);

--- a/core/src/main/java/com/alibaba/fastjson2/util/DateUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/DateUtils.java
@@ -25,6 +25,8 @@ public class DateUtils {
     public static final ZoneRules SHANGHAI_ZONE_RULES = SHANGHAI_ZONE_ID.getRules();
 
     static DateTimeFormatter DATE_TIME_FORMATTER_34;
+    static DateTimeFormatter DATE_TIME_FORMATTER_COOKIE;
+    static DateTimeFormatter DATE_TIME_FORMATTER_COOKIE_LOCAL;
     static DateTimeFormatter DATE_TIME_FORMATTER_RFC_2822;
 
     static final int LOCAL_EPOCH_DAY;
@@ -3239,6 +3241,12 @@ public class DateUtils {
             S8 = '0';
             zoneIdBegin = 17;
             isTimeZone = false;
+        } else if ((len == 32 && c6 == ',' && c7 == ' ' && c10 == '-' && c14 == '-' && c19 == ' ' && c22 == ':' && c25 == ':' && str.charAt(28) == ' ')
+                || (len == 33 && c7 == ',' && c8 == ' ' && c11 == '-' && c15 == '-' && c20 == ' ' && c23 == ':' && c26 == ':' && str.charAt(29) == ' ')
+                || (len == 34 && c8 == ',' && c9 == ' ' && c12 == '-' && c16 == '-' && c21 == ' ' && c24 == ':' && c27 == ':' && str.charAt(30) == ' ')
+                || (len == 35 && c9 == ',' && c10 == ' ' && c13 == '-' && c17 == '-' && c22 == ' ' && c25 == ':' && c28 == ':' && str.charAt(31) == ' ')
+        ) {
+            return parseZonedDateTimeCookie(str);
         } else if (len == 34) {
             DateTimeFormatter formatter = DATE_TIME_FORMATTER_34;
             if (formatter == null) {
@@ -3315,6 +3323,26 @@ public class DateUtils {
         }
 
         return ZonedDateTime.ofLocal(ldt, zoneId, null);
+    }
+
+    private static ZonedDateTime parseZonedDateTimeCookie(String str) {
+        if (str.endsWith(" CST")) {
+            DateTimeFormatter formatter = DATE_TIME_FORMATTER_COOKIE_LOCAL;
+            if (formatter == null) {
+                formatter = DateTimeFormatter.ofPattern("EEEE, dd-MMM-yyyy HH:mm:ss");
+                DATE_TIME_FORMATTER_COOKIE_LOCAL = formatter;
+            }
+            String strLocalDateTime = str.substring(0, str.length() - 4);
+            LocalDateTime ldt = LocalDateTime.parse(strLocalDateTime, formatter);
+            return ZonedDateTime.of(ldt, DateUtils.SHANGHAI_ZONE_ID);
+        }
+
+        DateTimeFormatter formatter = DATE_TIME_FORMATTER_COOKIE;
+        if (formatter == null) {
+            formatter = DateTimeFormatter.ofPattern("EEEE, dd-MMM-yyyy HH:mm:ss zzz");
+            DATE_TIME_FORMATTER_COOKIE = formatter;
+        }
+        return ZonedDateTime.parse(str, formatter);
     }
 
     public static ZoneId getZoneId(String zoneIdStr, ZoneId defaultZoneId) {

--- a/core/src/main/java/com/alibaba/fastjson2/util/DateUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/DateUtils.java
@@ -2351,6 +2351,8 @@ public class DateUtils {
             throw new DateTimeParseException("illegal input " + str, str, 0);
         }
 
+        String zoneIdStr = null;
+
         char c0 = str.charAt(0);
         char c1 = str.charAt(1);
         char c2 = str.charAt(2);
@@ -3047,6 +3049,45 @@ public class DateUtils {
             S8 = '0';
             zoneIdBegin = 28;
             isTimeZone = c28 == '|';
+        } else if (len == 28 && c3 == ' ' && c7 == ' ' && c10 == ' ' && c13 == ':' && c16 == ':' && c19 == ' ' && c23 == ' ') {
+            int month = DateUtils.month(c4, c5, c6);
+            if (month > 0) {
+                m0 = (char) ('0' + month / 10);
+                m1 = (char) ('0' + (month % 10));
+            } else {
+                m0 = '0';
+                m1 = '0';
+            }
+
+            d0 = c8;
+            d1 = c9;
+
+            h0 = c11;
+            h1 = c12;
+
+            i0 = c14;
+            i1 = c15;
+
+            s0 = c17;
+            s1 = c18;
+
+            y0 = c24;
+            y1 = c25;
+            y2 = c26;
+            y3 = c27;
+
+            S0 = '0';
+            S1 = '0';
+            S2 = '0';
+            S3 = '0';
+            S4 = '0';
+            S5 = '0';
+            S6 = '0';
+            S7 = '0';
+            S8 = '0';
+            zoneIdBegin = 19;
+            zoneIdStr = str.substring(20, 23);
+            isTimeZone = false;
         } else if (len == 28 && c3 == ',' && c4 == ' ' && c6 == ' ' && c10 == ' ' && c15 == ' '
                 && c18 == ':' && c21 == ':' && c24 == ' ') {
             // RFC 1123
@@ -3255,17 +3296,18 @@ public class DateUtils {
             if (first == 'Z') {
                 zoneId = UTC;
             } else {
-                String zoneIdStr;
-                if (first == '+' || first == '-') {
-                    zoneIdStr = str.substring(zoneIdBegin, len);
-                    //                    zoneIdStr = new String(chars, zoneIdBegin, len - zoneIdBegin);
-                } else if (first == ' ') {
-                    zoneIdStr = str.substring(zoneIdBegin + 1, len);
-                } else { // '[
-                    if (zoneIdBegin < len) {
-                        zoneIdStr = str.substring(zoneIdBegin + 1, len - 1);
-                    } else {
-                        zoneIdStr = null;
+                if (zoneIdStr == null) {
+                    if (first == '+' || first == '-') {
+                        zoneIdStr = str.substring(zoneIdBegin, len);
+                        //                    zoneIdStr = new String(chars, zoneIdBegin, len - zoneIdBegin);
+                    } else if (first == ' ') {
+                        zoneIdStr = str.substring(zoneIdBegin + 1, len);
+                    } else { // '[
+                        if (zoneIdBegin < len) {
+                            zoneIdStr = str.substring(zoneIdBegin + 1, len - 1);
+                        } else {
+                            zoneIdStr = null;
+                        }
                     }
                 }
                 zoneId = getZoneId(zoneIdStr, defaultZoneId);

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -2791,4 +2791,19 @@ public class TypeUtils {
 
         return object;
     }
+
+    public static boolean isFunction(Class type) {
+        if (type.isInterface()) {
+            String typeName = type.getName();
+            if (typeName.startsWith("java.util.function.")) {
+                return true;
+            }
+
+            if (type.isAnnotationPresent(FunctionalInterface.class)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
@@ -429,6 +429,11 @@ public class ObjectWriterAdapter<T>
 
     @Override
     public void writeWithFilter(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+        if (object == null) {
+            jsonWriter.writeNull();
+            return;
+        }
+
         if (jsonWriter.isWriteTypeInfo(object, fieldType, features)) {
             if (jsonWriter.jsonb) {
                 writeClassInfo(jsonWriter);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
@@ -658,19 +658,29 @@ public class ObjectWriterCreator {
         Class<?> declaringClass = field.getDeclaringClass();
         Method method = null;
 
-        boolean unsafeFieldWriter = JDKUtils.UNSAFE_SUPPORT;
-        if (declaringClass == Throwable.class && !unsafeFieldWriter) {
-            unsafeFieldWriter = JDKUtils.UNSAFE_SUPPORT;
+        final boolean unsafeFieldWriter = JDKUtils.UNSAFE_SUPPORT;
+        if (declaringClass == Throwable.class) {
             switch (field.getName()) {
                 case "detailMessage":
-                    method = BeanUtils.getMethod(Throwable.class, "getMessage");
-                    fieldName = "message";
+                    if (!unsafeFieldWriter) {
+                        method = BeanUtils.getMethod(Throwable.class, "getMessage");
+                        fieldName = "message";
+                    }
                     break;
                 case "cause":
-                    method = BeanUtils.getMethod(Throwable.class, "getCause");
+                    if (!unsafeFieldWriter) {
+                        method = BeanUtils.getMethod(Throwable.class, "getCause");
+                    }
                     break;
                 case "suppressedExceptions": {
-                    fieldName = "suppressed";
+                    if (!unsafeFieldWriter) {
+                        fieldName = "suppressed";
+                    }
+                    break;
+                }
+                case "stackTrace": {
+                    method = BeanUtils.getMethod(Throwable.class, "getStackTrace");
+                    break;
                 }
                 default:
                     break;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
 
 import static com.alibaba.fastjson2.JSONWriter.Feature.*;
 import static com.alibaba.fastjson2.util.JDKUtils.UNSAFE_SUPPORT;
+import static com.alibaba.fastjson2.util.TypeUtils.isFunction;
 import static com.alibaba.fastjson2.writer.ObjectWriterProvider.TYPE_INT64_MASK;
 
 public class ObjectWriterCreatorASM
@@ -328,7 +329,7 @@ public class ObjectWriterCreatorASM
 
                     Class<?> returnType = method.getReturnType();
                     // skip function
-                    if (returnType.getName().startsWith("java.util.function.")) {
+                    if (isFunction(returnType)) {
                         return;
                     }
 
@@ -3316,6 +3317,10 @@ public class ObjectWriterCreatorASM
 
         if (fieldClass == Double[].class) {
             return new FieldWriterObjectArrayField<>(fieldName, Float.class, ordinal, features, format, label, Double[].class, Double[].class, field);
+        }
+
+        if (isFunction(fieldClass)) {
+            return null;
         }
 
         return new FieldWriterObject(fieldName, ordinal, features, format, label, field.getGenericType(), fieldClass, field, null);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -266,6 +266,21 @@ public class ObjectWriterProvider
             return objectWriter;
         }
 
+        if (TypeUtils.isProxy(objectClass)) {
+            Class superclass = objectClass.getSuperclass();
+            if (objectClass == objectType) {
+                objectType = superclass;
+            }
+            objectClass = superclass;
+            if (fieldBased) {
+                fieldBased = false;
+                objectWriter = cacheFieldBased.get(objectType);
+                if (objectWriter != null) {
+                    return objectWriter;
+                }
+            }
+        }
+
         boolean useModules = true;
         if (fieldBased && objectClass != null) {
             if (Iterable.class.isAssignableFrom(objectClass)

--- a/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONArrayTest.java
@@ -1459,4 +1459,10 @@ public class JSONArrayTest {
         assertEquals("2", strings.get(1));
         assertEquals("3", strings.get(2));
     }
+
+    @Test
+    public void from() {
+        JSONArray array = JSONArray.from(Collections.emptyList(), JSONWriter.Feature.NotWriteEmptyArray);
+        assertEquals(0, array.size());
+    }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/JSONBTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONBTest.java
@@ -1090,4 +1090,18 @@ public class JSONBTest {
         byte[] bytes = {(byte) 0xa6, 0x79, 0x48, 0x7f, 0x7f, 0x7f, 0x7f};
         assertThrows(JSONException.class, () -> JSONB.parseObject(bytes));
     }
+
+    @Test
+    public void parseArray() {
+        assertNull(JSONB.parseArray(null, Bean.class, JSONReader.Feature.SupportAutoType));
+        assertNull(JSONB.parseArray(new byte[0], Bean.class, JSONReader.Feature.SupportAutoType));
+
+        byte[] jsonbBytes = JSONArray.of().toJSONBBytes();
+        List<Object> objects = JSONB.parseArray(jsonbBytes, Bean.class, JSONReader.Feature.SupportAutoType);
+        assertEquals(0, objects.size());
+    }
+
+    public static class Bean {
+        public int id;
+    }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/JSONObjectTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONObjectTest.java
@@ -1407,4 +1407,12 @@ public class JSONObjectTest {
         assertEquals(1, JSONObject.of("value", JSONObject.of("a", 1)).getSize("value"));
         assertEquals(2, JSONObject.of("value", JSONArray.of("a", "b")).getSize("value"));
     }
+
+    @Test
+    public void from() {
+        Bean bean = new Bean();
+        bean.id = 1001;
+        JSONObject object = JSONObject.from(bean, JSONWriter.Feature.NotWriteDefaultValue);
+        assertEquals(bean.id, object.getIntValue("id"));
+    }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/annotation/JSONTypeAutoTypeCheckHandlerTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/annotation/JSONTypeAutoTypeCheckHandlerTest.java
@@ -1,0 +1,44 @@
+package com.alibaba.fastjson2.annotation;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONTypeAutoTypeCheckHandlerTest {
+    @Test
+    public void test_for_checkAutoType() {
+        Cat cat = (Cat) JSON.parseObject("{\"@type\":\"Cat\",\"catId\":123}", Animal.class);
+        assertEquals(123, cat.catId);
+    }
+
+    @JSONType(autoTypeBeforeHandler = MyAutoTypeCheckHandler.class)
+    public static class Animal {
+    }
+
+    public static class Cat
+            extends Animal {
+        public int catId;
+    }
+
+    public static class Mouse
+            extends Animal {
+    }
+
+    public static class MyAutoTypeCheckHandler
+            implements JSONReader.AutoTypeBeforeHandler {
+        @Override
+        public Class<?> apply(String typeName, Class<?> expectClass, long features) {
+            if ("Cat".equals(typeName)) {
+                return Cat.class;
+            }
+
+            if ("Mouse".equals(typeName)) {
+                return Mouse.class;
+            }
+
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
@@ -1,0 +1,37 @@
+package com.alibaba.fastjson2.date;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.util.DateUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DateTest {
+    @Test
+    public void test() {
+        String str = "2023-03-11T11:33:22Z";
+        long millis = DateUtils.parseMillis(str);
+
+        assertEquals(millis, DateUtils.parseMillis("2023-03-11 19:33:22 CST"));
+        assertEquals(
+                millis,
+                JSON.parseObject("\"2023-03-11 19:33:22 CST\"", Date.class)
+                        .getTime()
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject("\"2023-03-11T11:33:22Z\"", Date.class)
+                        .getTime()
+        );
+
+        // ISO8601
+        assertEquals(
+                millis,
+                JSON.parseObject("\"2023-03-11T11:33:22+0000\"", Date.class)
+                        .getTime()
+        );
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
@@ -9,11 +9,9 @@ import java.util.Date;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DateTest {
+    static final long millis = DateUtils.parseMillis("2023-03-11T11:33:22Z");
     @Test
     public void test() {
-        String str = "2023-03-11T11:33:22Z";
-        long millis = DateUtils.parseMillis(str);
-
         assertEquals(millis, DateUtils.parseMillis("2023-03-11 19:33:22 CST"));
         assertEquals(
                 millis,
@@ -31,6 +29,29 @@ public class DateTest {
         assertEquals(
                 millis,
                 JSON.parseObject("\"2023-03-11T11:33:22+0000\"", Date.class)
+                        .getTime()
+        );
+    }
+
+    @Test
+    public void test1() {
+        String str = "Sun Mar 11 19:33:22 CST 2023";
+        String json = "\"" + str + "\"";
+
+        assertEquals(
+                millis,
+                DateUtils.parseMillis(str)
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject(json.getBytes(), Date.class)
+                        .getTime()
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject(json, Date.class)
                         .getTime()
         );
     }

--- a/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
@@ -59,6 +59,31 @@ public class DateTest {
         );
     }
 
+
+    @Test
+    public void test2() {
+        long millis = 1678669374000L;
+        String str = "Mon Mar 13 09:02:54 CST 2023";
+        String json = "\"" + str + "\"";
+
+        assertEquals(
+                millis,
+                DateUtils.parseMillis(str)
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject(json.getBytes(), Date.class)
+                        .getTime()
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject(json, Date.class)
+                        .getTime()
+        );
+    }
+
     @Test
     public void cookie() {
         String str = "Saturday, 11-Mar-2023 11:33:22 UTC";

--- a/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
@@ -4,6 +4,9 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.util.DateUtils;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -54,5 +57,72 @@ public class DateTest {
                 JSON.parseObject(json, Date.class)
                         .getTime()
         );
+    }
+
+    @Test
+    public void cookie() {
+        String str = "Saturday, 11-Mar-2023 11:33:22 UTC";
+        String json = "\"" + str + "\"";
+
+        assertEquals(
+                millis,
+                DateUtils.parseMillis(str)
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject(json.getBytes(), Date.class)
+                        .getTime()
+        );
+
+        assertEquals(
+                millis,
+                JSON.parseObject(json, Date.class)
+                        .getTime()
+        );
+    }
+
+    @Test
+    public void cookieUTC() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEEE, dd-MMM-yyyy HH:mm:ss zzz");
+        ZonedDateTime zdt = ZonedDateTime.now(ZoneId.of("UTC"));
+        zdt = zdt.minusNanos(zdt.getNano());
+        for (int i = 0; i < 500; i++) {
+            ZonedDateTime zdtI = zdt.plusDays(i);
+            long millisI = zdtI.toInstant().toEpochMilli();
+
+            String str = zdtI.format(formatter);
+            long millis = DateUtils.parseMillis(str);
+            assertEquals(millisI, millis, str);
+
+            String json = "\"" + str + "\"";
+            assertEquals(
+                    millisI,
+                    JSON.parseObject(json.getBytes(), Date.class)
+                            .getTime()
+            );
+        }
+    }
+
+    @Test
+    public void cookieCST() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEEE, dd-MMM-yyyy HH:mm:ss zzz");
+        ZonedDateTime zdt = ZonedDateTime.now(DateUtils.SHANGHAI_ZONE_ID);
+        zdt = zdt.minusNanos(zdt.getNano());
+        for (int i = 0; i < 500; i++) {
+            ZonedDateTime zdtI = zdt.plusDays(i);
+            long millisI = zdtI.toInstant().toEpochMilli();
+
+            String str = zdtI.format(formatter);
+            long millis = DateUtils.parseMillis(str);
+            assertEquals(millisI, millis, str);
+
+            String json = "\"" + str + "\"";
+            assertEquals(
+                    millisI,
+                    JSON.parseObject(json.getBytes(), Date.class)
+                            .getTime()
+            );
+        }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/date/DateTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DateTest {
     static final long millis = DateUtils.parseMillis("2023-03-11T11:33:22Z");
+
     @Test
     public void test() {
         assertEquals(millis, DateUtils.parseMillis("2023-03-11 19:33:22 CST"));
@@ -58,7 +59,6 @@ public class DateTest {
                         .getTime()
         );
     }
-
 
     @Test
     public void test2() {

--- a/core/src/test/java/com/alibaba/fastjson2/dubbo/Dubbo11775.java
+++ b/core/src/test/java/com/alibaba/fastjson2/dubbo/Dubbo11775.java
@@ -1,0 +1,60 @@
+package com.alibaba.fastjson2.dubbo;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Dubbo11775 {
+    @Test
+    public void test() {
+        ParamsDTO paramsDTO = new ParamsDTO();
+        ParamsItemDTO paramsItemDTO = new ParamsItemDTO();
+        paramsItemDTO.setA("aaa");
+        paramsDTO.setParamsItems(Arrays.asList(paramsItemDTO));
+
+        byte[] jsonbBytes = JSONB.toBytes(paramsDTO, writerFeatures);
+        ParamsDTO paramsDTO1 = (ParamsDTO) JSONB.parseObject(jsonbBytes, Object.class, readerFeatures);
+        assertEquals(paramsDTO.paramsItems.getClass(), paramsDTO1.paramsItems.getClass());
+        assertEquals(paramsDTO.paramsItems.size(), paramsDTO1.paramsItems.size());
+        assertEquals(paramsDTO.paramsItems.get(0).a, paramsDTO1.paramsItems.get(0).a);
+    }
+
+    @Data
+    public static class ParamsItemDTO
+            implements Serializable {
+        private String a;
+    }
+
+    @Data
+    public static class ParamsDTO
+            implements Serializable {
+        private List<ParamsItemDTO> paramsItems;
+    }
+
+    JSONWriter.Feature[] writerFeatures = {
+            JSONWriter.Feature.WriteClassName,
+            JSONWriter.Feature.FieldBased,
+            JSONWriter.Feature.ErrorOnNoneSerializable,
+            JSONWriter.Feature.ReferenceDetection,
+            JSONWriter.Feature.WriteNulls,
+            JSONWriter.Feature.NotWriteDefaultValue,
+            JSONWriter.Feature.NotWriteHashMapArrayListClassName,
+            JSONWriter.Feature.WriteNameAsSymbol
+    };
+
+    JSONReader.Feature[] readerFeatures = {
+            JSONReader.Feature.SupportAutoType,
+            JSONReader.Feature.UseDefaultConstructorAsPossible,
+            JSONReader.Feature.ErrorOnNoneSerializable,
+            JSONReader.Feature.UseNativeObject,
+            JSONReader.Feature.FieldBased
+    };
+}

--- a/core/src/test/java/com/alibaba/fastjson2/dubbo/DubboTest5.java
+++ b/core/src/test/java/com/alibaba/fastjson2/dubbo/DubboTest5.java
@@ -1,0 +1,57 @@
+package com.alibaba.fastjson2.dubbo;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class DubboTest5 {
+    @Test
+    public void test() {
+        RuntimeException ex = new RuntimeException();
+        byte[] jsonbBytes = JSONB.toBytes(ex, writerFeatures);
+        RuntimeException ex1 = (RuntimeException) JSONB.parseObject(jsonbBytes, Object.class, readerFeatures);
+        assertNotNull(ex1);
+        assertEquals(ex.getStackTrace().length, ex1.getStackTrace().length);
+    }
+
+    @Test
+    public void test1() {
+        RuntimeException ex = null;
+        try {
+            error();
+        } catch (RuntimeException e) {
+            ex = e;
+        }
+        byte[] jsonbBytes = JSONB.toBytes(ex, writerFeatures);
+        RuntimeException ex1 = (RuntimeException) JSONB.parseObject(jsonbBytes, Object.class, readerFeatures);
+        assertNotNull(ex1);
+        assertEquals(ex.getStackTrace().length, ex1.getStackTrace().length);
+    }
+
+    void error() {
+        throw new RuntimeException();
+    }
+
+    static final JSONReader.Feature[] readerFeatures = {
+            JSONReader.Feature.SupportAutoType,
+            JSONReader.Feature.UseDefaultConstructorAsPossible,
+            JSONReader.Feature.ErrorOnNoneSerializable,
+            JSONReader.Feature.UseNativeObject,
+            JSONReader.Feature.FieldBased
+    };
+
+    static final JSONWriter.Feature[] writerFeatures = {
+            JSONWriter.Feature.WriteClassName,
+            JSONWriter.Feature.FieldBased,
+            JSONWriter.Feature.ErrorOnNoneSerializable,
+            JSONWriter.Feature.ReferenceDetection,
+            JSONWriter.Feature.WriteNulls,
+            JSONWriter.Feature.NotWriteDefaultValue,
+            JSONWriter.Feature.NotWriteHashMapArrayListClassName,
+            JSONWriter.Feature.WriteNameAsSymbol
+    };
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1177.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1177.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.issues_1000;
 
 import com.alibaba.fastjson2.JSON;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
@@ -46,5 +47,59 @@ public class Issue1177 {
         public void setFunc(Function<String, String> func) {
             this.func = func;
         }
+    }
+
+    @Test
+    public void test1() {
+        Bean1 bean = new Bean1();
+        String str = JSON.toJSONString(bean);
+        assertEquals("{}", str);
+    }
+
+    @Data
+    public static class Bean1 {
+        private MyFunction function = new MyFunction() {
+            @Override
+            public Object apply(Object o) {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void test2() {
+        Bean2 bean = new Bean2();
+        String str = JSON.toJSONString(bean);
+        assertEquals("{}", str);
+    }
+
+    public static class Bean2 {
+        public MyFunction function = new MyFunction() {
+            @Override
+            public Object apply(Object o) {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void test3() {
+        Bean3 bean = new Bean3();
+        String str = JSON.toJSONString(bean);
+        assertEquals("{}", str);
+    }
+
+    private static class Bean3 {
+        public MyFunction function = new MyFunction() {
+            @Override
+            public Object apply(Object o) {
+                return null;
+            }
+        };
+    }
+
+    @FunctionalInterface
+    public interface MyFunction<R, T> {
+        R apply(T t);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1204.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1204.java
@@ -1,0 +1,42 @@
+package com.alibaba.fastjson2.issues_1000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import com.alibaba.fastjson2.writer.ObjectWriterProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1204 {
+    static final ObjectWriterProvider provider = new ObjectWriterProvider();
+
+    @BeforeEach
+    void setup() {
+        provider.register(BigDecimal.class, new ObjectWriter<BigDecimal>() {
+            @Override
+            public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+                BigDecimal decimal = (BigDecimal) object;
+                if (decimal.scale() == 0) {
+                    decimal = decimal.setScale(1);
+                }
+                jsonWriter.writeDecimal(decimal);
+            }
+        });
+    }
+
+    @Test
+    public void test() throws Exception {
+        BigDecimal decimal = BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE);
+        JSONWriter.Context context = JSONFactory.createWriteContext(provider);
+        String str = JSON.toJSONString(decimal, context);
+        assertEquals("9223372036854775808.0", str);
+        BigDecimal decimal1 = (BigDecimal) JSON.parse(str);
+        assertEquals(decimal, decimal1.stripTrailingZeros());
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1215.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1215.java
@@ -1,0 +1,14 @@
+package com.alibaba.fastjson2.issues_1000;
+
+import com.alibaba.fastjson2.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class Issue1215 {
+    @Test
+    public void test() {
+        String str = "{\"x\":{},\"message\":\"1\"}";
+        assertNull(JSONPath.extract(str, "$.x.y"));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1216.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1216.java
@@ -1,0 +1,23 @@
+package com.alibaba.fastjson2.issues_1000;
+
+import com.alibaba.fastjson2.util.DateUtils;
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1216 {
+    @Test
+    public void test() throws Exception {
+        String value = "2017-07-24 12:13:14";
+        String value1 = "2018-07-24 12:13:14";
+
+        long millis = DateUtils.parseMillis(value);
+        long millis1 = DateUtils.parseMillis(value1);
+
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        assertEquals(format.parse(value).getTime(), millis);
+        assertEquals(format.parse(value1).getTime(), millis1);
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1222.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1222.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson2.issues_1000;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1222 {
+    @Test
+    public void test() {
+        String text = "{\"businessLine\":5,\"ccId\":\"913440103290\",\"cardNo\":\"24000000039QWERR\"}";
+
+        HashMap<String, String> users2 = Optional
+                .ofNullable(text)
+                .map(
+                        t -> (HashMap<String, String>) JSONObject.parseObject(
+                                t,
+                                new TypeReference<HashMap<String, String>>() {}
+                        )
+                ).orElse(new HashMap<>());
+
+        assertEquals("5", users2.get("businessLine"));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1226.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1226.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson2.issues_1000;
+
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.writer.ObjectWriterAdapter;
+import com.alibaba.fastjson2.writer.ObjectWriterProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1226 {
+    @Test
+    public void test() {
+        ObjectWriterProvider provider = JSONFactory.getDefaultObjectWriterProvider();
+        ObjectWriterAdapter writerAdapter = (ObjectWriterAdapter) provider.getObjectWriter(Bean.class);
+
+        JSONWriter jsonWriter = JSONWriter.of();
+        writerAdapter.writeWithFilter(jsonWriter, null);
+        assertEquals("null", jsonWriter.toString());
+    }
+
+    static class Bean {
+        public int id;
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/read/type/CollectionTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/read/type/CollectionTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson2.read.type;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CollectionTest {
+    @Test
+    public void arrayList() {
+        String str = "[123]";
+        ArrayList<String> arrayList = JSON.parseObject(str, new ArrayList<String>() {}.getClass());
+        assertEquals("123", arrayList.get(0));
+    }
+
+    @Test
+    public void linkedList() {
+        String str = "[123]";
+        LinkedList<String> arrayList = JSON.parseObject(str, new LinkedList<String>() {}.getClass());
+        assertEquals("123", arrayList.get(0));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/read/type/MapTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/read/type/MapTest.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson2.read.type;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MapTest {
+    @Test
+    public void hashMap() {
+        String str = "{\"value\":123}";
+        HashMap<String, String> hashMap = JSON.parseObject(str, new HashMap<String, String>() {}.getClass());
+        assertEquals("123", hashMap.get("value"));
+    }
+
+    @Test
+    public void treeMap() {
+        String str = "{\"value\":123}";
+        TreeMap<String, String> hashMap = JSON.parseObject(str, new TreeMap<String, String>() {}.getClass());
+        assertEquals("123", hashMap.get("value"));
+    }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2:2.0.25'
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -65,7 +65,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba:fastjson:2.0.24'
+    implementation 'com.alibaba:fastjson:2.0.25'
 }
 ```
 
@@ -79,7 +79,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.24")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.25")
 }
 ```
 
@@ -101,7 +101,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -109,7 +109,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.25'
 }
 ```
 

--- a/docs/kotlin_cn.md
+++ b/docs/kotlin_cn.md
@@ -11,7 +11,7 @@
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -19,7 +19,7 @@
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.24")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.25")
 }
 ```
 

--- a/docs/kotlin_en.md
+++ b/docs/kotlin_en.md
@@ -11,7 +11,7 @@ If your project uses `kotlin`, you can use the` Fastjson-Kotlin` module, and use
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -19,7 +19,7 @@ If your project uses `kotlin`, you can use the` Fastjson-Kotlin` module, and use
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.24")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.25")
 }
 ```
 

--- a/docs/spring_support_cn.md
+++ b/docs/spring_support_cn.md
@@ -10,7 +10,7 @@ Fastjson2采用多module的结构设计，对SpringFramework等框架的支持�
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring5</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 
 or
@@ -18,7 +18,7 @@ or
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring6</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -26,13 +26,13 @@ or
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.25'
 }
 
 or
 
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.25'
 }
 ```
 > 2.0.23版本之后为了兼容Spring 5.x / 6.x，将不同版本独立开不同的依赖包。

--- a/docs/spring_support_en.md
+++ b/docs/spring_support_en.md
@@ -11,7 +11,7 @@ independent in the `extension` dependency.
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring5</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 
 or
@@ -19,7 +19,7 @@ or
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring6</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 
@@ -27,13 +27,13 @@ or
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.25'
 }
 
 or
 
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.24'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.25'
 }
 ```
 > After version 2.0.23, in order to be compatible with Spring 5.x / 6.x, different versions are independently opened with different dependency packages.

--- a/docs/vector_optimized.md
+++ b/docs/vector_optimized.md
@@ -1,13 +1,13 @@
 JDK 17中提供了[vector api](https://openjdk.org/jeps/426)，可以用SIMD来优化性能。
 
-fastjson 2.0.24中已经支持vector api，这个优化目前处于incubator状态，需要通过如下方法打开：
+fastjson 2.0.25中已经支持vector api，这个优化目前处于incubator状态，需要通过如下方法打开：
 
 加上依赖
 ```xml
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-incubator-vector</artifactId>
-    <version>2.0.24</version>
+    <version>2.0.25</version>
 </dependency>
 ```
 

--- a/example-graalvm-native/pom.xml
+++ b/example-graalvm-native/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
-        <fastjson2.version>2.0.25-SNAPSHOT</fastjson2.version>
+        <fastjson2.version>2.0.25</fastjson2.version>
         <imageName>fastjson2-example-graalvm-native</imageName>
     </properties>
 

--- a/example-graalvm-native/pom.xml
+++ b/example-graalvm-native/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
         <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
-        <fastjson2.version>2.0.25</fastjson2.version>
+        <fastjson2.version>2.0.26-SNAPSHOT</fastjson2.version>
         <imageName>fastjson2-example-graalvm-native</imageName>
     </properties>
 

--- a/example-spring-test/pom.xml
+++ b/example-spring-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/example-spring-test/pom.xml
+++ b/example-spring-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/example-spring-test/pom.xml
+++ b/example-spring-test/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>cn.hutool</groupId>
             <artifactId>hutool-all</artifactId>
-            <version>5.8.14</version>
+            <version>5.8.15</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/example-spring6-test/pom.xml
+++ b/example-spring6-test/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>cn.hutool</groupId>
             <artifactId>hutool-all</artifactId>
-            <version>5.8.14</version>
+            <version>5.8.15</version>
         </dependency>
 
         <dependency>

--- a/example-spring6-test/pom.xml
+++ b/example-spring6-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -15,7 +15,7 @@
     <description>example-spring6-test</description>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <fastjson2.version>2.0.25</fastjson2.version>
+        <fastjson2.version>2.0.26-SNAPSHOT</fastjson2.version>
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>

--- a/example-spring6-test/pom.xml
+++ b/example-spring6-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -15,7 +15,7 @@
     <description>example-spring6-test</description>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <fastjson2.version>2.0.25-SNAPSHOT</fastjson2.version>
+        <fastjson2.version>2.0.25</fastjson2.version>
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>

--- a/example-spring6-test/pom.xml
+++ b/example-spring6-test/pom.xml
@@ -98,7 +98,19 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-json</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
             <version>${spring.boot.version}</version>
             <scope>test</scope>
         </dependency>
@@ -118,6 +130,13 @@
                         </exclude>
                     </excludes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/example-spring6-test/src/main/java/com/alibaba/fastjson2/example/spring6test/controller/TestController.java
+++ b/example-spring6-test/src/main/java/com/alibaba/fastjson2/example/spring6test/controller/TestController.java
@@ -2,12 +2,16 @@ package com.alibaba.fastjson2.example.spring6test.controller;
 
 import cn.hutool.core.io.resource.ClassPathResource;
 import com.alibaba.fastjson2.example.spring6test.entity.User;
+import com.alibaba.fastjson2.example.spring6test.entity.WebFluxMockBean;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * @author jiangqiang
@@ -30,5 +34,35 @@ public class TestController {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @GetMapping("/webFluxGet")
+    public WebFluxMockBean webFluxGet() {
+        return WebFluxMockBean.builder()
+                .name("name")
+                .upperName("NAME")
+                .innerBean(WebFluxMockBean.InnerBean.builder()
+                        .id("id1")
+                        .upperId("ID1")
+                        .build())
+                .upperInnerBean(WebFluxMockBean.InnerBean.builder()
+                        .id("id2")
+                        .upperId("ID2")
+                        .build())
+                .build();
+    }
+
+    @PostMapping("/webFluxPost")
+    public WebFluxMockBean webFluxPost(@RequestBody WebFluxMockBean request) {
+        if (Objects.isNull(request)) {
+            return null;
+        }
+        request.setName("res=" + request.getName());
+        request.setUpperName("RES=" + request.getUpperName());
+        request.getInnerBean().setId("res=" + request.getInnerBean().getId());
+        request.getInnerBean().setUpperId("RES=" + request.getInnerBean().getUpperId());
+        request.getUpperInnerBean().setId("res=" + request.getUpperInnerBean().getId());
+        request.getUpperInnerBean().setUpperId("RES=" + request.getUpperInnerBean().getUpperId());
+        return request;
     }
 }

--- a/example-spring6-test/src/main/java/com/alibaba/fastjson2/example/spring6test/entity/WebFluxMockBean.java
+++ b/example-spring6-test/src/main/java/com/alibaba/fastjson2/example/spring6test/entity/WebFluxMockBean.java
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson2.example.spring6test.entity;
+
+import com.alibaba.fastjson2.annotation.JSONField;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * @author Xi.Liu
+ */
+@Data
+@Builder
+public class WebFluxMockBean {
+    private String name;
+    @JSONField(name = "UpperName")
+    private String upperName;
+
+    private InnerBean innerBean;
+    @JSONField(name = "UpperInnerBean")
+    private InnerBean upperInnerBean;
+
+    @Data
+    @Builder
+    public static class InnerBean {
+        private String id;
+        @JSONField(name = "UpperId")
+        private String upperId;
+    }
+}

--- a/example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/WebFluxTest.java
+++ b/example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/WebFluxTest.java
@@ -1,0 +1,53 @@
+package com.alibaba.fastjson2.example.spring6test;
+
+import cn.hutool.core.lang.Assert;
+import com.alibaba.fastjson2.example.spring6test.api.TestApi;
+import com.alibaba.fastjson2.example.spring6test.controller.Fastjson2Codec;
+import com.alibaba.fastjson2.example.spring6test.entity.WebFluxMockBean;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.support.WebClientAdapter;
+import org.springframework.web.service.invoker.HttpServiceProxyFactory;
+
+public class WebFluxTest {
+    private Fastjson2Codec fastjson2Codec;
+    private HttpServiceProxyFactory factory;
+
+    @Before
+    public void init() {
+        fastjson2Codec = new Fastjson2Codec();
+
+        // init WebClient
+        var webClient = WebClient.builder()
+                .codecs(configurer -> {
+                    configurer.defaultCodecs().enableLoggingRequestDetails(true);
+                    configurer.defaultCodecs().maxInMemorySize(5 * 1024 * 1024);
+                    configurer.defaultCodecs().jackson2JsonDecoder(this.fastjson2Codec.getDecoder());
+                    configurer.defaultCodecs().jackson2JsonEncoder(this.fastjson2Codec.getEncoder());
+                })
+                .build();
+        //根据web客户端去构建服http服务的代理工厂
+        this.factory = HttpServiceProxyFactory
+                .builder(WebClientAdapter.forClient(webClient))
+                .build();
+    }
+
+    @Test
+    public void testSearchWisdom() {
+        TestApi api = factory.createClient(TestApi.class);
+        try {
+            WebFluxMockBean bean1 = api.webFluxGet();
+            Assert.notNull(bean1);
+            Assert.isTrue("NAME".equals(bean1.getUpperName()));
+            System.out.println(bean1);
+
+            WebFluxMockBean bean2 = api.webFluxPost(bean1);
+            Assert.notNull(bean2);
+            Assert.isTrue("RES=ID2".equals(bean2.getUpperInnerBean().getUpperId()));
+            System.out.println(bean2);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/api/TestApi.java
+++ b/example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/api/TestApi.java
@@ -1,0 +1,15 @@
+package com.alibaba.fastjson2.example.spring6test.api;
+
+import com.alibaba.fastjson2.example.spring6test.entity.WebFluxMockBean;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.service.annotation.GetExchange;
+import org.springframework.web.service.annotation.HttpExchange;
+import org.springframework.web.service.annotation.PostExchange;
+
+@HttpExchange("http://127.0.0.1:8080")
+public interface TestApi {
+    @GetExchange("/webFluxGet")
+    WebFluxMockBean webFluxGet();
+    @PostExchange("/webFluxPost")
+    WebFluxMockBean webFluxPost(@RequestBody WebFluxMockBean request);
+}

--- a/example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/controller/Fastjson2Codec.java
+++ b/example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/controller/Fastjson2Codec.java
@@ -1,0 +1,22 @@
+package com.alibaba.fastjson2.example.spring6test.controller;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring6.http.codec.Fastjson2Decoder;
+import com.alibaba.fastjson2.support.spring6.http.codec.Fastjson2Encoder;
+import lombok.Getter;
+import org.springframework.core.codec.Decoder;
+import org.springframework.core.codec.Encoder;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Getter
+public class Fastjson2Codec {
+    private final Decoder<Object> decoder;
+    private final Encoder<Object> encoder;
+
+    public Fastjson2Codec() {
+        var config = new FastJsonConfig();
+        var objectMapper = Jackson2ObjectMapperBuilder.json().build();
+        this.decoder = new Fastjson2Decoder(objectMapper, config);
+        this.encoder = new Fastjson2Encoder(objectMapper, config);
+    }
+}

--- a/extension-spring5/pom.xml
+++ b/extension-spring5/pom.xml
@@ -159,6 +159,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/extension-spring5/pom.xml
+++ b/extension-spring5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-spring5/pom.xml
+++ b/extension-spring5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-spring5/pom.xml
+++ b/extension-spring5/pom.xml
@@ -92,7 +92,7 @@
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-bom</artifactId>
                 <type>pom</type>
-                <version>2021.2.8</version>
+                <version>2021.2.9</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Decoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Decoder.java
@@ -1,0 +1,96 @@
+package com.alibaba.fastjson2.support.spring.http.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.reactivestreams.Publisher;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.log.LogFormatUtils;
+import org.springframework.http.codec.json.AbstractJackson2Decoder;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+import reactor.core.publisher.Flux;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * Fastjson for Spring MVC Converter.
+ *
+ * @author Xi.Liu
+ * @see AbstractJackson2Decoder
+ */
+public class Fastjson2Decoder
+        extends AbstractJackson2Decoder {
+    private final FastJsonConfig config;
+
+    public Fastjson2Decoder(ObjectMapper mapper, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = new FastJsonConfig();
+    }
+
+    public Fastjson2Decoder(ObjectMapper mapper, FastJsonConfig config, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = config;
+    }
+
+    @NonNull
+    @Override
+    public Flux<Object> decode(@NonNull Publisher<DataBuffer> input,
+                               @NonNull ResolvableType elementType,
+                               MimeType mimeType,
+                               Map<String, Object> hints) {
+        throw new UnsupportedOperationException("Does not support stream decoding yet");
+    }
+
+    @Override
+    public Object decode(@NonNull DataBuffer dataBuffer,
+                         @NonNull ResolvableType targetType,
+                         MimeType mimeType,
+                         Map<String, Object> hints) throws DecodingException {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream();
+                InputStream in = dataBuffer.asInputStream()) {
+            byte[] buf = new byte[1 << 16];
+            for (; ; ) {
+                int len = in.read(buf);
+                if (len == -1) {
+                    break;
+                }
+                if (len > 0) {
+                    os.write(buf, 0, len);
+                }
+            }
+            Object value = JSON.parseObject(os.toByteArray(),
+                    targetType.getType(),
+                    this.config.getDateFormat(),
+                    this.config.getReaderFilters(),
+                    this.config.getReaderFeatures());
+            logValue(value, hints);
+            return value;
+        } catch (JSONException ex) {
+            throw new DecodingException("JSON parse error: " + ex.getMessage(), ex);
+        } catch (IOException ex) {
+            throw new DecodingException("I/O error while reading input message", ex);
+        } finally {
+            DataBufferUtils.release(dataBuffer);
+        }
+    }
+
+    private void logValue(@Nullable Object value,
+                          @Nullable Map<String, Object> hints) {
+        if (!Hints.isLoggingSuppressed(hints)) {
+            LogFormatUtils.traceDebug(logger, traceOn -> {
+                String formatted = LogFormatUtils.formatValue(value, !traceOn);
+                return Hints.getLogPrefix(hints) + "Decoded [" + formatted + "]";
+            });
+        }
+    }
+}

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Encoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Encoder.java
@@ -1,0 +1,151 @@
+package com.alibaba.fastjson2.support.spring.http.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.*;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.log.LogFormatUtils;
+import org.springframework.http.codec.json.AbstractJackson2Decoder;
+import org.springframework.http.codec.json.AbstractJackson2Encoder;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Fastjson for Spring MVC Converter.
+ *
+ * @author Xi.Liu
+ * @see AbstractJackson2Decoder
+ */
+public class Fastjson2Encoder
+        extends AbstractJackson2Encoder {
+    private final FastJsonConfig config;
+
+    public Fastjson2Encoder(ObjectMapper mapper, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = new FastJsonConfig();
+    }
+
+    public Fastjson2Encoder(ObjectMapper mapper, FastJsonConfig config, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = config;
+    }
+
+    @NonNull
+    @Override
+    public DataBuffer encodeValue(@Nullable Object value,
+                                  @NonNull DataBufferFactory bufferFactory,
+                                  @NonNull ResolvableType valueType,
+                                  MimeType mimeType,
+                                  Map<String, Object> hints) {
+        try {
+            logValue(hints, value);
+            if (value instanceof String && JSON.isValidObject((String) value)) {
+                byte[] strBytes = ((String) value).getBytes(this.config.getCharset());
+                DataBuffer buffer = bufferFactory.allocateBuffer(strBytes.length);
+                buffer.write(strBytes, 0, strBytes.length);
+                Hints.touchDataBuffer(buffer, hints, logger);
+                return buffer;
+            }
+            try (JSONWriter writer = JSONWriter.ofUTF8(this.config.getWriterFeatures())) {
+                if (value == null) {
+                    writer.writeNull();
+                } else {
+                    writer.setRootObject(value);
+                    configFilter(writer.context, this.config.getWriterFilters());
+                    Class<?> valueClass = value.getClass();
+                    ObjectWriter<?> objectWriter = writer.getObjectWriter(valueClass, valueClass);
+                    objectWriter.write(writer, value, null, null, 0);
+                }
+                DataBuffer buffer = bufferFactory.allocateBuffer(writer.size());
+                writer.flushTo(buffer.asOutputStream());
+                Hints.touchDataBuffer(buffer, hints, logger);
+                return buffer;
+            } catch (IOException e) {
+                throw new JSONException("JSON#writeTo cannot serialize '" + value + "' to 'OutputStream'", e);
+            }
+        } catch (JSONException ex) {
+            throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
+        }
+    }
+
+    private void configFilter(JSONWriter.Context context, Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            return;
+        }
+        for (Filter filter : filters) {
+            if (filter instanceof NameFilter) {
+                NameFilter f = (NameFilter) filter;
+                if (context.getNameFilter() == null) {
+                    context.setNameFilter(f);
+                } else {
+                    context.setNameFilter(NameFilter.compose(context.getNameFilter(), f));
+                }
+            }
+
+            if (filter instanceof ValueFilter) {
+                ValueFilter f = (ValueFilter) filter;
+                if (context.getValueFilter() == null) {
+                    context.setValueFilter(f);
+                } else {
+                    context.setValueFilter(ValueFilter.compose(context.getValueFilter(), f));
+                }
+            }
+
+            if (filter instanceof PropertyFilter) {
+                PropertyFilter f = (PropertyFilter) filter;
+                context.setPropertyFilter(f);
+            }
+
+            if (filter instanceof PropertyPreFilter) {
+                PropertyPreFilter f = (PropertyPreFilter) filter;
+                context.setPropertyPreFilter(f);
+            }
+
+            if (filter instanceof BeforeFilter) {
+                BeforeFilter f = (BeforeFilter) filter;
+                context.setBeforeFilter(f);
+            }
+
+            if (filter instanceof AfterFilter) {
+                AfterFilter f = (AfterFilter) filter;
+                context.setAfterFilter(f);
+            }
+
+            if (filter instanceof LabelFilter) {
+                LabelFilter f = (LabelFilter) filter;
+                context.setLabelFilter(f);
+            }
+
+            if (filter instanceof ContextValueFilter) {
+                ContextValueFilter f = (ContextValueFilter) filter;
+                context.setContextValueFilter(f);
+            }
+
+            if (filter instanceof ContextNameFilter) {
+                ContextNameFilter f = (ContextNameFilter) filter;
+                context.setContextNameFilter(f);
+            }
+        }
+    }
+
+    private void logValue(@Nullable Map<String, Object> hints, Object value) {
+        if (!Hints.isLoggingSuppressed(hints)) {
+            LogFormatUtils.traceDebug(logger, traceOn -> {
+                String formatted = LogFormatUtils.formatValue(value, !traceOn);
+                return Hints.getLogPrefix(hints) + "Encoding [" + formatted + "]";
+            });
+        }
+    }
+}

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -167,6 +167,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -99,7 +99,7 @@
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-bom</artifactId>
                 <type>pom</type>
-                <version>2022.0.2</version>
+                <version>2022.0.3</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -215,6 +215,12 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${springframework6.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Decoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Decoder.java
@@ -1,0 +1,95 @@
+package com.alibaba.fastjson2.support.spring6.http.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.reactivestreams.Publisher;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.log.LogFormatUtils;
+import org.springframework.http.codec.json.AbstractJackson2Decoder;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+import reactor.core.publisher.Flux;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * Fastjson for Spring MVC Converter.
+ *
+ * @author Xi.Liu
+ * @see AbstractJackson2Decoder
+ */
+public class Fastjson2Decoder
+        extends AbstractJackson2Decoder {
+    private final FastJsonConfig config;
+
+    public Fastjson2Decoder(ObjectMapper mapper, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = new FastJsonConfig();
+    }
+
+    public Fastjson2Decoder(ObjectMapper mapper, FastJsonConfig config, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = config;
+    }
+
+    @NonNull
+    @Override
+    public Flux<Object> decode(@NonNull Publisher<DataBuffer> input,
+                               @NonNull ResolvableType elementType,
+                               MimeType mimeType,
+                               Map<String, Object> hints) {
+        throw new UnsupportedOperationException("Does not support stream decoding yet");
+    }
+
+    @Override
+    public Object decode(@NonNull DataBuffer dataBuffer,
+                         @NonNull ResolvableType targetType,
+                         MimeType mimeType,
+                         Map<String, Object> hints) throws DecodingException {
+        try (ByteArrayOutputStream os = new ByteArrayOutputStream();
+                InputStream in = dataBuffer.asInputStream()) {
+            byte[] buf = new byte[1 << 16];
+            for (; ; ) {
+                int len = in.read(buf);
+                if (len == -1) {
+                    break;
+                }
+                if (len > 0) {
+                    os.write(buf, 0, len);
+                }
+            }
+            Object value = JSON.parseObject(os.toByteArray(),
+                    targetType.getType(),
+                    this.config.getDateFormat(),
+                    this.config.getReaderFilters(),
+                    this.config.getReaderFeatures());
+            logValue(value, hints);
+            return value;
+        } catch (JSONException ex) {
+            throw new DecodingException("JSON parse error: " + ex.getMessage(), ex);
+        } catch (IOException ex) {
+            throw new DecodingException("I/O error while reading input message", ex);
+        } finally {
+            DataBufferUtils.release(dataBuffer);
+        }
+    }
+
+    private void logValue(@Nullable Object value, @Nullable Map<String, Object> hints) {
+        if (!Hints.isLoggingSuppressed(hints)) {
+            LogFormatUtils.traceDebug(logger, traceOn -> {
+                String formatted = LogFormatUtils.formatValue(value, !traceOn);
+                return Hints.getLogPrefix(hints) + "Decoded [" + formatted + "]";
+            });
+        }
+    }
+}

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Encoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Encoder.java
@@ -1,0 +1,142 @@
+package com.alibaba.fastjson2.support.spring6.http.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.*;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.log.LogFormatUtils;
+import org.springframework.http.codec.json.AbstractJackson2Decoder;
+import org.springframework.http.codec.json.AbstractJackson2Encoder;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Fastjson for Spring MVC Converter.
+ *
+ * @author Xi.Liu
+ * @see AbstractJackson2Decoder
+ */
+public class Fastjson2Encoder
+        extends AbstractJackson2Encoder {
+    private final FastJsonConfig config;
+
+    public Fastjson2Encoder(ObjectMapper mapper, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = new FastJsonConfig();
+    }
+
+    public Fastjson2Encoder(ObjectMapper mapper, FastJsonConfig config, MimeType... mimeTypes) {
+        super(mapper, mimeTypes);
+        this.config = config;
+    }
+
+    @NonNull
+    @Override
+    public DataBuffer encodeValue(@Nullable Object value,
+                                  @NonNull DataBufferFactory bufferFactory,
+                                  @NonNull ResolvableType valueType,
+                                  MimeType mimeType,
+                                  Map<String, Object> hints) {
+        try {
+            logValue(hints, value);
+            if (value instanceof String v && JSON.isValidObject(v)) {
+                byte[] strBytes = v.getBytes(this.config.getCharset());
+                DataBuffer buffer = bufferFactory.allocateBuffer(strBytes.length);
+                buffer.write(strBytes, 0, strBytes.length);
+                Hints.touchDataBuffer(buffer, hints, logger);
+                return buffer;
+            }
+            try (JSONWriter writer = JSONWriter.ofUTF8(this.config.getWriterFeatures())) {
+                if (value == null) {
+                    writer.writeNull();
+                } else {
+                    writer.setRootObject(value);
+                    configFilter(writer.context, this.config.getWriterFilters());
+                    Class<?> valueClass = value.getClass();
+                    ObjectWriter<?> objectWriter = writer.getObjectWriter(valueClass, valueClass);
+                    objectWriter.write(writer, value, null, null, 0);
+                }
+                DataBuffer buffer = bufferFactory.allocateBuffer(writer.size());
+                writer.flushTo(buffer.asOutputStream());
+                Hints.touchDataBuffer(buffer, hints, logger);
+                return buffer;
+            } catch (IOException e) {
+                throw new JSONException("JSON#writeTo cannot serialize '" + value + "' to 'OutputStream'", e);
+            }
+        } catch (JSONException ex) {
+            throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
+        }
+    }
+
+    private void configFilter(JSONWriter.Context context, Filter... filters) {
+        if (filters == null || filters.length == 0) {
+            return;
+        }
+        for (Filter filter : filters) {
+            if (filter instanceof NameFilter f) {
+                if (context.getNameFilter() == null) {
+                    context.setNameFilter(f);
+                } else {
+                    context.setNameFilter(NameFilter.compose(context.getNameFilter(), f));
+                }
+            }
+
+            if (filter instanceof ValueFilter f) {
+                if (context.getValueFilter() == null) {
+                    context.setValueFilter(f);
+                } else {
+                    context.setValueFilter(ValueFilter.compose(context.getValueFilter(), f));
+                }
+            }
+
+            if (filter instanceof PropertyFilter f) {
+                context.setPropertyFilter(f);
+            }
+
+            if (filter instanceof PropertyPreFilter f) {
+                context.setPropertyPreFilter(f);
+            }
+
+            if (filter instanceof BeforeFilter f) {
+                context.setBeforeFilter(f);
+            }
+
+            if (filter instanceof AfterFilter f) {
+                context.setAfterFilter(f);
+            }
+
+            if (filter instanceof LabelFilter f) {
+                context.setLabelFilter(f);
+            }
+
+            if (filter instanceof ContextValueFilter f) {
+                context.setContextValueFilter(f);
+            }
+
+            if (filter instanceof ContextNameFilter f) {
+                context.setContextNameFilter(f);
+            }
+        }
+    }
+
+    private void logValue(@Nullable Map<String, Object> hints, Object value) {
+        if (!Hints.isLoggingSuppressed(hints)) {
+            LogFormatUtils.traceDebug(logger, traceOn -> {
+                String formatted = LogFormatUtils.formatValue(value, !traceOn);
+                return Hints.getLogPrefix(hints) + "Encoding [" + formatted + "]";
+            });
+        }
+    }
+}

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/Dubbo11775.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/Dubbo11775.java
@@ -1,0 +1,76 @@
+package com.alibaba.fastjson2.support.spring6;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.AdvisedSupport;
+import org.springframework.aop.framework.DefaultAopProxyFactory;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class Dubbo11775 {
+    @Test
+    public void test() {
+        ParamsDTO paramsDTO = new ParamsDTO();
+        ParamsItemDTO paramsItemDTO = new ParamsItemDTO();
+        paramsItemDTO.setA("aaa");
+        paramsDTO.setParamsItems(Arrays.asList(paramsItemDTO));
+
+        AdvisedSupport config = new AdvisedSupport();
+        config.setTarget(paramsDTO);
+        DefaultAopProxyFactory factory = new DefaultAopProxyFactory();
+        Object proxy = factory.createAopProxy(config).getProxy();
+        Object proxy1 = factory.createAopProxy(config).getProxy();
+
+        ObjectWriter objectWriter = JSONFactory.getDefaultObjectWriterProvider().getObjectWriter(proxy.getClass());
+        ObjectWriter objectWriter1 = JSONFactory.getDefaultObjectWriterProvider().getObjectWriter(proxy1.getClass());
+        assertSame(objectWriter, objectWriter1);
+
+        byte[] jsonbBytes = JSONB.toBytes(proxy, writerFeatures);
+        System.out.println(JSONB.toJSONString(jsonbBytes));
+        ParamsDTO paramsDTO1 = (ParamsDTO) JSONB.parseObject(jsonbBytes, Object.class, readerFeatures);
+        assertEquals(paramsDTO.paramsItems.getClass(), paramsDTO1.paramsItems.getClass());
+        assertEquals(paramsDTO.paramsItems.size(), paramsDTO1.paramsItems.size());
+        assertEquals(paramsDTO.paramsItems.get(0).a, paramsDTO1.paramsItems.get(0).a);
+    }
+
+    @Data
+    public static class ParamsItemDTO
+            implements Serializable {
+        private String a;
+    }
+
+    @Data
+    public static class ParamsDTO
+            implements Serializable {
+        private List<ParamsItemDTO> paramsItems;
+    }
+
+    JSONWriter.Feature[] writerFeatures = {
+            JSONWriter.Feature.WriteClassName,
+            JSONWriter.Feature.FieldBased,
+            JSONWriter.Feature.ErrorOnNoneSerializable,
+            JSONWriter.Feature.ReferenceDetection,
+            JSONWriter.Feature.WriteNulls,
+            JSONWriter.Feature.NotWriteDefaultValue,
+            JSONWriter.Feature.NotWriteHashMapArrayListClassName,
+            JSONWriter.Feature.WriteNameAsSymbol
+    };
+
+    JSONReader.Feature[] readerFeatures = {
+            JSONReader.Feature.SupportAutoType,
+            JSONReader.Feature.UseDefaultConstructorAsPossible,
+            JSONReader.Feature.ErrorOnNoneSerializable,
+            JSONReader.Feature.UseNativeObject,
+            JSONReader.Feature.FieldBased
+    };
+}

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fastjson1-compatible/pom.xml
+++ b/fastjson1-compatible/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fastjson1-compatible/pom.xml
+++ b/fastjson1-compatible/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fastjson1-compatible/pom.xml
+++ b/fastjson1-compatible/pom.xml
@@ -94,7 +94,7 @@
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-bom</artifactId>
                 <type>pom</type>
-                <version>2021.2.8</version>
+                <version>2021.2.9</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/annotation/JSONType.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/annotation/JSONType.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson.annotation;
 
 import com.alibaba.fastjson.PropertyNamingStrategy;
 import com.alibaba.fastjson.parser.Feature;
+import com.alibaba.fastjson.parser.ParserConfig;
 import com.alibaba.fastjson.serializer.SerializeFilter;
 import com.alibaba.fastjson.serializer.SerializerFeature;
 
@@ -70,4 +71,6 @@ public @interface JSONType {
      * @since 1.2.49
      */
     Class<? extends SerializeFilter>[] serialzeFilters() default {};
+
+    Class<? extends ParserConfig.AutoTypeCheckHandler> autoTypeCheckHandler() default ParserConfig.AutoTypeCheckHandler.class;
 }

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -3,16 +3,22 @@ package com.alibaba.fastjson.parser;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.util.DateUtils;
 
+import java.io.Closeable;
 import java.math.BigDecimal;
+import java.util.Calendar;
 
 public class JSONScanner
-        extends JSONLexerBase {
+        extends JSONLexerBase
+        implements Closeable {
     private final JSONReader reader;
     private boolean orderedField;
 
     protected int token;
     private String strVal;
+    protected Calendar calendar;
+    protected String str;
 
     public JSONScanner(JSONReader reader) {
         this.reader = reader;
@@ -20,10 +26,35 @@ public class JSONScanner
 
     public JSONScanner(String str) {
         this.reader = JSONReader.of(str);
+        this.str = str;
     }
 
     public JSONScanner(String str, int features) {
         this.reader = JSONReader.of(str, JSON.createReadContext(features));
+    }
+
+    public Calendar getCalendar() {
+        return calendar;
+    }
+
+    public boolean scanISO8601DateIfMatch() {
+        return scanISO8601DateIfMatch(true);
+    }
+
+    public boolean scanISO8601DateIfMatch(boolean strict) {
+        if (str != null) {
+            try {
+                long millis = DateUtils.parseMillis(str);
+                Calendar calendar = Calendar.getInstance();
+                calendar.setTimeInMillis(millis);
+                this.calendar = calendar;
+                return true;
+            } catch (Exception ignored) {
+                return false;
+            }
+        }
+
+        throw new JSONException("UnsupportedOperation");
     }
 
     @Override
@@ -246,5 +277,9 @@ public class JSONScanner
     @Override
     public boolean isEOF() {
         return reader.isEnd();
+    }
+
+    @Override
+    public void close() {
     }
 }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/JSONTypeAutoTypeCheckHandlerTest.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/JSONTypeAutoTypeCheckHandlerTest.java
@@ -1,0 +1,43 @@
+package com.alibaba.fastjson;
+
+import com.alibaba.fastjson.annotation.JSONType;
+import com.alibaba.fastjson.parser.ParserConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONTypeAutoTypeCheckHandlerTest {
+    @Test
+    public void test_for_checkAutoType() {
+        Cat cat = (Cat) JSON.parseObject("{\"@type\":\"Cat\",\"catId\":123}", Animal.class);
+        assertEquals(123, cat.catId);
+    }
+
+    @JSONType(autoTypeCheckHandler = MyAutoTypeCheckHandler.class)
+    public static class Animal {
+    }
+
+    public static class Cat
+            extends Animal {
+        public int catId;
+    }
+
+    public static class Mouse
+            extends Animal {
+    }
+
+    public static class MyAutoTypeCheckHandler
+            implements ParserConfig.AutoTypeCheckHandler {
+        public Class<?> handler(String typeName, Class<?> expectClass, int features) {
+            if ("Cat".equals(typeName)) {
+                return Cat.class;
+            }
+
+            if ("Mouse".equals(typeName)) {
+                return Mouse.class;
+            }
+
+            return null;
+        }
+    }
+}

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_4200/Issue4355.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_4200/Issue4355.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson.issue_4200;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.annotation.JSONCreator;
+import com.alibaba.fastjson.annotation.JSONField;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue4355 {
+    @Test
+    public void test() {
+        MemberInfo member = new MemberInfo("1234", "BIZ");
+        String json = JSON.toJSONString(member);
+        assertEquals("{\"bizUserId\":\"1234\",\"memberType\":\"BIZ\"}", json);
+        MemberInfo memberInfo1 = JSON.parseObject(json, MemberInfo.class);
+        assertEquals(memberInfo1.bizUserId, memberInfo1.bizUserId);
+        assertEquals(memberInfo1.memberType, memberInfo1.memberType);
+    }
+
+    public static class MemberInfo {
+        private String bizUserId;
+        private String memberType;
+
+        @JSONCreator
+        public MemberInfo(String bizUserId, String memberType) {
+            this.bizUserId = bizUserId;
+            this.memberType = memberType;
+        }
+
+        @JSONField
+        public String bizUserId() {
+            return this.bizUserId;
+        }
+
+        @JSONField
+        public String memberType() {
+            return this.memberType;
+        }
+    }
+}

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue1216.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue1216.java
@@ -1,0 +1,35 @@
+package com.alibaba.fastjson.v2issues;
+
+import com.alibaba.fastjson.parser.JSONScanner;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue1216 {
+    @Test
+    public void test() {
+        String value = "2017-07-24 12:13:14";
+        String value2 = "2018-07-24 12:13:14";
+
+        Object[] objects = new Object[2];
+        JSONScanner dateLexer = new JSONScanner(value);
+        assertTrue(dateLexer.scanISO8601DateIfMatch());
+        objects[0] = new Timestamp(dateLexer.getCalendar().getTimeInMillis());
+        if (value2 != null) {
+            dateLexer.close();
+            dateLexer = new JSONScanner(value2);
+            dateLexer.scanISO8601DateIfMatch(false);
+            objects[1] = new Timestamp(dateLexer.getCalendar().getTimeInMillis());
+        }
+        dateLexer.close();
+    }
+
+    @Test
+    public void test1() {
+        JSONScanner dateLexer = new JSONScanner("xxx");
+        assertFalse(dateLexer.scanISO8601DateIfMatch());
+    }
+}

--- a/incubator-vector/pom.xml
+++ b/incubator-vector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/incubator-vector/pom.xml
+++ b/incubator-vector/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -103,7 +103,7 @@
                     <plugin>
                         <groupId>org.jetbrains.dokka</groupId>
                         <artifactId>dokka-maven-plugin</artifactId>
-                        <version>1.7.20</version>
+                        <version>1.8.10</version>
                         <executions>
                             <execution>
                                 <phase>prepare-package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-parent</artifactId>
-    <version>2.0.25-SNAPSHOT</version>
+    <version>2.0.25</version>
     <name>${project.artifactId}</name>
     <description>Fastjson is a JSON processor (JSON parser + JSON generator) written in Java</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <type>pom</type>
-                <version>3.22.0</version>
+                <version>3.22.1</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
             <dependency>
                 <groupId>com.aliyun.odps</groupId>
                 <artifactId>odps-sdk-udf</artifactId>
-                <version>0.43.1-public</version>
+                <version>0.43.2-public</version>
             </dependency>
             <dependency>
                 <groupId>com.caucho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <fastjson1x.version>1.2.83</fastjson1x.version>
         <jackson.version>2.14.2</jackson.version>
-        <jetty.version>11.0.13</jetty.version>
+        <jetty.version>11.0.14</jetty.version>
         <jersey.version>2.39</jersey.version>
         <springframework5.version>5.3.25</springframework5.version>
         <springframework6.version>6.0.6</springframework6.version>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
             <dependency>
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
-                <version>2.4.8</version>
+                <version>2.4.9</version>
             </dependency>
             <dependency>
                 <groupId>net.sf.json-lib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
                 <type>pom</type>
-                <version>3.22.1</version>
+                <version>3.22.2</version>
                 <scope>import</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -751,7 +751,7 @@
                 <plugin>
                     <groupId>org.moditect</groupId>
                     <artifactId>moditect-maven-plugin</artifactId>
-                    <version>1.0.0.RC2</version>
+                    <version>1.0.0.RC3</version>
                     <executions>
                         <execution>
                             <id>add-module-infos</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-parent</artifactId>
-    <version>2.0.25</version>
+    <version>2.0.26-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>Fastjson is a JSON processor (JSON parser + JSON generator) written in Java</description>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
             <dependency>
                 <groupId>com.github.erosb</groupId>
                 <artifactId>everit-json-schema</artifactId>
-                <version>1.14.1</version>
+                <version>1.14.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.gson</groupId>

--- a/safemode-test/pom.xml
+++ b/safemode-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25</version>
+        <version>2.0.26-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/safemode-test/pom.xml
+++ b/safemode-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.25-SNAPSHOT</version>
+        <version>2.0.25</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
### 这个PR提供了通过webclient模式进行rpc调用时，使用fastjson2替换spring5+默认的jackson的实现

### 提供的
1. com.alibaba.fastjson2.support.spring6.http.codec.Fastjson2Encoder
2. com.alibaba.fastjson2.support.spring6.http.codec.Fastjson2Decoder
3. com.alibaba.fastjson2.support.spring5.http.codec.Fastjson2Encoder
4. com.alibaba.fastjson2.support.spring5.http.codec.Fastjson2Decoder

#### 使用方式
```
spring 6 (jdk17)
var webClient = WebClient.builder()
                .codecs(configurer -> {
                    configurer.defaultCodecs().jackson2JsonDecoder(new Fastjson2Decoder());
                    configurer.defaultCodecs().jackson2JsonEncoder(new Fastjson2Encoder());
                });
```
- 测试用例参考 example-spring6-test/src/test/java/com/alibaba/fastjson2/example/spring6test/WebFluxTest
- 暂时未进行压测，部分代码参考了已有的一些实现

