### PR TITLE
fix add fail-fast to avoid OOM for ObjectReader when field value is n…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
@@ -4,8 +4,10 @@ import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.util.Fnv;
 import com.alibaba.fastjson2.util.TypeUtils;
 
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -337,4 +339,15 @@ public interface ObjectReader<T> {
      * @throws JSONException If a suitable ObjectReader is not found
      */
     T readObject(JSONReader jsonReader, Type fieldType, Object fieldName, long features);
+
+    default void failFastIfNecessary(Object fieldValue, Type fieldType, String parseType) {
+        if (fieldValue == null) {
+            if (fieldType instanceof ParameterizedType) {
+                Type rawType = ((ParameterizedType) fieldType).getRawType();
+                if (List.class.isAssignableFrom((Class<?>) rawType)) {
+                    throw new JSONException(String.format("%s parses error, found null value when field type belongs to collection to avoid OOM", parseType));
+                }
+            }
+        }
+    }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplEnum.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplEnum.java
@@ -187,6 +187,7 @@ public final class ObjectReaderImplEnum
                 fieldValue = getEnumByHashCode(nameHash);
             }
         }
+        failFastIfNecessary(fieldValue, fieldType, this.getClass().getSimpleName());
         return fieldValue;
     }
 
@@ -248,6 +249,7 @@ public final class ObjectReaderImplEnum
                 throw new JSONException(jsonReader.info("parse enum error, class " + enumClass.getName() + ", value " + strVal));
             }
         }
+        failFastIfNecessary(fieldValue, fieldType, this.getClass().getSimpleName());
         return fieldValue;
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplEnum2X4.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplEnum2X4.java
@@ -125,6 +125,7 @@ public final class ObjectReaderImplEnum2X4
                 }
             }
         }
+        failFastIfNecessary(fieldValue, fieldType, this.getClass().getSimpleName());
         return fieldValue;
     }
 
@@ -159,6 +160,7 @@ public final class ObjectReaderImplEnum2X4
                 }
             }
         }
+        failFastIfNecessary(fieldValue, fieldType, this.getClass().getSimpleName());
         return fieldValue;
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1545.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1545.java
@@ -43,7 +43,6 @@ public class Issue1545 {
         private PermMode mode;
 
         public enum PermMode {
-
             READ,
 
             WRITE,

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1545.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1545.java
@@ -38,7 +38,6 @@ public class Issue1545 {
 
     @Data
     public class FieldPerm {
-
         private String fieldId;
 
         private PermMode mode;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1545.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1545.java
@@ -1,0 +1,55 @@
+package com.alibaba.fastjson2.issues_1500;
+
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONObject;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Issue1545 {
+    @Test
+    public void testString() {
+        String s = "{\n" +
+                "    \"fieldPermissions\": [\n" +
+                "        {\n" +
+                "            \"mode\": \"READ\",\n" +
+                "            \"fieldId\": \"updatedTime\"\n" +
+                "        }\n" +
+                "    ]\n" +
+                "}";
+        Exception ex = null;
+        try {
+            JSONObject.parseObject(s, ApproveActionConfig.class);
+        } catch (Exception e) {
+            ex = e;
+        }
+        assertTrue(ex instanceof JSONException);
+        assertEquals("ObjectReaderImplEnum parses error, found null value when field type belongs to collection to avoid OOM", ex.getMessage());
+    }
+
+    @Data
+    public class ApproveActionConfig {
+        private List<FieldPerm.PermMode> fieldPermissions;
+    }
+
+    @Data
+    public class FieldPerm {
+
+        private String fieldId;
+
+        private PermMode mode;
+
+        public enum PermMode {
+
+            READ,
+
+            WRITE,
+
+            NONE
+        }
+    }
+}


### PR DESCRIPTION

### What this PR does / why we need it?
fix add fail-fast to avoid OOM for ObjectReader when field value is null and field type belongs to collection, for issue #1545


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
