### PR TITLE
fix: FastJsonHttpMessageConverter lose contentLength header

### DIFF
--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -120,7 +120,7 @@ public class FastJsonHttpMessageConverter
     protected void writeInternal(Object object, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
         HttpHeaders headers = outputMessage.getHeaders();
 
-        try {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             int contentLength;
             if (object instanceof String && JSON.isValidObject((String) object)) {
                 byte[] strBytes = ((String) object).getBytes(config.getCharset());
@@ -136,8 +136,8 @@ public class FastJsonHttpMessageConverter
                 }
 
                 contentLength = JSON.writeTo(
-                        outputMessage.getBody(),
-                        object, config.getDateFormat(),
+                        baos, object,
+                        config.getDateFormat(),
                         config.getWriterFilters(),
                         config.getWriterFeatures()
                 );
@@ -146,6 +146,7 @@ public class FastJsonHttpMessageConverter
             if (headers.getContentLength() < 0 && config.isWriteContentLength()) {
                 headers.setContentLength(contentLength);
             }
+            baos.writeTo(outputMessage.getBody());
         } catch (JSONException ex) {
             throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
         } catch (IOException ex) {

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterUnitTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/FastJsonHttpMessageConverterUnitTest.java
@@ -73,11 +73,11 @@ public class FastJsonHttpMessageConverterUnitTest {
         assertTrue(messageConverter.canWrite(VO.class, VO.class, MediaType.APPLICATION_JSON));
 
         messageConverter.setSupportedMediaTypes(Arrays
-            .asList(new MediaType[]{MediaType.APPLICATION_JSON}));
+                .asList(new MediaType[] {MediaType.APPLICATION_JSON}));
         assertEquals(1, messageConverter.getSupportedMediaTypes().size());
 
         Method method = FastJsonHttpMessageConverter.class.getDeclaredMethod(
-            "supports", Class.class);
+                "supports", Class.class);
         method.setAccessible(true);
         method.invoke(messageConverter, int.class);
 


### PR DESCRIPTION
### What this PR does / why we need it?

fix FastJsonHttpMessageConverter(spring5) setContentLength not working when writeContentLength enabled

### Summary of your change

Ensure that the outputMessage.getBody() method is called after the headers.setContentLength(contentLength) method.


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
