### PR TITLE
fix StackOverFlowError for JsonWriter when feature of ReferenceDetection not specified explicitly, for issue #1543 and #1544

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -1364,6 +1364,12 @@ public abstract class JSONWriter
 
     public abstract int flushTo(OutputStream out, Charset charset) throws IOException;
 
+    public void checkLevel(int level) {
+        if (level >= context.maxLevel) {
+            throw new JSONException("level too large : " + level);
+        }
+    }
+
     public static final class Context {
         static final ZoneId DEFAULT_ZONE_ID = ZoneId.systemDefault();
 
@@ -1379,7 +1385,7 @@ public abstract class JSONWriter
         boolean formatHasHour;
         long features;
         ZoneId zoneId;
-
+        int maxLevel = 2048;
         boolean hasFilter;
         PropertyPreFilter propertyPreFilter;
         PropertyFilter propertyFilter;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterJSONB.java
@@ -77,6 +77,7 @@ final class JSONWriterJSONB
 
     @Override
     public void startObject() {
+        super.checkLevel(level);
         level++;
         int off = this.off;
         if (off == bytes.length) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
@@ -83,6 +83,7 @@ class JSONWriterUTF16
 
     @Override
     public final void startObject() {
+        super.checkLevel(level);
         level++;
         startObject = true;
 
@@ -150,6 +151,7 @@ class JSONWriterUTF16
 
     @Override
     public final void startArray() {
+        super.checkLevel(level);
         level++;
         int off = this.off;
         int minCapacity = off + (pretty ? 2 + indent : 1);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
@@ -178,6 +178,7 @@ class JSONWriterUTF8
 
     @Override
     public final void startObject() {
+        super.checkLevel(level);
         level++;
         startObject = true;
 
@@ -245,6 +246,7 @@ class JSONWriterUTF8
 
     @Override
     public final void startArray() {
+        super.checkLevel(level);
         level++;
         int off = this.off;
         int minCapacity = off + (pretty ? 2 + indent : 1);

--- a/core/src/test/java/com/alibaba/fastjson2/JSONWriterUTF16Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONWriterUTF16Test.java
@@ -104,7 +104,7 @@ public class JSONWriterUTF16Test {
 
     @Test
     public void startObject() {
-        final int COUNT = 100_000;
+        final int COUNT = 2048;
         JSONWriterUTF16 jsonWriter = new JSONWriterUTF16(JSONFactory.createWriteContext());
         for (int i = 0; i < COUNT; i++) {
             jsonWriter.startObject();
@@ -132,7 +132,7 @@ public class JSONWriterUTF16Test {
 
     @Test
     public void startArray() {
-        final int COUNT = 100_000;
+        final int COUNT = 2048;
         JSONWriterUTF16 jsonWriter = new JSONWriterUTF16(JSONFactory.createWriteContext());
         for (int i = 0; i < COUNT; i++) {
             jsonWriter.startArray();

--- a/core/src/test/java/com/alibaba/fastjson2/JSONWriterUTF8Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONWriterUTF8Test.java
@@ -160,7 +160,7 @@ public class JSONWriterUTF8Test {
 
     @Test
     public void startObject() {
-        final int COUNT = 100_000;
+        final int COUNT = 2048;
         JSONWriterUTF8 jsonWriter = new JSONWriterUTF8(JSONFactory.createWriteContext());
         for (int i = 0; i < COUNT; i++) {
             jsonWriter.startObject();
@@ -188,7 +188,7 @@ public class JSONWriterUTF8Test {
 
     @Test
     public void startArray() {
-        final int COUNT = 100_000;
+        final int COUNT = 2048;
         JSONWriterUTF8 jsonWriter = new JSONWriterUTF8(JSONFactory.createWriteContext());
         for (int i = 0; i < COUNT; i++) {
             jsonWriter.startArray();

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1543_1544.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1543_1544.java
@@ -1,0 +1,37 @@
+package com.alibaba.fastjson2.issues_1500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Issue1543_1544 {
+    @Test
+    public void testMap() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("t", map);
+        try {
+            JSON.toJSONString(map);
+        } catch (Exception e) {
+            assertTrue(e instanceof JSONException);
+            assertEquals("level too large : 2048", e.getMessage());
+        }
+    }
+
+    @Test
+    public void testList() {
+        ArrayList<Object> list = new ArrayList<>();
+        list.add(list);
+        try {
+            JSON.toJSONString(list);
+        } catch (Exception e) {
+            assertTrue(e instanceof JSONException);
+            assertEquals("level too large : 2048", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
fix StackOverFlowError for JsonWriter when feature of ReferenceDetection not specified explicitly


### Summary of your change
add checkLevel method when startObject or startArray called, the max level is set to 2048


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
