### PR TITLE
Fixed 6 Flaky tests in `fastjson1-compatible` module

### DIFF
--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/geo/FeatureCollectionTest.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/geo/FeatureCollectionTest.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.support.geo.FeatureCollection;
 import com.alibaba.fastjson.support.geo.Geometry;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -62,9 +63,9 @@ public class FeatureCollectionTest {
         Geometry geometry = JSON.parseObject(str, Geometry.class);
         assertEquals(FeatureCollection.class, geometry.getClass());
 
-        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry));
+        JSONAssert.assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry), true);
 
         String str2 = JSON.toJSONString(geometry);
-        assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)));
+        JSONAssert.assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)), true);
     }
 }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1300/Issue1363.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1300/Issue1363.java
@@ -3,11 +3,11 @@ package com.alibaba.fastjson.issue_1300;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.annotation.JSONCreator;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -26,7 +26,7 @@ public class Issue1363 {
         String jsonStr = JSON.toJSONString(b);
         System.out.println(jsonStr);
         DataSimpleVO obj = JSON.parseObject(jsonStr, DataSimpleVO.class);
-        assertEquals(jsonStr, JSON.toJSONString(obj));
+        JSONAssert.assertEquals(jsonStr, JSON.toJSONString(obj), true);
     }
 
     @Test
@@ -43,7 +43,7 @@ public class Issue1363 {
         DataSimpleVO obj = JSON.parseObject(jsonStr, DataSimpleVO.class);
         System.out.println(obj.toString());
         assertNotNull(obj.value1);
-        assertEquals(jsonStr, JSON.toJSONString(obj));
+        JSONAssert.assertEquals(jsonStr, JSON.toJSONString(obj), true);
     }
 
     public static class DataSimpleVO {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1900/Issue1972.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1900/Issue1972.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPath;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -23,6 +24,6 @@ public class Issue1972 {
         jsonObject.put("a", a);
         JSONPath.arrayAdd(jsonObject, "$.a.b[?(@.c = '2018-04')].d", obj);
 
-        assertEquals("{\"a\":{\"b\":{\"c\":\"2018-04\",\"d\":[123]}}}", jsonObject.toString());
+        JSONAssert.assertEquals("{\"a\":{\"b\":{\"c\":\"2018-04\",\"d\":[123]}}}", jsonObject.toString(),true);
     }
 }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/jsonp/JSONPParseTest.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/jsonp/JSONPParseTest.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson.jsonp;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPObject;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +24,7 @@ public class JSONPParseTest {
         assertEquals(1, param.get("id"));
         assertEquals("idonans", param.get("name"));
 
-        String json = JSON.toJSONString(jsonpObject);
-        assertEquals("callback({\"name\":\"idonans\",\"id\":1})", json);
+        String json = JSON.toJSONString(jsonpObject, SerializerFeature.MapSortField);
+        assertEquals("callback({\"id\":1,\"name\":\"idonans\"})", json);
     }
 }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/jsonp/JSONPParseTest1.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/jsonp/JSONPParseTest1.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson.jsonp;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPObject;
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,7 +24,7 @@ public class JSONPParseTest1 {
         assertEquals(1, param.get("id"));
         assertEquals("idonans", param.get("name"));
 
-        String json = JSON.toJSONString(jsonpObject);
-        assertEquals("callback({\"name\":\"idonans\",\"id\":1})", json);
+        String json = JSON.toJSONString(jsonpObject, SerializerFeature.MapSortField);
+        assertEquals("callback({\"id\":1,\"name\":\"idonans\"})", json);
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes all flaky tests captured in https://github.com/alibaba/fastjson2/issues/2033.

### Summary of your change

- As elaborated in the above mentioned issue, 4 of the identified 6 tests are asserting on JSON objects and this could lead to failures if the ordering of elements in the JSON object is shuffled. 
- The other two tests `com.alibaba.fastjson.jsonp.JSONPParseTest1#test_f` and `com.alibaba.fastjson.jsonp.JSONPParseTest#test_f` can fail non-deterministically if the strings are compared directly without considering their order.
- For the four tests with JSON assertion issues, the solution is to use `JSONAssert` to perform the comparison as this compares not only the presence of elements but also their order.
- For `com.alibaba.fastjson.jsonp.JSONPParseTest1#test_f` and `com.alibaba.fastjson.jsonp.JSONPParseTest#test_f`, we can sort the string first using `SerializerFeature.MapSortField`.
- This ensures the strings are always in one particular order and then comparing with the expected string ensures the validation of both order of elements and their presence.


#### Please indicate you've done the following:

- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
