### PR TITLE
Fixed identified Flaky tests in `Core` and `Extension` Modules

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -253,6 +253,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
             <version>${springframework5.version}</version>

--- a/core/src/test/java/com/alibaba/fastjson2/features/MapSortFieldTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/features/MapSortFieldTest.java
@@ -3,7 +3,9 @@ package com.alibaba.fastjson2.features;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONWriter;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -12,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MapSortFieldTest {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         assertEquals("{\"v2\":2,\"v1\":1}",
                 JSON.toJSONString(
                         JSONObject.of("v2", 2, "v1", 1))
@@ -32,7 +34,7 @@ public class MapSortFieldTest {
         HashMap map2 = new HashMap();
         map2.put("v2", 2);
         map2.put("v1", 1);
-        assertEquals("{\"v1\":1,\"v2\":2}", JSON.toJSONString(map2));
+        JSONAssert.assertEquals("{\"v1\":1,\"v2\":2}", JSON.toJSONString(map2), true);
         assertEquals("{\"v1\":1,\"v2\":2}", JSON.toJSONString(map2, JSONWriter.Feature.MapSortField));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue1411.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue1411.java
@@ -3,7 +3,9 @@ package com.alibaba.fastjson2.issues;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONReader;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.TreeMap;
@@ -69,11 +71,11 @@ public class Issue1411 {
     }
 
     @Test
-    public void test5() {
+    public void test5() throws JSONException {
         String text = "{\"@type\":\"java.util.concurrent.ConcurrentHashMap\",\"id\":2,\"name\":\"fastjson\"}";
         Object result = JSON.parse(text, JSONReader.Feature.SupportAutoType);
         assertInstanceOf(ConcurrentHashMap.class, result);
-        assertEquals("{\"name\":\"fastjson\",\"id\":2}", JSON.toJSONString(result));
+        JSONAssert.assertEquals("{\"name\":\"fastjson\",\"id\":2}", JSON.toJSONString(result), true);
 
         JSONObject jsonObject = (JSONObject) JSON.parse(text);
         assertEquals("java.util.concurrent.ConcurrentHashMap", jsonObject.get("@type"));

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue273.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue273.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -14,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Issue273 {
     @Test
     public void test() {
-        Map<Integer, Long> map0 = new HashMap<>();
+        Map<Integer, Long> map0 = new LinkedHashMap<>();
         map0.put(1, 111L);
         map0.put(2, 222L);
         String json = JSON.toJSONString(map0);

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue507.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue507.java
@@ -3,7 +3,9 @@ package com.alibaba.fastjson2.issues;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.TypeReference;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -28,13 +30,13 @@ public class Issue507 {
     }
 
     @Test
-    public void test1() {
+    public void test1() throws JSONException {
         Map<Long, String> map = new HashMap<>();
         map.put(1L, "张三");
         map.put(2L, "张四");
 
         String str = JSON.toJSONString(map, JSONWriter.Feature.WriteClassName);
-        assertEquals("{\"@type\":\"java.util.HashMap\",1L:\"张三\",2L:\"张四\"}", str);
+        JSONAssert.assertEquals("{\"@type\":\"java.util.HashMap\",1L:\"张三\",2L:\"张四\"}", str, true);
 
         Map map2 = (Map) JSON.parseObject(str, Object.class);
         assertEquals("张三", map2.get(1L));

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue586.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue586.java
@@ -1,7 +1,9 @@
 package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSON;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Set;
 
@@ -9,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue586 {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         Bean bean = JSON.parseObject("{\"resourceIds\":Set[1L,100L,1000L,1001L,1002L,1003L,1004L,1005L,1006L]}", Bean.class);
         assertEquals(9, bean.resourceIds.size());
-        assertEquals("[1,100,1000,1001,1002,1003,1004,1005,1006]", JSON.toJSONString(bean.resourceIds));
+        JSONAssert.assertEquals("[1,100,1000,1001,1002,1003,1004,1005,1006]", JSON.toJSONString(bean.resourceIds), false);
     }
 
     public static class Bean {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1269.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1269.java
@@ -4,7 +4,9 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.JSONWriter;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 
@@ -12,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue1269 {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         HashMap<Integer, Integer> map = new HashMap<>();
         map.put(1, 1);
         map.put(2, 2);
@@ -20,7 +22,7 @@ public class Issue1269 {
         JavaObj o = new JavaObj(map);
         byte[] bt = JSON.toJSONBytes(o, JSONWriter.Feature.WriteNonStringKeyAsString); // 兼容其他语言
         JSONObject jsonObj = JSON.parseObject(bt);
-        assertEquals("{\"map\":{\"1\":1,\"2\":2}}", jsonObj.toString());
+        JSONAssert.assertEquals("{\"map\":{\"1\":1,\"2\":2}}", jsonObj.toString(), true);
 
         o = jsonObj.to(JavaObj.class, JSONReader.Feature.FieldBased);
         assertEquals(1, o.getMap().get(1)); // 这里泛型不匹配, String的key没有自动转为int 仍是String类型。

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1401.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1401.java
@@ -2,7 +2,9 @@ package com.alibaba.fastjson2.issues_1000;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,9 +30,9 @@ public class Issue1401 {
     }
 
     @Test
-    public void test() {
+    public void test() throws JSONException {
         Bean bean = new Bean();
-        assertEquals("{\"map\":{\"0\":\"Test\",\"null\":-1,\"-9223372036854775808\":\"-9223372036854775808\",\"9223372036854775807\":\"9223372036854775807\",\"2020\":2021,\"2022\":2023}}", JSON.toJSONString(bean, JSONWriter.Feature.BrowserCompatible));
-        assertEquals("{\"map\":{\"0\":\"Test\",\"null\":-1,\"-9223372036854775808\":-9223372036854775808,\"9223372036854775807\":9223372036854775807,\"2020\":2021,\"2022\":2023}}", JSON.toJSONString(bean, JSONWriter.Feature.WriteNonStringKeyAsString));
+        JSONAssert.assertEquals("{\"map\":{\"0\":\"Test\",\"null\":-1,\"-9223372036854775808\":\"-9223372036854775808\",\"9223372036854775807\":\"9223372036854775807\",\"2020\":2021,\"2022\":2023}}", JSON.toJSONString(bean, JSONWriter.Feature.BrowserCompatible), true);
+        JSONAssert.assertEquals("{\"map\":{\"0\":\"Test\",\"null\":-1,\"-9223372036854775808\":-9223372036854775808,\"9223372036854775807\":9223372036854775807,\"2020\":2021,\"2022\":2023}}", JSON.toJSONString(bean, JSONWriter.Feature.WriteNonStringKeyAsString), true);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1479.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1479.java
@@ -4,17 +4,17 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 import lombok.Data;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class Issue1479 {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         JSON.register(Gender.class, new ObjectWriter<Object>() {
             @Override
             public void write(JSONWriter writer, Object value, Object fieldName, Type type, long feature) {
@@ -29,7 +29,7 @@ public class Issue1479 {
         Student student = new Student();
         student.setName("张三");
         student.setGender(Gender.MALE);
-        assertEquals("{\"gender\":{\"remark\":\"male\",\"value\":\"M\"},\"name\":\"张三\"}", JSON.toJSONString(student));
+        JSONAssert.assertEquals("{\"gender\":{\"remark\":\"male\",\"value\":\"M\"},\"name\":\"张三\"}", JSON.toJSONString(student), true);
     }
 
     public enum Gender {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1494.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1000/Issue1494.java
@@ -2,29 +2,30 @@ package com.alibaba.fastjson2.issues_1000;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONWriter;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue1494 {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         JSONWriter.Feature[] FASTJSON_DEFAULT_WRITER_FEATURES = {
                 JSONWriter.Feature.BrowserCompatible, JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.WriteNullListAsEmpty, JSONWriter.Feature.WriteNullBooleanAsFalse, JSONWriter.Feature.WriteNulls, JSONWriter.Feature.WriteEnumsUsingName, JSONWriter.Feature.WritePairAsJavaBean, JSONWriter.Feature.IgnoreErrorGetter, JSONWriter.Feature.WriteBigDecimalAsPlain, JSONWriter.Feature.LargeObject
         };
 
-        Map<String, Object> map = new HashMap<>();
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
         map.put("tag", "TAG1.cpu");
         map.put("qos", 0);
         map.put("time", 1684394501624L);
         map.put("value", new BigDecimal(String.format("%.2e", 3.74e4)));
 
-        String expected = "{\"qos\":0,\"tag\":\"TAG1.cpu\",\"time\":1684394501624,\"value\":37400}";
-        assertEquals(expected, JSON.toJSONString(map, FASTJSON_DEFAULT_WRITER_FEATURES));
+        String expected = "{\"tag\":\"TAG1.cpu\",\"qos\":0,\"time\":1684394501624,\"value\":37400}";
+        JSONAssert.assertEquals(expected, JSON.toJSONString(map, FASTJSON_DEFAULT_WRITER_FEATURES), false);
         assertEquals(expected, new String(JSON.toJSONBytes(map, FASTJSON_DEFAULT_WRITER_FEATURES)));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1700/Issue1745.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1700/Issue1745.java
@@ -4,13 +4,15 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONReader;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Issue1745 {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         String str = "{\n" +
                 "    \"features\": [\n" +
                 "        {\n" +
@@ -39,7 +41,7 @@ public class Issue1745 {
 
         JSONObject object = JSON.parseObject(str, features);
         JSONArray jsonArray = object.getJSONArray("features");
-        assertEquals("[{\"maxFillRatio\":{\"ref\":\"不引用\",\"original\":100},\"minFillRatio\":{\"ref\":\"不引用\",\"original\":0}}]", jsonArray.toJSONString());
+        JSONAssert.assertEquals("[{\"maxFillRatio\":{\"ref\":\"不引用\",\"original\":100},\"minFillRatio\":{\"ref\":\"不引用\",\"original\":0}}]", jsonArray.toJSONString(), true);
         assertEquals(1, jsonArray.size());
         assertEquals(100, jsonArray.getJSONObject(0).getJSONObject("maxFillRatio").getIntValue("original"));
         assertEquals(0, jsonArray.getJSONObject(0).getJSONObject("minFillRatio").getIntValue("original"));

--- a/core/src/test/java/com/alibaba/fastjson2/jackson_support/JsonIncludeTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/jackson_support/JsonIncludeTest.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson2.jackson_support;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,7 +27,7 @@ public class JsonIncludeTest {
         Bean1 bean = new Bean1();
         bean.id = 101;
         String str = new ObjectMapper().writeValueAsString(bean);
-        assertEquals("{\"id\":101,\"name\":null}", str);
+        JSONAssert.assertEquals("{\"id\":101,\"name\":null}", str, true);
     }
 
     @JsonInclude

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/geo/FeatureCollectionTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/geo/FeatureCollectionTest.java
@@ -3,13 +3,15 @@ package com.alibaba.fastjson2.v1issues.geo;
 import com.alibaba.fastjson.support.geo.FeatureCollection;
 import com.alibaba.fastjson.support.geo.Geometry;
 import com.alibaba.fastjson2.JSON;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FeatureCollectionTest {
     @Test
-    public void test_geo() {
+    public void test_geo() throws JSONException {
         String str = "{\n" +
                 "    \"type\": \"FeatureCollection\",\n" +
                 "    \"features\": [{\n" +
@@ -62,9 +64,9 @@ public class FeatureCollectionTest {
         Geometry geometry = JSON.parseObject(str, Geometry.class);
         assertEquals(FeatureCollection.class, geometry.getClass());
 
-        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry));
+        JSONAssert.assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry), true);
 
         String str2 = JSON.toJSONString(geometry);
-        assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)));
+        JSONAssert.assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)), true);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_1100/Issue1177_2.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_1100/Issue1177_2.java
@@ -4,10 +4,9 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONPath;
 import com.alibaba.fastjson2.TypeReference;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by wenshao on 05/05/2017.
@@ -22,7 +21,7 @@ public class Issue1177_2 {
         String jsonpath = "$..x";
         String value = "y2";
         JSONPath.set(jsonObject, jsonpath, value);
-        assertEquals("{\"a\":{\"x\":\"y2\"},\"b\":{\"x\":\"y2\"}}", JSON.toJSONString(jsonObject));
+        JSONAssert.assertEquals("{\"a\":{\"x\":\"y2\"},\"b\":{\"x\":\"y2\"}}", JSON.toJSONString(jsonObject), true);
     }
 
     public static class Model {

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_2100/Issue2182.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_2100/Issue2182.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.JSON;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,11 +19,11 @@ public class Issue2182 {
         multimap.put("user", "user.delete");
 
         String json = JSON.toJSONString(multimap);
-        assertEquals("{\"admin\":[\"admin.create\",\"admin.update\",\"admin.delete\"],\"user\":[\"user.create\",\"user.delete\"]}", json);
+        JSONAssert.assertEquals("{\"admin\":[\"admin.create\",\"admin.update\",\"admin.delete\"],\"user\":[\"user.create\",\"user.delete\"]}", json, true);
 
         ArrayListMultimap multimap1 = JSON.parseObject(json, ArrayListMultimap.class);
 
         assertEquals(multimap.size(), multimap1.size());
-        assertEquals(json, JSON.toJSONString(multimap1));
+        JSONAssert.assertEquals(json, JSON.toJSONString(multimap1), true);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_2400/Issue2430.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_2400/Issue2430.java
@@ -2,13 +2,13 @@ package com.alibaba.fastjson2.v1issues.issue_2400;
 
 import com.alibaba.fastjson2.JSON;
 import com.google.common.collect.ArrayListMultimap;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class Issue2430 {
     @Test
-    public void testForIssue() {
+    public void testForIssue() throws JSONException {
         ArrayListMultimap<String, String> multimap = ArrayListMultimap.create();
         multimap.put("a", "1");
         multimap.put("a", "2");
@@ -19,15 +19,15 @@ public class Issue2430 {
         vo.setMap(multimap);
         vo.setName("zhangsan");
 
-        assertEquals("{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}",
-                JSON.toJSONString(vo));
+        JSONAssert.assertEquals("{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}",
+                JSON.toJSONString(vo), true);
     }
 
     @Test
-    public void testForIssue2() {
+    public void testForIssue2() throws JSONException {
         String jsonString = "{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}";
         VO vo = JSON.parseObject(jsonString, VO.class);
-        assertEquals("{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}", JSON.toJSONString(vo));
+        JSONAssert.assertEquals("{\"map\":{\"a\":[\"1\",\"2\",\"3\"],\"b\":[\"1\"]},\"name\":\"zhangsan\"}", JSON.toJSONString(vo), true);
     }
 
     public static class VO {

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_3800/Issue3824.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_3800/Issue3824.java
@@ -2,18 +2,18 @@ package com.alibaba.fastjson2.v1issues.issue_3800;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class Issue3824 {
     @Test
-    public void test_for_issue3824() {
+    public void test_for_issue3824() throws JSONException {
         Map<String, Object> result = new HashMap<>();
         XX a = new XX();
         a.a = 100;
@@ -25,9 +25,9 @@ public class Issue3824 {
         result.put("a.b.c", x);
         result.put("x", a);
         String s = JSON.toJSONString(result);
-        assertEquals("{\"a.b.c\":{\"y\":{\"2_wdk\":[{\"a\":100}]}},\"x\":{\"a\":100}}", s);
+        JSONAssert.assertEquals("{\"a.b.c\":{\"y\":{\"2_wdk\":[{\"a\":100}]}},\"x\":{\"a\":100}}", s, true);
         JSONObject revert = JSON.parseObject(s);
-        assertEquals("{\"a.b.c\":{\"y\":{\"2_wdk\":[{\"a\":100}]}},\"x\":{\"a\":100}}", JSON.toJSONString(revert));
+        JSONAssert.assertEquals("{\"a.b.c\":{\"y\":{\"2_wdk\":[{\"a\":100}]}},\"x\":{\"a\":100}}", JSON.toJSONString(revert), true);
     }
 
     public static class XX {

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_4000/Issue4008.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_4000/Issue4008.java
@@ -1,18 +1,18 @@
 package com.alibaba.fastjson2.v1issues.issue_4000;
 
 import com.alibaba.fastjson2.JSON;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class Issue4008 {
     @Test
-    public void test_for_issue4008() {
+    public void test_for_issue4008() throws JSONException {
         Map<String, String> studentMap = new HashMap<>();
         studentMap.put("name", "jerry");
         studentMap.put("sex", "male");
@@ -22,6 +22,6 @@ public class Issue4008 {
         Map<String, List<Map<String, Map<String, String>>>> schoolMap = new HashMap<>();
         schoolMap.put("class", Arrays.asList(classMap));
         String fastJSON = JSON.toJSONString(schoolMap);
-        assertEquals("{\"class\":[{\"student2\":{\"sex\":\"male\",\"name\":\"jerry\"},\"student1\":{\"sex\":\"male\",\"name\":\"jerry\"}}]}", fastJSON);
+        JSONAssert.assertEquals("{\"class\":[{\"student2\":{\"sex\":\"male\",\"name\":\"jerry\"},\"student1\":{\"sex\":\"male\",\"name\":\"jerry\"}}]}", fastJSON, true);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterSetTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterSetTest.java
@@ -3,7 +3,7 @@ package com.alibaba.fastjson2.writer;
 import com.alibaba.fastjson2.JSON;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,10 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class ObjectWriterSetTest {
     @Test
     public void testJsonbSet() {
-        Set<Integer> set = new HashSet<Integer>();
+        Set<Integer> set = new LinkedHashSet<Integer>();
         set.add(1);
         set.add(null);
         String str = JSON.toJSONString(set);
-        assertEquals(str, "[null,1]");
+        assertEquals(str, "[1,null]");
     }
 }

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -171,6 +171,12 @@
             <version>1.18.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extension/src/test/java/com/alibaba/fastjson2/geo/FeatureCollectionTest.java
+++ b/extension/src/test/java/com/alibaba/fastjson2/geo/FeatureCollectionTest.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.support.geo.FeatureCollection;
 import com.alibaba.fastjson2.support.geo.Geometry;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -62,9 +63,9 @@ public class FeatureCollectionTest {
         Geometry geometry = JSON.parseObject(str, Geometry.class);
         assertEquals(FeatureCollection.class, geometry.getClass());
 
-        assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry));
+        JSONAssert.assertEquals("{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Point\",\"coordinates\":[102.0,0.5]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"0.0\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[102.0,0.0],[103.0,1.0],[104.0,0.0],[105.0,1.0]]}},{\"type\":\"Feature\",\"properties\":{\"prop1\":\"{\\\"this\\\":\\\"that\\\"}\",\"prop0\":\"value0\"},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]]]}}]}", JSON.toJSONString(geometry), true);
 
         String str2 = JSON.toJSONString(geometry);
-        assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)));
+        JSONAssert.assertEquals(str2, JSON.toJSONString(JSON.parseObject(str2, Geometry.class)), true);
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aims to fix all flaky tests captured in https://github.com/alibaba/fastjson2/issues/2055.

### Summary of your change

- As elaborated in the mentioned issue, 19 tests in `core` and 1 test in `extension` have been detected as flaky using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.
- Out of the 20 detected flaky tests, 18 off them are showing flaky behaviour owing to the comparison of a static JSON with a JSON object. This comparison expects the JSON object to hold the elements in the exact order like the static JSON.
- In order to carry out the comparison by taking both order of elements and actual presence of elements into account, we can use the `jsonAssert` function.
- I have added the required dependency to both modules for leveraging jsonAssert in the affected tests.
- For `com.alibaba.fastjson2.issues_1000.Issue1494#test`, we can switch `map` to leverage a `LinkedHashMap` which helps to preserve the order of elements in it. The previous `HashMap` does not preserve the order of elements.
- On a similar note, for `com.alibaba.fastjson2.writer.ObjectWriterSetTest#testJsonbSet`, we can switch `set` from `HashSet` to `LinkedHashSet` as the former is not expected to retain the exact order of elements.

#### Please indicate you've done the following:

- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
