### PR TITLE
修复 #1613 问题，当方法名为get开头，返回值为void类型时报ArrayIndexOutOfBoundsException 的问题

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -283,7 +283,7 @@ public class ObjectWriterCreatorASM
 
                     Class<?> returnType = method.getReturnType();
                     // skip function
-                    if (isFunction(returnType)) {
+                    if (isFunction(returnType) || returnType == Void.TYPE) {
                         return;
                     }
 


### PR DESCRIPTION
### What this PR does / why we need it?

修复 #1613 问题，当方法名为get开头，返回值为void类型时报ArrayIndexOutOfBoundsException 的问题

### Summary of your change

判断一下返回值类型，如果是void类型则忽略此字段


