### PR TITLE
fix final field initialized in the constructor set twice for issue #1873

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderCollectionFieldReadOnly.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderCollectionFieldReadOnly.java
@@ -37,7 +37,10 @@ final class FieldReaderCollectionFieldReadOnly<T>
             throw new JSONException("set " + fieldName + " error", e);
         }
 
-        if (collection == Collections.EMPTY_LIST || collection == Collections.EMPTY_SET || collection == null) {
+        if (collection == Collections.EMPTY_LIST
+                || collection == Collections.EMPTY_SET
+                || collection == null
+                || collection.equals(value)) {
             return;
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1873.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1873.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson2.issues_1800;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue1873 {
+    @Test
+    public void test() {
+        String json = "[{\"array\":[\"test1\",\"test2\",\"test3\"]}]";
+        List<ListTest> values = JSONObject.parseObject(json, TypeReference.collectionType(List.class, ListTest.class));
+        assertEquals(json, JSONObject.toJSONString(values));
+        json = "{\"array\":[\"test1\",\"test2\",\"test3\"]}";
+        ListTest listTest = JSONObject.parseObject(json, ListTest.class);
+        assertEquals(json, JSONObject.toJSONString(listTest));
+    }
+
+    static class ListTest {
+        public final List<String> array;
+
+        public ListTest(List<String> array) {
+            this.array = array;
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

fix final field initialized in the constructor set twice for issue #1873

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
