### PR TITLE
feat add length and size index to JSONPathParser

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -274,6 +274,32 @@ class JSONPathParser {
                 }
                 break;
             }
+            case '(': {
+                jsonReader.next();
+                if (jsonReader.nextIfMatch('@') && jsonReader.nextIfMatch('.')) {
+                    String fieldName = jsonReader.readFieldNameUnquote();
+                    switch (fieldName) {
+                        case "length":
+                        case "size": {
+                            int index = jsonReader.readInt32Value();
+                            if (!jsonReader.nextIfMatch(')')) {
+                                throw new JSONException("not support : " + fieldName);
+                            }
+                            if (index > 0) {
+                                throw new JSONException("not support : " + fieldName);
+                            } else {
+                                segment = JSONPathSegmentIndex.of(index);
+                            }
+                            break;
+                        }
+                        default:
+                            throw new JSONException("not support : " + path);
+                    }
+                } else {
+                    throw new JSONException("not support : " + path);
+                }
+                break;
+            }
             default:
                 throw new JSONException("TODO : " + jsonReader.current());
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1516.java
@@ -27,28 +27,42 @@ public class Issue1516 {
     public void testFastjson2JSONPathCompile() {
         String jsonArray = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":20,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]";
         String path = "$[?( @.name=='aa' && @.age==18 && @.city=='beijing' && @.province=='beijing' )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        String empty = "[]";
+        String ageOf18 = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]";
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.name=='aa' || @.age==16 || @.city=='beijing' || @.province=='beijing')]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.name =~ /aa/ )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.age==18 && (@.name =~ /aa/)  )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.age==18 || (@.name =~ /aa/)  )]";
-        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(ageOf18, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.name =~ /aa/ && @.age==18 )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( (@.name =~ /aa/ && (@.city=='aa')) && @.age==18 )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( (@.name =~ /aa/ && (@.city=='aa')) || @.age==18 )]";
-        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(ageOf18, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.age==18 && (@.name in ('aa', 'aa2') )  )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?( @.age==18 || (@.name in ('aa', 'aa2') )  )]";
-        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(ageOf18, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?(@.name in ('aa', 'aa2') && @.age==18 )]";
-        assertEquals("[]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(empty, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
         path = "$[?(@.name in ('aa', 'aa2') || @.age==18 )]";
-        assertEquals("[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]", JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        assertEquals(ageOf18, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+    }
+
+    @Test
+    public void testWithLengthOrSize() {
+        String jsonArray = "[{\"name\":\"小花\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":20,\"city\":\"扬州\"},{\"name\":\"小明\",\"age\":18,\"city\":\"扬州\"},{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}]";
+        String last = "{\"name\":\"小花\",\"age\":18,\"city\":\"苏州\"}";
+        String path = "$[-1]";
+        assertEquals(last, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[(@.length-1)]";
+        assertEquals(last, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
+        path = "$[(@.size-1)]";
+        assertEquals(last, JSON.toJSONString(JSONPath.of(path).extract(JSONReader.of(jsonArray))));
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?
add length and size index to JSONPathParser， such as $.[(@.length-1)]

### Summary of your change
![image](https://github.com/alibaba/fastjson2/assets/22208736/6ab5687b-594f-4174-82d2-d14e50a3006b)

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
