### PR TITLE
修复已知的 NPE 缺陷，改进部分代码细节

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -3811,9 +3811,10 @@ public interface JSON {
         if (objectWriter instanceof ObjectWriterAdapter && objectReader instanceof ObjectReaderBean) {
             List<FieldWriter> fieldWriters = objectWriter.getFieldWriters();
 
+            final int size = fieldWriters.size();
             if (objectReader instanceof ObjectReaderNoneDefaultConstructor) {
-                Map<String, Object> map = new HashMap(fieldWriters.size());
-                for (int i = 0; i < fieldWriters.size(); i++) {
+                Map<String, Object> map = new HashMap<>(size, 1F);
+                for (int i = 0; i < size; i++) {
                     FieldWriter fieldWriter = fieldWriters.get(i);
                     Object fieldValue = fieldWriter.getFieldValue(object);
                     map.put(fieldWriter.fieldName, fieldValue);
@@ -3823,7 +3824,7 @@ public interface JSON {
             }
 
             T instance = (T) objectReader.createInstance(featuresValue);
-            for (int i = 0; i < fieldWriters.size(); i++) {
+            for (int i = 0; i < size; i++) {
                 FieldWriter fieldWriter = fieldWriters.get(i);
                 FieldReader fieldReader = objectReader.getFieldReader(fieldWriter.fieldName);
                 if (fieldReader == null) {
@@ -3888,7 +3889,7 @@ public interface JSON {
             List<FieldWriter> fieldWriters = objectWriter.getFieldWriters();
 
             if (objectReader instanceof ObjectReaderNoneDefaultConstructor) {
-                Map<String, Object> map = new HashMap(fieldWriters.size());
+                Map<String, Object> map = new HashMap<>(fieldWriters.size(), 1F);
                 for (int i = 0; i < fieldWriters.size(); i++) {
                     FieldWriter fieldWriter = fieldWriters.get(i);
                     Object fieldValue = fieldWriter.getFieldValue(object);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1101,7 +1101,6 @@ public class JSONObject
      * @return JSON {@link String}
      */
     @Override
-    @SuppressWarnings("unchecked")
     public String toString() {
         try (JSONWriter writer = JSONWriter.of()) {
             writer.setRootObject(this);
@@ -1116,7 +1115,6 @@ public class JSONObject
      * @param features features to be enabled in serialization
      * @return JSON {@link String}
      */
-    @SuppressWarnings("unchecked")
     public String toString(JSONWriter.Feature... features) {
         try (JSONWriter writer = JSONWriter.of(features)) {
             writer.setRootObject(this);
@@ -1152,7 +1150,6 @@ public class JSONObject
      * @param features features to be enabled in serialization
      * @return JSONB bytes
      */
-    @SuppressWarnings("unchecked")
     public byte[] toJSONBBytes(JSONWriter.Feature... features) {
         try (JSONWriter writer = JSONWriter.ofJSONB(features)) {
             writer.setRootObject(this);
@@ -1857,7 +1854,7 @@ public class JSONObject
      * @param value the value of the element
      */
     public static JSONObject of(String key, Object value) {
-        JSONObject object = new JSONObject(1);
+        JSONObject object = new JSONObject(1, 1F);
         object.put(key, value);
         return object;
     }
@@ -1876,7 +1873,7 @@ public class JSONObject
      * @since 2.0.2
      */
     public static JSONObject of(String k1, Object v1, String k2, Object v2) {
-        JSONObject object = new JSONObject(2);
+        JSONObject object = new JSONObject(2, 1F);
         object.put(k1, v1);
         object.put(k2, v2);
         return object;
@@ -1931,7 +1928,7 @@ public class JSONObject
             Object v3,
             String k4,
             Object v4) {
-        JSONObject object = new JSONObject(4);
+        JSONObject object = new JSONObject(4, 1F);
         object.put(k1, v1);
         object.put(k2, v2);
         object.put(k3, v3);
@@ -2004,9 +2001,8 @@ public class JSONObject
     /**
      * See {@link JSON#parseObject} for details
      */
-    @SuppressWarnings("unchecked")
     public static <T> T parseObject(String text, TypeReference<T> typeReference, JSONReader.Feature... features) {
-        return (T) JSON.parseObject(text, typeReference, features);
+        return JSON.parseObject(text, typeReference, features);
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -127,11 +127,10 @@ final class JSONReaderJSONB
             charset = StandardCharsets.UTF_16LE;
         } else if (strtype == BC_STR_UTF16BE) {
             charset = StandardCharsets.UTF_16BE;
-        } else if (strtype == BC_SYMBOL) {
-            int symbol = strlen;
-            int index = symbol * 2;
-//            return symbols[index];
-            throw new JSONException("TODO : " + JSONB.typeName(strtype));
+//      } else if (strtype == BC_SYMBOL) {
+//          int symbol = strlen;
+//          int index = symbol * 2;
+//          return symbols[index];
         } else {
             throw new JSONException("TODO : " + JSONB.typeName(strtype));
         }
@@ -420,13 +419,14 @@ final class JSONReaderJSONB
         throw new JSONException("object not support input " + error(type));
     }
 
+    @Override
     public void read(final Map map, long features) {
         if (bytes[offset] != BC_OBJECT) {
             throw new JSONException("object not support input " + error(type));
         }
         offset++;
 
-        for (int i = 0; ; ++i) {
+        while (true) {
             byte type = bytes[offset];
             if (type == BC_OBJECT_END) {
                 offset++;
@@ -1287,10 +1287,7 @@ final class JSONReaderJSONB
             objectClass = autoTypeBeforeHandler.apply(getString(), expectClass, features);
         }
         if (objectClass != null) {
-            ObjectReader objectReader = context.getObjectReader(objectClass);
-            if (objectReader != null) {
-                return objectReader;
-            }
+            return context.getObjectReader(objectClass);
         }
         return null;
     }
@@ -1535,8 +1532,7 @@ final class JSONReaderJSONB
 
         message.append(", offset ")
                 .append(offset);
-        JSONException error = new JSONException(message.toString());
-        return error;
+        return new JSONException(message.toString());
     }
 
     @Override
@@ -2369,7 +2365,7 @@ final class JSONReaderJSONB
                 return;
             }
             case BC_OBJECT: {
-                for (int i = 0; ; ++i) {
+                while (true) {
                     if (bytes[offset] == BC_OBJECT_END) {
                         offset++;
                         break;
@@ -4708,14 +4704,16 @@ final class JSONReaderJSONB
         throw new UnsupportedOperationException();
     }
 
+    @Override
     public OffsetTime readOffsetTime() {
         ZonedDateTime zdt = readZonedDateTime();
         return zdt == null ? null : zdt.toOffsetDateTime().toOffsetTime();
     }
 
+    @Override
     public OffsetDateTime readOffsetDateTime() {
         ZonedDateTime zdt = readZonedDateTime();
-        return zdt == null ? zdt.toOffsetDateTime() : zdt.toOffsetDateTime();
+        return zdt == null ? null : zdt.toOffsetDateTime();
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
@@ -62,11 +62,12 @@ final class ConstructorFunction<T>
 
         this.alternateConstructors = alternateConstructors;
         if (alternateConstructors != null) {
-            alternateConstructorMap = new HashMap<>(alternateConstructors.size());
-            alternateConstructorNames = new HashMap<>(alternateConstructors.size());
-            alternateConstructorArgTypes = new HashMap<>(alternateConstructors.size());
-            alternateConstructorNameHashCodes = new HashMap<>(alternateConstructors.size());
-            for (int i = 0; i < alternateConstructors.size(); i++) {
+            final int size = alternateConstructors.size();
+            alternateConstructorMap = new HashMap<>(size, 1F);
+            alternateConstructorNames = new HashMap<>(size, 1F);
+            alternateConstructorArgTypes = new HashMap<>(size, 1F);
+            alternateConstructorNameHashCodes = new HashMap<>(size, 1F);
+            for (int i = 0; i < size; i++) {
                 Constructor alternateConstructor = alternateConstructors.get(i);
                 alternateConstructor.setAccessible(true);
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -175,7 +175,7 @@ public class ObjectReaderAdapter<T>
 
         this.seeAlso = seeAlso;
         if (seeAlso != null) {
-            this.seeAlsoMapping = new HashMap<>(seeAlso.length);
+            this.seeAlsoMapping = new HashMap<>(seeAlso.length, 1F);
             this.seeAlsoNames = new String[seeAlso.length];
             for (int i = 0; i < seeAlso.length; i++) {
                 Class seeAlsoClass = seeAlso[i];

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
@@ -158,8 +158,8 @@ public final class ObjectSchema
 
         JSONObject dependentRequired = input.getJSONObject("dependentRequired");
         if (dependentRequired != null && !dependentRequired.isEmpty()) {
-            this.dependentRequired = new LinkedHashMap<>(dependentRequired.size());
-            this.dependentRequiredHashCodes = new LinkedHashMap<>(dependentRequired.size());
+            this.dependentRequired = new LinkedHashMap<>(dependentRequired.size(), 1F);
+            this.dependentRequiredHashCodes = new LinkedHashMap<>(dependentRequired.size(), 1F);
             Set<String> keys = dependentRequired.keySet();
             for (String key : keys) {
                 String[] dependentRequiredProperties = dependentRequired.getObject(key, String[].class);
@@ -177,8 +177,8 @@ public final class ObjectSchema
 
         JSONObject dependentSchemas = input.getJSONObject("dependentSchemas");
         if (dependentSchemas != null && !dependentSchemas.isEmpty()) {
-            this.dependentSchemas = new LinkedHashMap<>(dependentSchemas.size());
-            this.dependentSchemasHashMapping = new LinkedHashMap<>(dependentSchemas.size());
+            this.dependentSchemas = new LinkedHashMap<>(dependentSchemas.size(), 1F);
+            this.dependentSchemasHashMapping = new LinkedHashMap<>(dependentSchemas.size(), 1F);
             Set<String> keys = dependentSchemas.keySet();
             for (String key : keys) {
                 JSONSchema dependentSchema = dependentSchemas.getObject(key, JSONSchema::of);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
@@ -302,7 +302,8 @@ public class ObjectWriterAdapter<T>
             writeTypeInfo(jsonWriter);
         }
 
-        for (int i = 0; i < fieldWriters.size(); i++) {
+        final int size = fieldWriters.size();
+        for (int i = 0; i < size; i++) {
             FieldWriter fieldWriter = fieldWriters.get(i);
             fieldWriter.write(jsonWriter, object);
         }
@@ -311,8 +312,9 @@ public class ObjectWriterAdapter<T>
     }
 
     public Map<String, Object> toMap(Object object) {
-        JSONObject map = new JSONObject(fieldWriters.size());
-        for (int i = 0; i < fieldWriters.size(); i++) {
+        final int size = fieldWriters.size();
+        JSONObject map = new JSONObject(size, 1F);
+        for (int i = 0; i < size; i++) {
             FieldWriter fieldWriter = fieldWriters.get(i);
             map.put(
                     fieldWriter.fieldName,


### PR DESCRIPTION
### What this PR does / why we need it?

1. 改进部分代码细节；
2. 修复已知的 NPE 缺陷。


### Summary of your change

1. 由于 `HashMap/LinkedHashMap` 默认的负载因子 为 `0.75f`，因此 `new JSONObject(1)` 在 `put` 1个 *键值对* 后，仍然会因为超过阈值 `threshold = 初始化容量 * 负载因子` 而触发再次扩容。
    因此，**初始化容量**应该直接满足  `≥ 实际容量/0.75`，或者将 负载因子 调整为 `1F`（这样可以节省底层数组空间，少量元素也不至于因为 Hash 碰撞导致性能极端劣化）。
  
2. 修正 潜在的 NPE 问题。


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
