### PR TITLE
[fix] 修复 fastjson2 在反序列化列表对象存在引用关系时，存在数据数组越界或者数据丢失的问题

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -451,7 +451,7 @@ public abstract class JSONReader
                         if (index == list.size()) {
                             list.add(fieldValue);
                         } else {
-                            list.set(index, fieldValue);
+                            list.add(index, fieldValue);
                         }
                         continue;
                     }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -451,7 +451,11 @@ public abstract class JSONReader
                         if (index == list.size()) {
                             list.add(fieldValue);
                         } else {
-                            list.add(index, fieldValue);
+                            if (index < list.size() && list.get(index) == null) {
+                                list.set(index, fieldValue);
+                            } else {
+                                list.add(index, fieldValue);
+                            }
                         }
                         continue;
                     }


### PR DESCRIPTION
### What this PR does / why we need it?

#2148 fastjson2 在反序列化列表对象存在引用关系时，存在数据数组越界或者数据丢失的问题。 

### Summary of your change



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
