### PR TITLE
Addressing two flaky tests seen in `fastjson1-compatible` module

### DIFF
--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1100/Issue1177_2.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1100/Issue1177_2.java
@@ -6,6 +6,7 @@ import com.alibaba.fastjson.JSONPath;
 import com.alibaba.fastjson.TypeReference;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,7 +18,7 @@ public class Issue1177_2 {
     @Test
     public void test_for_issue() throws Exception {
         String text = "{\"a\":{\"x\":\"y\"},\"b\":{\"x\":\"y\"}}";
-        Map<String, Model> jsonObject = JSONObject.parseObject(text, new TypeReference<Map<String, Model>>() {
+        Map<String, Model> jsonObject = JSONObject.parseObject(text, new TypeReference<LinkedHashMap<String, Model>>() {
         }.getType());
         System.out.println(JSON.toJSONString(jsonObject));
         String jsonpath = "$..x";

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_2400/Issue2447.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_2400/Issue2447.java
@@ -30,8 +30,8 @@ public class Issue2447 {
         vo.properties.put("longitude", 127);
 
         Object obj = JSON.toJSON(vo);
-        String text = JSON.toJSONString(obj, SerializerFeature.SortField);
-        assertEquals("{\"latitude\":37,\"id\":123,\"longitude\":127}", text);
+        String text = JSON.toJSONString(obj, SerializerFeature.SortField, SerializerFeature.MapSortField);
+        assertEquals("{\"id\":123,\"latitude\":37,\"longitude\":127}", text);
     }
 
     public static class VO {


### PR DESCRIPTION
### What this PR does / why we need it?

https://github.com/alibaba/fastjson2/issues/2017 

I reported the above issue a couple of days back regarding a few flaky tests that I had found in the `fastjson1-compatible` module. This PR aims to address a couple of flaky tests mentioned in the list attached in the issue.

### Summary of your change

The two flaky tests addressed via this PR are the following:
- `com.alibaba.fastjson.issue_2400.Issue2447.test_for_issue2`.
- `com.alibaba.fastjson.issue_1100.Issue1177_2#test_for_issue`.

**Issue2447.test_for_issue2**
- In `Issue2447.test_for_issue2`, the order of elements in `text` can change despite using `SerializerFeature.SortField` to sort the elements in lexicographical order.
```
[INFO] Running com.alibaba.fastjson.issue_2400.Issue2447
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.096 s <<< FAILURE! -- in com.alibaba.fastjson.issue_2400.Issue2447
[ERROR] com.alibaba.fastjson.issue_2400.Issue2447.test_for_issue2 -- Time elapsed: 0.085 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"latitude":37,"id":123,"longitude":127}> but was: <{"longitude":127,"latitude":37,"id":123}>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at com.alibaba.fastjson.issue_2400.Issue2447.test_for_issue2(Issue2447.java:34)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   Issue2447.test_for_issue2:34 expected: <{"latitude":37,"id":123,"longitude":127}> but was: <{"longitude":127,"latitude":37,"id":123}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
- To overcome the non-determinism seen here, we can additionally sort the `properties` map using `SerializerFeature.MapSortField` and compare `text` to always contain id followed by the elements of `properties`.

**Issue1177_2#test_for_issue**

- The current test performs a direct assertion expecting the order of elements to be intact during the parsing of JSON.
- The implementation as such is not guaranteed to maintain the order of elements owing to the use of `Map` which does not guarantee order preservation.

```
[INFO] -------------------------------------------------------
[INFO] Running com.alibaba.fastjson.issue_1100.Issue1177_2
{"b":{"x":"y"},"a":{"x":"y"}}
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.140 s <<< FAILURE! -- in com.alibaba.fastjson.issue_1100.Issue1177_2
[ERROR] com.alibaba.fastjson.issue_1100.Issue1177_2.test_for_issue -- Time elapsed: 0.128 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <{"a":{"x":"y2"},"b":{"x":"y2"}}> but was: <{"b":{"x":"y2"},"a":{"x":"y2"}}>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
        at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
        at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
        at com.alibaba.fastjson.issue_1100.Issue1177_2.test_for_issue(Issue1177_2.java:26)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   Issue1177_2.test_for_issue:26 expected: <{"a":{"x":"y2"},"b":{"x":"y2"}}> but was: <{"b":{"x":"y2"},"a":{"x":"y2"}}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```
- To aid in preserving the order of elements for aiding a bare assertion on the presence of elements in their expected order, we can retain the generic type information using a `LinkedHashMap`.
- This helps in not only retaining all relevant elements but also preserves them in order.

#### Please indicate you've done the following:

- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
