### PR TITLE
fix support nested filters, regex and in, for issue #1516

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -60,6 +60,7 @@ public abstract class JSONReader
     protected int offset;
     protected char ch;
     protected boolean comma;
+    protected int filterNests;
 
     protected boolean nameEscape;
     protected boolean valueEscape;
@@ -441,6 +442,18 @@ public abstract class JSONReader
 
     public final int getOffset() {
         return offset;
+    }
+
+    public void incrFilterNests() {
+        ++this.filterNests;
+    }
+
+    public void decrFilterNests() {
+        --this.filterNests;
+    }
+
+    public boolean isFilterNested() {
+        return this.filterNests > 0;
     }
 
     public abstract void next();

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
@@ -16,7 +16,39 @@ public class Issue1516 {
         Object result = JSONPath.of(jsonPath).extract(JSONReader.of(jsonArray));
         String jsonPath2 = "$[?( @.name=='小花' && @.age==18)][?( @.city=='扬州' )]";
         Object result2 = JSONPath.of(jsonPath2).extract(JSONReader.of(jsonArray));
+        String jsonPath3 = "$[?( @.name=='小花' && @.age==18 || @.city=='扬州' )]";
+        Object result3 = JSONPath.of(jsonPath3).extract(JSONReader.of(jsonArray));
         assertEquals(expected, JSON.toJSONString(result));
         assertEquals(expected, JSON.toJSONString(result2));
+        assertEquals(jsonArray, JSON.toJSONString(result3));
+    }
+
+    @Test
+    public void testFastjson2JSONPathCompile() {
+        String jsonArray = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":20,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]";
+        String path = "$[?( @.name=='aa' && @.age==18 && @.city=='beijing' && @.province=='beijing' )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.name=='aa' || @.age==16 || @.city=='beijing' || @.province=='beijing')]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.name =~ /aa/ )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 && (@.name =~ /aa/)  )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 || (@.name =~ /aa/)  )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.name =~ /aa/ && @.age==18 )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( (@.name =~ /aa/ && (@.city=='aa')) && @.age==18 )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( (@.name =~ /aa/ && (@.city=='aa')) || @.age==18 )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 && (@.name in ('aa', 'aa2') )  )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?( @.age==18 || (@.name in ('aa', 'aa2') )  )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?(@.name in ('aa', 'aa2') && @.age==18 )]";
+        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[?(@.name in ('aa', 'aa2') || @.age==18 )]";
+        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?
aim to support nested filters, regex and in. 

### Summary of your change
For JSONReader, add a new field of filterNests to manage nested filters, such as  "$[?( (@.name =~ /aa/) && @.age==18 )]";
For JSONPathParser, support to parse nested filter.
For JSONPathFilter, replace GroupFilter's and with a new added field of and. Besides, this change can work normally when path like "$[?( @.name=='小花' && @.age==18 || @.city=='扬州' )]" which older one throws exception.

#### Please indicate you've done the following:
support nested filter parsing
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
