### PR TITLE
fix ObjectReaderImplMapTyped.createInstance

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapTyped.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapTyped.java
@@ -73,7 +73,7 @@ class ObjectReaderImplMapTyped
             Object key = entry.getKey();
             Object fieldValue = entry.getValue();
             Object fieldName;
-            if (keyType == null || key == String.class) {
+            if (keyType == null || keyType == String.class) {
                 fieldName = key.toString();
             } else {
                 fieldName = TypeUtils.cast(key, keyType);


### PR DESCRIPTION
### What this PR does / why we need it?

fix method of ObjectReaderImplMapTyped.createInstance:
modify the condition of `keyType == null || key == String.class` 
to `keyType == null || keyType == String.class`


### Summary of your change



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
