### PR TITLE
[alibaba/fastjson2][bug-#1399] 修正jsonb序列化JSONObject对象为null时，反序列化失败报错的问题

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMap.java
@@ -324,6 +324,11 @@ public final class ObjectReaderImplMap
                     continue;
                 }
 
+                if(jsonReader.isEnd() && null == fieldName){
+                    map = null;
+                    break;
+                }
+
                 Object value;
                 type = jsonReader.getType();
                 if (type >= BC_STR_ASCII_FIX_MIN && type <= BC_STR_UTF16BE) {


### PR DESCRIPTION

### 修正jsonb反序列化为JSONObject时，值为null报错的问题
具体问题为，当序列化对象为JSONObject，且序列化值为null，反序列化时第一次读取内容后，根据jsonReader.getType()再次读取会超出字节数组长度，造成数组下标越界对null处理不兼容。


### Summary of your change
改进为在一阶段读取结束后判定是否已读取完毕，并且判定读取值是否为null，如果条件达成则不执行后续其他处理流程，直接跳出后续处理引用等代码。


#### Please indicate you've done the following:
- [ ] 兼容处理当值为null时反序列化为JSONObject
