### PR TITLE
fix TypeReference NullPointerException

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
@@ -491,7 +491,8 @@ public abstract class JSON
 
     @SuppressWarnings("unchecked")
     public static <T> T parseObject(String str, TypeReference<T> typeReference, Feature... features) {
-        return (T) parseObject(str, typeReference.getType(), features);
+        Type type = typeReference != null ? typeReference.getType() : Object.class;
+        return (T) parseObject(str, type, features);
     }
 
     public static <T> T parseObject(String input, Type clazz, int featureValues, Feature... features) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -253,6 +253,9 @@ public class JSONObject
 
     public <T> T getObject(String key, TypeReference typeReference) {
         Object obj = map.get(key);
+        if (obj == null) {
+            return null;
+        }
         if (typeReference == null) {
             return (T) obj;
         }


### PR DESCRIPTION
While I am in the process of using fastjson2 to maintain compatibility with fastjson1, I have encountered a NullPointerException. I believe it should have null-checking logic, similar to other overloaded methods, as follows:

case1:
`JSONObject j = new JSONObject();`
`String key = null;`
`j.getObject(key, new TypeReference<String>(){});`    -> NullPointerException
// The key here could be empty, it should perform null checks like other overloaded methods.


case2:
`TypeReference<String> typeReference = null;`
`JSON.parseObject("key1", typeReference);`    -> NullPointerException
// The typeReference here could be empty, it should perform null checks like the toJavaObject method.

