### PR TITLE
fix JSONPathParser support multi and of &&, for issue #1516

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -8,6 +8,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -472,7 +473,12 @@ class JSONPathParser {
         }
         List<JSONPathFilter> filters = new ArrayList<>();
         filters.add((JSONPathFilter) segment);
-        filters.add((JSONPathFilter) right);
+        if (right instanceof JSONPathFilter.GroupFilter) {
+            JSONPathFilter.GroupFilter group = (JSONPathFilter.GroupFilter) right;
+            group.filters.stream().filter(Objects::nonNull).forEach(f -> filters.add(f));
+        } else {
+            filters.add((JSONPathFilter) right);
+        }
         return new JSONPathFilter.GroupFilter(filters, and);
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
@@ -1,0 +1,22 @@
+package com.alibaba.fastjson2.issues_1500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONPath;
+import com.alibaba.fastjson2.JSONReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1516 {
+    @Test
+    public void test() {
+        String jsonArray = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":20,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]";
+        String expected = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"}]";
+        String jsonPath = "$[?( @.name=='小花' && @.age==18 && @.city=='扬州' )]";
+        Object result = JSONPath.of(jsonPath).extract(JSONReader.of(jsonArray));
+        String jsonPath2 = "$[?( @.name=='小花' && @.age==18)][?( @.city=='扬州' )]";
+        Object result2 = JSONPath.of(jsonPath2).extract(JSONReader.of(jsonArray));
+        assertEquals(expected, JSON.toJSONString(result));
+        assertEquals(expected, JSON.toJSONString(result2));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

fix JSONPathParser support multi-and of &&, for issue #1516（https://github.com/alibaba/fastjson2/issues/1516）

### Summary of your change
Because of java.lang.ClassCastException, there is a need to determine the true type of variable right. 

#### Please indicate you've done the following:
![image](https://github.com/alibaba/fastjson2/assets/22208736/fd9a7bf0-e1e1-4ca3-a4c9-5c1a9c6eb4ea)
Beside, there is a test class of com.alibaba.fastjson2.issues_1500.Issue1516 added.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
