### PR TITLE
改进部分代码细节，修复已知的 NPE 缺陷

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1857,7 +1857,7 @@ public class JSONObject
      * @param value the value of the element
      */
     public static JSONObject of(String key, Object value) {
-        JSONObject object = new JSONObject(1);
+        JSONObject object = new JSONObject(1, 1F);
         object.put(key, value);
         return object;
     }
@@ -1876,7 +1876,7 @@ public class JSONObject
      * @since 2.0.2
      */
     public static JSONObject of(String k1, Object v1, String k2, Object v2) {
-        JSONObject object = new JSONObject(2);
+        JSONObject object = new JSONObject(2, 1F);
         object.put(k1, v1);
         object.put(k2, v2);
         return object;
@@ -1931,7 +1931,7 @@ public class JSONObject
             Object v3,
             String k4,
             Object v4) {
-        JSONObject object = new JSONObject(4);
+        JSONObject object = new JSONObject(4, 1F);
         object.put(k1, v1);
         object.put(k2, v2);
         object.put(k3, v3);
@@ -1971,7 +1971,7 @@ public class JSONObject
             Object v5
 
     ) {
-        JSONObject object = new JSONObject(5);
+        JSONObject object = new JSONObject(5, 1F);
         object.put(k1, v1);
         object.put(k2, v2);
         object.put(k3, v3);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -4708,14 +4708,16 @@ final class JSONReaderJSONB
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public OffsetTime readOffsetTime() {
         ZonedDateTime zdt = readZonedDateTime();
         return zdt == null ? null : zdt.toOffsetDateTime().toOffsetTime();
     }
 
+    @Override
     public OffsetDateTime readOffsetDateTime() {
         ZonedDateTime zdt = readZonedDateTime();
-        return zdt == null ? zdt.toOffsetDateTime() : zdt.toOffsetDateTime();
+        return zdt == null ? null : zdt.toOffsetDateTime();
     }
 
     @Override


### PR DESCRIPTION
### What this PR does / why we need it?

1. 改进部分代码细节；
2. 修复已知的 NPE 缺陷。


### Summary of your change

1. 由于 `HashMap/LinkedHashMap` 默认的负载因子 为 `0.75f`，因此 `new JSONObject(1)` 在 `put` 1个 *键值对* 后，仍然会因为超过阈值 `threshold = 初始化容量 * 负载因子` 而触发再次扩容。
    因此，**初始化容量**应该直接满足  `≥ 实际容量/0.75`，或者将 负载因子 调整为 `1F`（这样可以节省底层数组空间，少量元素也不至于因为 Hash 碰撞导致性能极端劣化）。
  
2. 修正 潜在的 NPE 问题。


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
