### PR TITLE
enhancement change default buffer size from 8192 to 512 * 1024, with …

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -2009,8 +2009,9 @@ public interface JSON {
         int cacheIndex = System.identityHashCode(Thread.currentThread()) & (CACHE_ITEMS.length - 1);
         final CacheItem cacheItem = CACHE_ITEMS[cacheIndex];
         byte[] bytes = BYTES_UPDATER.getAndSet(cacheItem, null);
+        int bufferSize = 512 * 1024;
         if (bytes == null) {
-            bytes = new byte[8192];
+            bytes = new byte[bufferSize];
         }
 
         int offset = 0, start = 0, end;
@@ -2060,7 +2061,7 @@ public interface JSON {
                         start = 0;
                         offset = len;
                     } else {
-                        bytes = Arrays.copyOf(bytes, bytes.length + 8192);
+                        bytes = Arrays.copyOf(bytes, bytes.length + bufferSize);
                     }
                 }
             }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -3507,6 +3507,7 @@ public abstract class JSONReader
         boolean formatHasHour;
         boolean useSimpleFormatter;
         int maxLevel = 2048;
+        int bufferSize = 1024 * 512;
         DateTimeFormatter dateFormatter;
         ZoneId zoneId;
         long features;
@@ -3815,6 +3816,18 @@ public abstract class JSONReader
 
         public void setMaxLevel(int maxLevel) {
             this.maxLevel = maxLevel;
+        }
+
+        public int getBufferSize() {
+            return bufferSize;
+        }
+
+        public Context setBufferSize(int bufferSize) {
+            if (bufferSize < 0) {
+                throw new IllegalArgumentException("buffer size can not be less than zero");
+            }
+            this.bufferSize = bufferSize;
+            return this;
         }
 
         public Locale getLocale() {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -54,8 +54,9 @@ class JSONReaderJSONB
         int cacheIndex = System.identityHashCode(Thread.currentThread()) & (CACHE_ITEMS.length - 1);
         cacheItem = CACHE_ITEMS[cacheIndex];
         byte[] bytes = BYTES_UPDATER.getAndSet(cacheItem, null);
+        int bufferSize = ctx.getBufferSize();
         if (bytes == null) {
-            bytes = new byte[8192];
+            bytes = new byte[bufferSize];
         }
 
         int off = 0;
@@ -68,7 +69,7 @@ class JSONReaderJSONB
                 off += n;
 
                 if (off == bytes.length) {
-                    bytes = Arrays.copyOf(bytes, bytes.length + 8192);
+                    bytes = Arrays.copyOf(bytes, bytes.length + bufferSize);
                 }
             }
         } catch (IOException ioe) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -377,8 +377,9 @@ class JSONReaderUTF16
         final int cacheIndex = System.identityHashCode(Thread.currentThread()) & (CACHE_ITEMS.length - 1);
         final CacheItem cacheItem = CACHE_ITEMS[cacheIndex];
         byte[] bytes = BYTES_UPDATER.getAndSet(cacheItem, null);
+        int bufferSize = ctx.getBufferSize();
         if (bytes == null) {
-            bytes = new byte[8192];
+            bytes = new byte[bufferSize];
         }
 
         char[] chars;
@@ -392,7 +393,7 @@ class JSONReaderUTF16
                 off += n;
 
                 if (off == bytes.length) {
-                    bytes = Arrays.copyOf(bytes, bytes.length + 8192);
+                    bytes = Arrays.copyOf(bytes, bytes.length + bufferSize);
                 }
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -39,8 +39,9 @@ class JSONReaderUTF8
         int cacheIndex = System.identityHashCode(Thread.currentThread()) & (CACHE_ITEMS.length - 1);
         cacheItem = CACHE_ITEMS[cacheIndex];
         byte[] bytes = BYTES_UPDATER.getAndSet(cacheItem, null);
+        int bufferSize = ctx.getBufferSize();
         if (bytes == null) {
-            bytes = new byte[8192];
+            bytes = new byte[bufferSize];
         }
 
         int off = 0;
@@ -53,7 +54,7 @@ class JSONReaderUTF8
                 off += n;
 
                 if (off == bytes.length) {
-                    bytes = Arrays.copyOf(bytes, bytes.length + 8192);
+                    bytes = Arrays.copyOf(bytes, bytes.length + bufferSize);
                 }
             }
         } catch (IOException ioe) {


### PR DESCRIPTION

### What this PR does / why we need it?
enhancement change default buffer size from 8192 to 512 * 1024, with buffer size being customized for InputStream input.


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
