### PR TITLE
Fix compatibility issues: ContextAutoTypeBeforeHandler add java.util.Collections$SingletonList

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -86,6 +86,7 @@ public class ContextAutoTypeBeforeHandler
             Collections.emptyList().getClass(),
             Collections.emptyMap().getClass(),
             CLASS_SINGLE_SET,
+            CLASS_SINGLE_List,
             CLASS_UNMODIFIABLE_COLLECTION,
             CLASS_UNMODIFIABLE_LIST,
             CLASS_UNMODIFIABLE_SET,


### PR DESCRIPTION
### What this PR does / why we need it?
The pojo has field with java.util.Collections$SingletonList type when use dubbo 
and then the dubbo print ERROR log:
```
11:18:31.217 [main] ERROR org.apache.dubbo.common.serialize.fastjson2.Fastjson2SecurityManager -  
[DUBBO] [Serialization Security] Serialized class java.util.Collections$SingletonList is not in allow list. 
Current mode is `WARN`, will allow to deserialize it by default. 
Dubbo will set to `STRICT` mode by default in the future. 
Please add it into security/serialize.allowlist or follow FAQ to configure it.
, dubbo version: 3.2.0-beta.4, current host: 160.6.56.171, error code: 4-21. 
This may be caused by , go to https://dubbo.apache.org/faq/4/21 to find instructions. 

```
Avoid **compatibility issues** when Dubbo sets to `STRICT` mode by default in the future. 

ContextAutoTypeBeforeHandler need to add **java.util.Collections$SingletonList**.


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
