### PR TITLE
fix StringToAny to support nonempty str parsing when targetClass belongs to collection

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/function/impl/StringToAny.java
+++ b/core/src/main/java/com/alibaba/fastjson2/function/impl/StringToAny.java
@@ -1,5 +1,6 @@
 package com.alibaba.fastjson2.function.impl;
 
+import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.util.DateUtils;
@@ -76,6 +77,8 @@ public class StringToAny
         if (targetClass == Collections.class || targetClass == List.class || targetClass == JSONArray.class) {
             if ("[]".equals(str)) {
                 return new JSONArray();
+            } else {
+                return JSON.parseObject(str, targetClass);
             }
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1517.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1517.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.issues_1500;
 
 import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.annotation.JSONField;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -27,8 +28,27 @@ public class Issue1517 {
         assertEquals(123123, bean.id);
     }
 
+    @Test
+    public void testWithStringList() {
+        Map map = new HashMap<>();
+        map.put("id", 123123);
+
+        List artist = new ArrayList();
+        Map art = new HashMap();
+        art.put("key", "2345");
+        art.put("name", "luger");
+        artist.add(art);
+        // artist 对应的是个数组格式的字符串
+        map.put("artist", JSONObject.toJSONString(artist));
+
+        Bean bean = JSONObject.from(map).toJavaObject(Bean.class);
+        // 应该对比list是否转换成功
+        assertEquals("luger", bean.list.get(0).name);
+    }
+
     private static class Bean {
         private long id;
+        @JSONField(alternateNames = "artist")
         private List<Artist> list;
 
         public long getId() {


### PR DESCRIPTION
…ngs to collection, for issue #1517

### What this PR does / why we need it?
StringToAny to support nonempty str parsing when targetClass belongs to collection

### Summary of your change
Add JSON.parseObject to StringToAny

#### Please indicate you've done the following:
To enable nonempty string array can be deserialized into its actual colletion 

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
