### PR TITLE
fix writeDouble and writeFloat of JSONWriter when value Not a Number …

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -903,6 +903,10 @@ public abstract class JSONWriter
             writeFloat(value);
             return;
         }
+        if (Float.isNaN(value) || Float.isInfinite(value)) {
+            writeNull();
+            return;
+        }
 
         String str = format.format(value);
         writeRaw(str);
@@ -958,6 +962,10 @@ public abstract class JSONWriter
     public final void writeDouble(double value, DecimalFormat format) {
         if (format == null || jsonb) {
             writeDouble(value);
+            return;
+        }
+        if (Double.isNaN(value) || Double.isInfinite(value)) {
+            writeNull();
             return;
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1562.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1562.java
@@ -1,0 +1,44 @@
+package com.alibaba.fastjson2.issues_1500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.annotation.JSONField;
+import lombok.Data;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1562 {
+    @Test
+    public void test() {
+        String expected = "{\"value\":null,\"value10\":null,\"value11\":null,\"value12\":null,\"value2\":null,\"value3\":null,\"value4\":null,\"value5\":null,\"value6\":null,\"value7\":null,\"value8\":null,\"value9\":null}";
+        assertEquals(expected, JSON.toJSONString(new Cs()));
+    }
+
+    @Data
+    class Cs {
+        @JSONField(format = "#.##")
+        private double value = Double.NaN;
+        @JSONField(format = "#.##")
+        private float value2 = Float.NaN;
+        @JSONField(format = "#.##")
+        private double value3 = Double.NEGATIVE_INFINITY;
+        @JSONField(format = "#.##")
+        private float value4 = Float.NEGATIVE_INFINITY;
+        @JSONField(format = "#.##")
+        private double value5 = Double.POSITIVE_INFINITY;
+        @JSONField(format = "#.##")
+        private float value6 = Float.POSITIVE_INFINITY;
+        @JSONField
+        private double value7 = Double.NaN;
+        @JSONField
+        private float value8 = Float.NaN;
+        @JSONField
+        private double value9 = Double.NEGATIVE_INFINITY;
+        @JSONField
+        private float value10 = Float.NEGATIVE_INFINITY;
+        @JSONField
+        private double value11 = Double.POSITIVE_INFINITY;
+        @JSONField
+        private float value12 = Float.POSITIVE_INFINITY;
+    }
+}


### PR DESCRIPTION
…, for issue #1562

### What this PR does / why we need it?
fix writeDouble and writeFloat of JSONWriter when value Not a Number , for issue #1562


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
