### PR TITLE
fix support nested filters, regex and in, for issue #1516

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -60,6 +60,7 @@ public abstract class JSONReader
     protected int offset;
     protected char ch;
     protected boolean comma;
+    protected int filterNests;
 
     protected boolean nameEscape;
     protected boolean valueEscape;
@@ -243,7 +244,7 @@ public abstract class JSONReader
     }
 
     public final ObjectReader getObjectReader(Type type) {
-        boolean fieldBased = (context.features & JSONReader.Feature.FieldBased.mask) != 0;
+        boolean fieldBased = (context.features & Feature.FieldBased.mask) != 0;
         return context.provider.getObjectReader(type, fieldBased);
     }
 
@@ -441,6 +442,18 @@ public abstract class JSONReader
 
     public final int getOffset() {
         return offset;
+    }
+
+    public void incrFilterNests() {
+        ++this.filterNests;
+    }
+
+    public void decrFilterNests() {
+        --this.filterNests;
+    }
+
+    public boolean isFilterNested() {
+        return this.filterNests > 0;
     }
 
     public abstract void next();
@@ -1738,7 +1751,7 @@ public abstract class JSONReader
             Object origin = map.put(name, value);
             if (origin != null) {
                 long contextFeatures = features | context.getFeatures();
-                if ((contextFeatures & JSONReader.Feature.DuplicateKeyValueAsArray.mask) != 0) {
+                if ((contextFeatures & Feature.DuplicateKeyValueAsArray.mask) != 0) {
                     if (origin instanceof Collection) {
                         ((Collection) origin).add(value);
                         map.put(name, origin);
@@ -1788,7 +1801,7 @@ public abstract class JSONReader
             Object origin = object.put(name, value);
             if (origin != null) {
                 long contextFeatures = features | context.getFeatures();
-                if ((contextFeatures & JSONReader.Feature.DuplicateKeyValueAsArray.mask) != 0) {
+                if ((contextFeatures & Feature.DuplicateKeyValueAsArray.mask) != 0) {
                     if (origin instanceof Collection) {
                         ((Collection) origin).add(value);
                         object.put(name, origin);
@@ -2725,7 +2738,7 @@ public abstract class JSONReader
     }
 
     @Deprecated
-    public static JSONReader of(JSONReader.Context context, byte[] utf8Bytes) {
+    public static JSONReader of(Context context, byte[] utf8Bytes) {
         boolean ascii = false;
         if (PREDICATE_IS_ASCII != null) {
             ascii = PREDICATE_IS_ASCII.test(utf8Bytes);
@@ -2745,7 +2758,7 @@ public abstract class JSONReader
         }
     }
 
-    public static JSONReader of(byte[] utf8Bytes, JSONReader.Context context) {
+    public static JSONReader of(byte[] utf8Bytes, Context context) {
         boolean ascii = false;
         if (PREDICATE_IS_ASCII != null) {
             ascii = PREDICATE_IS_ASCII.test(utf8Bytes);
@@ -2824,7 +2837,7 @@ public abstract class JSONReader
     }
 
     @Deprecated
-    public static JSONReader ofJSONB(JSONReader.Context context, byte[] jsonbBytes) {
+    public static JSONReader ofJSONB(Context context, byte[] jsonbBytes) {
         return new JSONReaderJSONB(
                 context,
                 jsonbBytes,
@@ -2832,7 +2845,7 @@ public abstract class JSONReader
                 jsonbBytes.length);
     }
 
-    public static JSONReader ofJSONB(byte[] jsonbBytes, JSONReader.Context context) {
+    public static JSONReader ofJSONB(byte[] jsonbBytes, Context context) {
         return new JSONReaderJSONB(
                 context,
                 jsonbBytes,
@@ -2840,7 +2853,7 @@ public abstract class JSONReader
                 jsonbBytes.length);
     }
 
-    public static JSONReader ofJSONB(byte[] jsonbBytes, JSONReader.Feature... features) {
+    public static JSONReader ofJSONB(byte[] jsonbBytes, Feature... features) {
         Context context = JSONFactory.createReadContext();
         context.config(features);
         return new JSONReaderJSONB(

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
@@ -16,7 +16,39 @@ public class Issue1516 {
         Object result = JSONPath.of(jsonPath).extract(JSONReader.of(jsonArray));
         String jsonPath2 = "$[?( @.name=='小花' && @.age==18)][?( @.city=='扬州' )]";
         Object result2 = JSONPath.of(jsonPath2).extract(JSONReader.of(jsonArray));
+        String jsonPath3 = "$[?( @.name=='小花' && @.age==18 || @.city=='扬州' )]";
+        Object result3 = JSONPath.of(jsonPath3).extract(JSONReader.of(jsonArray));
         assertEquals(expected, JSON.toJSONString(result));
         assertEquals(expected, JSON.toJSONString(result2));
+        assertEquals(jsonArray, JSON.toJSONString(result3));
+    }
+
+    @Test
+    public void testFastjson2JSONPathCompile() {
+        String jsonArray = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":20,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]";
+        String path = "$[?( @.name=='aa' && @.age==18 && @.city=='beijing' && @.province=='beijing' )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.name=='aa' || @.age==16 || @.city=='beijing' || @.province=='beijing')]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.name =~ /aa/ )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 && (@.name =~ /aa/)  )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 || (@.name =~ /aa/)  )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.name =~ /aa/ && @.age==18 )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( (@.name =~ /aa/ && (@.city=='aa')) && @.age==18 )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( (@.name =~ /aa/ && (@.city=='aa')) || @.age==18 )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 && (@.name in ('aa', 'aa2') )  )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 || (@.name in ('aa', 'aa2') )  )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?(@.name in ('aa', 'aa2') && @.age==18 )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?(@.name in ('aa', 'aa2') || @.age==18 )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?
support nested filters, regex and in

### Summary of your change
For JSONReader, add a field of filterNests to manage nested filters($.?((@.param1) && @.param2));
For JSONPathFilter, delete GroupFilter's field and, add a field of and to achieve the same aim;
For JSONPathParser, support nested filters, regex and in.


#### Please indicate you've done the following:
support nested filters, regex and in

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
