### PR TITLE
fix FieldReader features missing

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReader.java
@@ -453,10 +453,7 @@ public abstract class FieldReader<T>
             } else {
                 if (autoCast) {
                     String fieldValueJSONString = JSON.toJSONString(fieldValue);
-                    JSONReader.Context readContext = JSONFactory.createReadContext();
-                    if ((features & JSONReader.Feature.SupportSmartMatch.mask) != 0) {
-                        readContext.config(JSONReader.Feature.SupportSmartMatch);
-                    }
+                    JSONReader.Context readContext = JSONFactory.createReadContext(features);
                     try (JSONReader jsonReader = JSONReader.of(fieldValueJSONString, readContext)) {
                         ObjectReader fieldObjectReader = getObjectReader(jsonReader);
                         typedFieldValue = fieldObjectReader.readObject(jsonReader, null, fieldName, features);


### PR DESCRIPTION
### What this PR does / why we need it?
for issue #2114 
fix fearues not working very well
### Summary of your change
com.alibaba.fastjson2.reader.FieldReader#acceptAny:456
`JSONReader.Context readContext = JSONFactory.createReadContext();
                    if ((features & JSONReader.Feature.SupportSmartMatch.mask) != 0) {
                        readContext.config(JSONReader.Feature.SupportSmartMatch);
                    }`
->
`JSONReader.Context readContext = JSONFactory.createReadContext(features);`
#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.