### PR TITLE
Downgrade kotlin.version and kotest.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,15 @@
         <springboot3.version>3.1.1</springboot3.version>
         <arrow.version>12.0.1</arrow.version>
 
-        <kotlin.version>1.9.0</kotlin.version>
+        <!-- Requires kotlin minor version less than the latest version -->
+        <kotlin.version>1.6.21</kotlin.version>
         <!-- https://kotlinlang.org/docs/maven.html#attributes-specific-to-jvm -->
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <!-- https://kotlinlang.org/docs/maven.html#specifying-compiler-options -->
         <kotlin.compiler.apiVersion>1.5</kotlin.compiler.apiVersion>
 
         <junit5.version>5.9.3</junit5.version>
-        <kotest.version>5.6.2</kotest.version>
+        <kotest.version>5.5.5</kotest.version>
         <jmh.version>1.36</jmh.version>
 
         <!-- overridden by submodule that need skip deploy -->


### PR DESCRIPTION
downgrade kotest.version to 5.5.5
downgrade kotlin.version to 1.6.21

### What this PR does / why we need it?

尽量保持kotlin minor version比最新版本小于二至三个次版本

避免与用户构建的版本冲突时导致编译失败: 
`Kotlin: Module was compiled with an incompatible version of Kotlin.
 The binary version of its metadata is 1.9.0, expected version is 1.7.1`

若`dependabot`检测更新可在其PR下评论`@dependabot ignore this minor version`忽略次版本更新

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
