### PR TITLE
解决为接口注册 ObjectReader 不生效的问题

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -733,6 +733,14 @@ public class ObjectReaderProvider
                 ? cacheFieldBased.get(objectType)
                 : cache.get(objectType);
 
+        if (objectReader == null && objectType instanceof WildcardType) {
+            Type[] upperBounds = ((WildcardType) objectType).getUpperBounds();
+            if (upperBounds.length == 1) {
+                Type upperBoundType = upperBounds[0];
+                objectReader = fieldBased ? cacheFieldBased.get(upperBoundType) : cache.get(upperBoundType);
+            }
+        }
+
         return objectReader != null
                 ? objectReader
                 : getObjectReaderInternal(objectType, fieldBased);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1900/Issue1972Kt.kt
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1900/Issue1972Kt.kt
@@ -1,0 +1,85 @@
+package com.alibaba.fastjson2.issues_1900
+
+import com.alibaba.fastjson2.JSON
+import com.alibaba.fastjson2.JSONObject
+import com.alibaba.fastjson2.JSONReader
+import com.alibaba.fastjson2.reader.ObjectReader
+import org.junit.Assert
+import org.junit.Test
+import java.lang.reflect.Type
+
+class Issue1972Kt {
+    @Test
+    fun test() {
+        val json = "{" +
+                "       \"groupCode\": \"A12\"," +
+                "       \"items\": [" +
+                "           {" +
+                "               \"impl1Code\": \"code1\"" +
+                "           }," +
+                "           {" +
+                "               \"impl2Code\": \"code2\"" +
+                "           }" +
+                "       ]" +
+                "   }"
+        JSON.register(InterfaceDemo::class.java, InterfaceDemoReader())
+
+        val result = JSON.parseObject(json, InterfaceDemo::class.java)
+        Assert.assertTrue(result is InterfaceImplGroup)
+
+        val group = result as InterfaceImplGroup
+        Assert.assertEquals(group.groupCode, "A12")
+        Assert.assertNotNull(group.items)
+        Assert.assertEquals(group.items?.size, 2)
+
+        Assert.assertTrue(group.items?.get(0) is InterfaceImpl1)
+        Assert.assertTrue(group.items?.get(1) is InterfaceImpl2)
+
+        val impl1 = group.items?.get(0) as InterfaceImpl1
+        Assert.assertEquals(impl1.impl1Code, "code1")
+
+        val impl2 = group.items?.get(1) as InterfaceImpl2
+        Assert.assertEquals(impl2.impl2Code, "code2")
+    }
+}
+
+class InterfaceDemoReader : ObjectReader<InterfaceDemo> {
+    override fun readObject(reader: JSONReader?, fieldType: Type?, fieldName: Any?, features: Long): InterfaceDemo? {
+        if (reader == null || reader.nextIfNull()) return null
+        return resolveObject(reader.readJSONObject())
+    }
+
+    override fun createInstance(map: MutableMap<Any?, Any?>, features: Long): InterfaceDemo {
+        if (map is JSONObject) {
+            val value = resolveObject(map)
+            if (value != null) return value
+        }
+        return super.createInstance(map, features)
+    }
+
+    private fun resolveObject(obj: JSONObject): InterfaceDemo? {
+        if (obj.containsKey("impl1Code")) {
+            return obj.to(InterfaceImpl1::class.java)
+        } else if (obj.containsKey("impl2Code")) {
+            return obj.to(InterfaceImpl2::class.java)
+        } else if (obj.containsKey("groupCode")) {
+            return obj.to(InterfaceImplGroup::class.java)
+        }
+        return null
+    }
+}
+
+interface InterfaceDemo
+
+class InterfaceImpl1 : InterfaceDemo {
+    var impl1Code: String? = null
+}
+
+class InterfaceImpl2 : InterfaceDemo {
+    var impl2Code: String? = null
+}
+
+class InterfaceImplGroup : InterfaceDemo {
+    var groupCode: String? = null
+    var items: List<InterfaceDemo>? = null
+}


### PR DESCRIPTION
### What this PR does / why we need it?

给一个接口类型指定 ObjectReader，并使用 `com.alibaba.fastjson2.JSON#register(java.lang.reflect.Type, com.alibaba.fastjson2.reader.ObjectReader<?>)` 方法注册后，缓存中存在的类型 key 是接口 `interface xxx`，而反序列化获取对应的 ObjectReader 时，参数传入的是一个 WildcardType 类型的 `? extends xxx`，无法正确获取到自定义的 ObjectReader。

### Summary of your change

当缓存中获取不到对应的 ObjectReader 且传入的是 WildcardType 类型时，根据 WildcardType 的上边界类型重新在缓存中尝试获取一次 ObjectReader。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
