### PR TITLE
Support nested duplicate keys when enable DuplicateKeyValueAsArray #1786

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -2339,7 +2339,18 @@ public abstract class JSONReader
                 default:
                     throw new JSONException(info("illegal input " + ch));
             }
-            object.put(name, val);
+            Object origin = object.put(name, val);
+            if (origin != null) {
+                if ((context.getFeatures() & JSONReader.Feature.DuplicateKeyValueAsArray.mask) != 0) {
+                    if (origin instanceof Collection) {
+                        ((Collection) origin).add(val);
+                        object.put(name, origin);
+                    } else {
+                        JSONArray array = JSONArray.of(origin, val);
+                        object.put(name, array);
+                    }
+                }
+            }
         }
 
         if (comma = (ch == ',')) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1700/Issue1786.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1700/Issue1786.java
@@ -1,0 +1,17 @@
+package com.alibaba.fastjson2.issues_1700;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1786 {
+    @Test
+    public void test() {
+        String json = "{\"c1\":{\"a\":1,\"a\":2}}";
+        JSONObject jsonObject = JSON.parseObject(json, JSONReader.Feature.DuplicateKeyValueAsArray);
+        assertEquals("[1,2]", ((JSONObject) jsonObject.get("c1")).get("a").toString());
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
https://github.com/alibaba/fastjson2/issues/1786


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
