### PR TITLE
update JSONPathParser with a nullable judgement added, for issue #1516

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -5,10 +5,7 @@ import com.alibaba.fastjson2.util.TypeUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
@@ -475,7 +472,7 @@ class JSONPathParser {
         filters.add((JSONPathFilter) segment);
         if (right instanceof JSONPathFilter.GroupFilter) {
             JSONPathFilter.GroupFilter group = (JSONPathFilter.GroupFilter) right;
-            group.filters.stream().filter(Objects::nonNull).forEach(f -> filters.add(f));
+            Optional.ofNullable(group.filters).ifPresent(fs ->fs.stream().filter(Objects::nonNull).forEach(f -> filters.add(f)));
         } else {
             filters.add((JSONPathFilter) right);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
@@ -54,7 +54,7 @@ public class FieldReaderList<T, V>
     }
 
     public Collection<V> createList(JSONReader.Context context) {
-        if (fieldClass == List.class || fieldClass == Collection.class || fieldClass == ArrayList.class) {
+        if (Collection.class.isAssignableFrom(fieldClass)) {
             return new ArrayList<>();
         }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
@@ -2273,7 +2273,7 @@ public class ObjectReaderCreator {
             fieldClassResolved = TypeUtils.getMapping(fieldTypeResolved);
         }
 
-        if (fieldClass == List.class || fieldClass == ArrayList.class) {
+        if (Collection.class.isAssignableFrom(fieldClass)) {
             if (fieldTypeResolved instanceof ParameterizedType) {
                 ParameterizedType parameterizedType = (ParameterizedType) fieldTypeResolved;
                 Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1520.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1520.java
@@ -1,0 +1,32 @@
+package com.alibaba.fastjson2.issues_1500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.TypeReference;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1520 {
+
+    @Test
+    public void test() {
+        String json = "{\"testa\":[{\"name\":\"test\"}, {\"name\":\"test2\"}]}";
+        TestB testB1 = JSON.parseObject(json, new TypeReference<TestB>() {});
+        LinkedList<TestA> testa = testB1.getTesta();
+        assertEquals(new LinkedList<>().getClass().getName(), testa.getClass().getName());
+        assertEquals(TestA.class.getName(), testa.get(0).getClass().getName());
+    }
+
+    @Data
+    public class TestB {
+        private LinkedList<TestA> testa;
+    }
+
+    @Data
+    public class TestA {
+        private String name;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
Sorry for the second pr on the same issue. The more defensive, the more robust. Even if the GourpFilter.Filters can not be null in current version, but we can not guarantee that stands in future version. So, I add a nullable judgement before iterating over the filters.

### Summary of your change

![image](https://github.com/alibaba/fastjson2/assets/22208736/3704f96b-43ca-40ab-a0b9-4a4cd6bf32fc)

#### Please indicate you've done the following:
add a nullable judgement before iterating over the filters.

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
