### PR TITLE
update JSONPathParser with nullable judgement, for issue #1516

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -5,10 +5,7 @@ import com.alibaba.fastjson2.util.TypeUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -475,7 +472,7 @@ class JSONPathParser {
         filters.add((JSONPathFilter) segment);
         if (right instanceof JSONPathFilter.GroupFilter) {
             JSONPathFilter.GroupFilter group = (JSONPathFilter.GroupFilter) right;
-            group.filters.stream().filter(Objects::nonNull).forEach(f -> filters.add(f));
+            Optional.ofNullable(group.filters).ifPresent(fs -> fs.stream().filter(Objects::nonNull).forEach(f -> filters.add(f)));
         } else {
             filters.add((JSONPathFilter) right);
         }


### PR DESCRIPTION
### What this PR does / why we need it?
Sorry for the second pr on the same issue. The more defensive, the more robust. Even if the GourpFilter.Filters  can not be null in current version, but we can not guarantee that stands in future version. So, I add a nullable judgement before iterating over the filters.


### Summary of your change

![image](https://github.com/alibaba/fastjson2/assets/22208736/84204ba0-337e-4a05-90fb-fb3d52cf8380)


#### Please indicate you've done the following:
add a nullable judgement before iterating over the filters.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
