### PR TITLE
处理反序列化枚举值中以 ‘"[{’等字符开头时失败导致结果为空的问题

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -1467,6 +1467,19 @@ public class TypeUtils {
             return (T) typeConvert.apply(obj);
         }
 
+        if (targetClass.isEnum()) {
+            ObjectReader objectReader = JSONFactory.getDefaultObjectReaderProvider().getObjectReader(targetClass);
+            if (objectReader instanceof ObjectReaderImplEnum) {
+                if (obj instanceof Integer) {
+                    int intValue = (Integer) obj;
+                    return (T) ((ObjectReaderImplEnum) objectReader).of(intValue);
+                } else {
+                    JSONReader jsonReader = JSONReader.of(JSON.toJSONString(obj));
+                    return (T) objectReader.readObject(jsonReader, null, null, 0);
+                }
+            }
+        }
+
         if (obj instanceof String) {
             String json = (String) obj;
             if (json.isEmpty() || "null".equals(json)) {
@@ -1486,16 +1499,6 @@ public class TypeUtils {
                     .getDefaultObjectReaderProvider()
                     .getObjectReader(targetClass);
             return (T) objectReader.readObject(jsonReader, null, null, 0);
-        }
-
-        if (targetClass.isEnum()) {
-            if (obj instanceof Integer) {
-                int intValue = (Integer) obj;
-                ObjectReader objectReader = JSONFactory.getDefaultObjectReaderProvider().getObjectReader(targetClass);
-                if (objectReader instanceof ObjectReaderImplEnum) {
-                    return (T) ((ObjectReaderImplEnum) objectReader).of(intValue);
-                }
-            }
         }
 
         if (obj instanceof Collection) {


### PR DESCRIPTION
### What this PR does / why we need it?

当一个枚举值中包含带有 “[{” 的字符串时
```java
enum class ObjectType(@JsonValue val value: String, val label: String) {
    COLLECTION("[]", "集合类型"),
    OBJECT("{}", "对象类型"),
}
```
反序列化会优先以字符串的方式处理，但是遇到特殊字符时，反序列化的处理的结果为空

### Summary of your change

- 将枚举对象的反序列化提前到字符串处理之前
- 使枚举类型的判断中反序列化支持除int以为的更多类型


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
