### PR TITLE
fix @JSONCreator not work in fastjson2

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -1286,6 +1286,7 @@ public class ObjectReaderBaseModule
 
             switch (annotationType.getName()) {
                 case "com.alibaba.fastjson.annotation.JSONCreator":
+                case "com.alibaba.fastjson2.annotation.JSONCreator":
                     creatorMethod = true;
                     BeanUtils.annotationMethods(annotationType, m1 -> {
                         try {


### PR DESCRIPTION
在查找类的构造函数时，如果使用@JSONCreator标记,判断的是com.alibaba.fastjson.annotation.JSONCreator, 即v1的类名。应当使用v2的类名判断。

