### PR TITLE
fix wrong methods of new BigDecimal() and equals()

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathFilter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathFilter.java
@@ -1045,7 +1045,7 @@ abstract class JSONPathFilter
                         if (item instanceof BigDecimal) {
                             BigDecimal decimal = (BigDecimal) item;
                             long longValue = decimal.longValue();
-                            if (value == longValue && decimal.equals(BigDecimal.valueOf(value))) {
+                            if (value == longValue && decimal.compareTo(BigDecimal.valueOf(value)) == 0) {
                                 containsItem = true;
                                 break;
                             }
@@ -1130,7 +1130,7 @@ abstract class JSONPathFilter
                 BigDecimal decimal = (BigDecimal) fieldValue;
                 long longValue = decimal.longValue();
                 for (long value : values) {
-                    if (value == longValue && decimal.equals(BigDecimal.valueOf(value))) {
+                    if (value == longValue && decimal.compareTo(BigDecimal.valueOf(value)) == 0) {
                         return !not;
                     }
                 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/NumberSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/NumberSchema.java
@@ -38,7 +38,7 @@ final class NumberSchema
             this.exclusiveMinimum = false;
         }
 
-        if (this.minimum == null || !this.minimum.equals(BigDecimal.valueOf(this.minimum.longValue()))) {
+        if (this.minimum == null || !(this.minimum.compareTo(BigDecimal.valueOf(this.minimum.longValue())) == 0)) {
             minimumLongValue = Long.MIN_VALUE;
         } else {
             minimumLongValue = this.minimum.longValue();
@@ -57,7 +57,7 @@ final class NumberSchema
             this.exclusiveMaximum = false;
         }
 
-        if (this.maximum == null || !this.maximum.equals(BigDecimal.valueOf(this.maximum.longValue()))) {
+        if (this.maximum == null || !(this.maximum.compareTo(BigDecimal.valueOf(this.maximum.longValue())) == 0)) {
             maximumLongValue = Long.MIN_VALUE;
         } else {
             maximumLongValue = this.maximum.longValue();
@@ -68,7 +68,7 @@ final class NumberSchema
             this.multipleOfLongValue = Long.MIN_VALUE;
         } else {
             long longValue = multipleOf.longValue();
-            if (multipleOf.equals(BigDecimal.valueOf(longValue))) {
+            if (multipleOf.compareTo(BigDecimal.valueOf(longValue)) == 0) {
                 this.multipleOfLongValue = longValue;
             } else {
                 this.multipleOfLongValue = Long.MIN_VALUE;
@@ -283,11 +283,11 @@ final class NumberSchema
         com.alibaba.fastjson2.schema.NumberSchema that = (com.alibaba.fastjson2.schema.NumberSchema) o;
         return Objects.equals(title, that.title)
                 && Objects.equals(description, that.description)
-                && Objects.equals(minimum, that.minimum)
                 && Objects.equals(exclusiveMinimum, that.exclusiveMinimum)
-                && Objects.equals(maximum, that.maximum)
                 && Objects.equals(exclusiveMaximum, that.exclusiveMaximum)
-                && Objects.equals(multipleOf, that.multipleOf);
+                && (minimum == null ? that.minimum == null : minimum.compareTo(that.minimum) == 0)
+                && (maximum == null ? that.maximum == null : maximum.compareTo(that.maximum) == 0)
+                && (multipleOf == null ? that.multipleOf == null : multipleOf.compareTo(that.multipleOf) == 0);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -3139,9 +3139,9 @@ public class TypeUtils {
             } else if (typeB == Long.class) {
                 b = new BigDecimal((Long) b);
             } else if (typeB == Float.class) {
-                b = new BigDecimal((Float) b);
+                b = BigDecimal.valueOf((Float) b);
             } else if (typeB == Double.class) {
-                b = new BigDecimal((Double) b);
+                b = BigDecimal.valueOf((Double) b);
             } else if (typeB == BigInteger.class) {
                 b = new BigDecimal((BigInteger) b);
             }
@@ -3151,10 +3151,10 @@ public class TypeUtils {
             } else if (typeB == Long.class) {
                 b = BigInteger.valueOf((Long) b);
             } else if (typeB == Float.class) {
-                b = new BigDecimal((Float) b);
+                b = BigDecimal.valueOf((Float) b);
                 a = new BigDecimal((BigInteger) a);
             } else if (typeB == Double.class) {
-                b = new BigDecimal((Double) b);
+                b = BigDecimal.valueOf((Double) b);
                 a = new BigDecimal((BigInteger) a);
             } else if (typeB == BigDecimal.class) {
                 a = new BigDecimal((BigInteger) a);


### PR DESCRIPTION
### What this PR does / why we need it?
1. new BigDecimal(double d) produces BigDecimal that is inexactly equal to the supplied double value, use BigDecimal.valueOf(double) instead.
2. compare two java.math.BigDecimal numbers should use b1.compareTo(b2) == 0 rather than equals().

### Summary of your change



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
