### PR TITLE
fix: FastJsonHttpMessageConverter(spring5) missing contentLength

### DIFF
--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -120,7 +120,7 @@ public class FastJsonHttpMessageConverter
     protected void writeInternal(Object object, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
         HttpHeaders headers = outputMessage.getHeaders();
 
-        try {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             int contentLength;
             if (object instanceof String && JSON.isValidObject((String) object)) {
                 byte[] strBytes = ((String) object).getBytes(config.getCharset());
@@ -136,8 +136,8 @@ public class FastJsonHttpMessageConverter
                 }
 
                 contentLength = JSON.writeTo(
-                        outputMessage.getBody(),
-                        object, config.getDateFormat(),
+                        baos, object,
+                        config.getDateFormat(),
                         config.getWriterFilters(),
                         config.getWriterFeatures()
                 );
@@ -146,6 +146,7 @@ public class FastJsonHttpMessageConverter
             if (headers.getContentLength() < 0 && config.isWriteContentLength()) {
                 headers.setContentLength(contentLength);
             }
+            baos.writeTo(outputMessage.getBody());
         } catch (JSONException ex) {
             throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
         } catch (IOException ex) {

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterUnitTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterUnitTest.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -60,6 +62,42 @@ public class FastJsonHttpMessageConverterUnitTest {
                 return new HttpHeaders();
             }
         });
+    }
+
+    @Test
+    public void testHeader() throws Exception {
+        FastJsonHttpMessageConverter messageConverter = new FastJsonHttpMessageConverter();
+        messageConverter.setFastJsonConfig(new FastJsonConfig());
+        assertNotNull(messageConverter.getFastJsonConfig());
+        assertTrue(messageConverter.canRead(VO.class, VO.class, MediaType.APPLICATION_JSON));
+        assertTrue(messageConverter.canWrite(VO.class, VO.class, MediaType.APPLICATION_JSON));
+
+        messageConverter.setSupportedMediaTypes(Arrays
+            .asList(new MediaType[]{MediaType.APPLICATION_JSON}));
+        assertEquals(1, messageConverter.getSupportedMediaTypes().size());
+
+        Method method = FastJsonHttpMessageConverter.class.getDeclaredMethod(
+            "supports", Class.class);
+        method.setAccessible(true);
+        method.invoke(messageConverter, int.class);
+
+        VO vo = (VO) messageConverter.read(VO.class, VO.class, new HttpInputMessage() {
+            @Override
+            public InputStream getBody() {
+                return new ByteArrayInputStream("{\"id\":123}".getBytes(Charset.forName("UTF-8")));
+            }
+
+            @Override
+            public HttpHeaders getHeaders() {
+                return new HttpHeaders();
+            }
+        });
+        assertEquals(vo.getId(), 123);
+
+        final MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        messageConverter.write(vo, VO.class, MediaType.APPLICATION_JSON, new ServletServerHttpResponse(mockHttpServletResponse));
+        final String contentLength = mockHttpServletResponse.getHeader(HttpHeaders.CONTENT_LENGTH);
+        assertEquals("10", contentLength);
     }
 
     public static class VO {


### PR DESCRIPTION
### What this PR does / why we need it?
fix FastJsonHttpMessageConverter(spring5) missing contentLength when writeContentLength enabled


### Summary of your change
Ensure that the outputMessage.getBody() method is called after the headers.setContentLength(contentLength) method.


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
