### PR TITLE
Fix issue1866.

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -2257,19 +2257,19 @@ public class ObjectWriterCreatorASM
 
         mw.visitJumpInsn(Opcodes.IFNONNULL, notNull_);
 
-        mwc.genIsEnabled(
-                WriteNulls.mask | NullAsDefaultValue.mask | WriteNullNumberAsZero.mask,
-                writeNullValue_,
-                endIfNull_
-        );
-
         mw.visitLabel(writeNullValue_);
 
-        gwFieldName(mwc, fieldWriter, i);
-
-        // TODO : if ((features & (JSONWriter.Feature.WriteNulls.mask | JSONWriter.Feature.NullAsEmpty.mask)) == 0) {
-        mw.visitVarInsn(Opcodes.ALOAD, JSON_WRITER);
-        mw.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TYPE_JSON_WRITER, "writeNumberNull", "()V", false);
+        long features = fieldWriter.features | mwc.var2(CONTEXT_FEATURES);
+        if ((features & WriteNullNumberAsZero.mask) != 0) {
+            gwFieldName(mwc, fieldWriter, i);
+            mw.visitVarInsn(Opcodes.ALOAD, JSON_WRITER);
+            mw.visitLdcInsn(0);
+            mw.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TYPE_JSON_WRITER, "writeInt32", "(I)V", false);
+        } else if ((features & (WriteNulls.mask | NullAsDefaultValue.mask)) != 0) {
+            gwFieldName(mwc, fieldWriter, i);
+            mw.visitVarInsn(Opcodes.ALOAD, JSON_WRITER);
+            mw.visitMethodInsn(Opcodes.INVOKEVIRTUAL, TYPE_JSON_WRITER, "writeNull", "()V", false);
+        }
 
         mw.visitJumpInsn(Opcodes.GOTO, endIfNull_);
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1866.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1866.java
@@ -1,0 +1,78 @@
+package com.alibaba.fastjson2.issues_1800;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.annotation.JSONField;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue1866 {
+    @Test
+    public void test() {
+        User hello = new User();
+        hello.setAge1(null);  // WriteNullNumberAsZero, 期望为0
+        hello.setAge2(null);  // WriteNulls, 期望为null
+        hello.setAge3(null);  // 期望不序列化
+
+        // age4, age5不为null应不受影响
+        hello.setAge4(10);
+        hello.setAge5(10);
+        assertEquals(JSON.toJSONString(hello), "{\"age1\":0,\"age2\":null,\"age4\":10,\"age5\":10}");
+    }
+
+    public static class User {
+        @JSONField(serializeFeatures = JSONWriter.Feature.WriteNullNumberAsZero)
+        private Integer age1;
+
+        @JSONField(serializeFeatures = JSONWriter.Feature.WriteNulls)
+        private Integer age2;
+
+        private Integer age3;
+
+        @JSONField(serializeFeatures = JSONWriter.Feature.WriteNullNumberAsZero)
+        private Integer age4;
+
+        private Integer age5;
+
+        public Integer getAge1() {
+            return age1;
+        }
+
+        public void setAge1(Integer age1) {
+            this.age1 = age1;
+        }
+
+        public Integer getAge2() {
+            return age2;
+        }
+
+        public void setAge2(Integer age2) {
+            this.age2 = age2;
+        }
+
+        public Integer getAge3() {
+            return age3;
+        }
+
+        public void setAge3(Integer age3) {
+            this.age3 = age3;
+        }
+
+        public Integer getAge4() {
+            return age4;
+        }
+
+        public void setAge4(Integer age4) {
+            this.age4 = age4;
+        }
+
+        public Integer getAge5() {
+            return age5;
+        }
+
+        public void setAge5(Integer age5) {
+            this.age5 = age5;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1866.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1866.java
@@ -15,7 +15,6 @@ public class Issue1866 {
         hello.setAge2(null);  // WriteNulls, 期望为null
         hello.setAge3(null);  // NullAsDefaultValue, 期望为0
         hello.setAge4(null);  // 期望不被序列化
-
         // age5, age6不为null应不受影响
         hello.setAge5(10);
         hello.setAge6(10);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1866.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1800/Issue1866.java
@@ -13,12 +13,14 @@ public class Issue1866 {
         User hello = new User();
         hello.setAge1(null);  // WriteNullNumberAsZero, 期望为0
         hello.setAge2(null);  // WriteNulls, 期望为null
-        hello.setAge3(null);  // 期望不序列化
+        hello.setAge3(null);  // NullAsDefaultValue, 期望为0
+        hello.setAge4(null);  // 期望不被序列化
 
-        // age4, age5不为null应不受影响
-        hello.setAge4(10);
+        // age5, age6不为null应不受影响
         hello.setAge5(10);
-        assertEquals(JSON.toJSONString(hello), "{\"age1\":0,\"age2\":null,\"age4\":10,\"age5\":10}");
+        hello.setAge6(10);
+        System.out.println(JSON.toJSONString(hello));
+        assertEquals("{\"age1\":0,\"age2\":null,\"age3\":0,\"age5\":10,\"age6\":10}", JSON.toJSONString(hello));
     }
 
     public static class User {
@@ -28,12 +30,14 @@ public class Issue1866 {
         @JSONField(serializeFeatures = JSONWriter.Feature.WriteNulls)
         private Integer age2;
 
+        @JSONField(serializeFeatures = JSONWriter.Feature.NullAsDefaultValue)
         private Integer age3;
 
-        @JSONField(serializeFeatures = JSONWriter.Feature.WriteNullNumberAsZero)
         private Integer age4;
 
         private Integer age5;
+
+        private Integer age6;
 
         public Integer getAge1() {
             return age1;
@@ -73,6 +77,14 @@ public class Issue1866 {
 
         public void setAge5(Integer age5) {
             this.age5 = age5;
+        }
+
+        public Integer getAge6() {
+            return age6;
+        }
+
+        public void setAge6(Integer age6) {
+            this.age6 = age6;
         }
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?
修复Issue1866中WriteNullNumberAsZero不生效的问题


### Summary of your change
在生成字节码时（ObjectWriterCreatorASM.gwInt32()），没有对Field.features进行判断（@JSONField(serializeFeatures = JSONWriter.Feature.WriteNullNumberAsZero存放在Field.features中），只判断了JSONWriter.context.features.

ps:
1、JSONWriter.context.features和Field.features之间关联吗？
2、ObjectWriterCreatorASM的其他函数, JSONWRITER的函数似乎都只判断了JSONWriter.context.features，是我理解有问题吗？
