### PR TITLE
Change the scope(kotlin-stdlib) to `provided`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,15 @@ dependencies {
     <artifactId>fastjson2-kotlin</artifactId>
     <version>2.0.33</version>
 </dependency>
+```
 
-<!-- 有些场景需要依赖kotlin-reflect -->
+```xml
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-stdlib</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+
 <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-reflect</artifactId>
@@ -105,6 +112,13 @@ dependencies {
 ```kotlin
 dependencies {
     implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.33")
+}
+```
+
+```kotlin
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 }
 ```
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -99,11 +99,32 @@ If your project uses `kotlin`, you can use the `Fastjson-Kotlin` module, and use
 </dependency>
 ```
 
-`Kotlin Gradle`:
+```xml
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-stdlib</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-reflect</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+```
+
+* `Kotlin Gradle`:
 
 ```kotlin
 dependencies {
     implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.33")
+}
+```
+
+```kotlin
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 }
 ```
 

--- a/android-test/app/build.gradle
+++ b/android-test/app/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'com.alibaba:fastjson:1.1.73.android'
     implementation 'com.alibaba.fastjson2:fastjson2:2.0.33-SNAPSHOT'
     implementation 'com.alibaba.fastjson2:fastjson2-kotlin:2.0.33-SNAPSHOT'
+
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.10'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.8.10'
 
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.2'

--- a/docs/kotlin_cn.md
+++ b/docs/kotlin_cn.md
@@ -7,7 +7,6 @@
 `Maven`:
 
 ```xml
-
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
@@ -15,11 +14,32 @@
 </dependency>
 ```
 
-`Kotlin Gradle`:
+```xml
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-stdlib</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-reflect</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+```
+
+* `Kotlin Gradle`:
 
 ```kotlin
 dependencies {
     implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.33")
+}
+```
+
+```kotlin
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 }
 ```
 

--- a/docs/kotlin_en.md
+++ b/docs/kotlin_en.md
@@ -7,7 +7,6 @@ If your project uses `kotlin`, you can use the` Fastjson-Kotlin` module, and use
 `Maven`:
 
 ```xml
-
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
@@ -15,11 +14,32 @@ If your project uses `kotlin`, you can use the` Fastjson-Kotlin` module, and use
 </dependency>
 ```
 
-`Kotlin Gradle`:
+```xml
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-stdlib</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+
+<dependency>
+    <groupId>org.jetbrains.kotlin</groupId>
+    <artifactId>kotlin-reflect</artifactId>
+    <version>${kotlin-version}</version>
+</dependency>
+```
+
+* `Kotlin Gradle`:
 
 ```kotlin
 dependencies {
     implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.33")
+}
+```
+
+```kotlin
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 }
 ```
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -43,6 +43,7 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What this PR does / why we need it?

依赖`kotlin-stdlib`范围改为`provided`, 由用户选择`kotlin`版本
常见于Android中影响用户中`build.gradle`的`kotlin-gradle-plugin`插件版本

### Summary of your change

```xml
<dependency>
        <groupId>org.jetbrains.kotlin</groupId>
        <artifactId>kotlin-stdlib-jdk8</artifactId>
        <scope>provided</scope> // here
</dependency>
```

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
