### PR TITLE
Fix identified Flaky test in core module

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue507.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue507.java
@@ -12,19 +12,20 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue507 {
     @Test
-    public void test() {
+    public void test() throws JSONException {
         Map<Long, String> map = new HashMap<>();
         map.put(1L, "张三");
         map.put(2L, "张四");
 
         String str = JSON.toJSONString(map, JSONWriter.Feature.WriteClassName);
-        assertEquals("{\"@type\":\"java.util.HashMap\",1L:\"张三\",2L:\"张四\"}", str);
+        JSONAssert.assertEquals("{\"@type\":\"java.util.HashMap\",1L:\"张三\",2L:\"张四\"}", str, true);
 
         Map map2 = (Map) JSON.parseObject(str, HashMap.class);
-        assertEquals(1L, map2.keySet().iterator().next());
+        assertTrue(map2.containsKey(1L));
         assertEquals("张三", map2.get(1L));
         assertEquals("张四", map2.get(2L));
     }


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the flaky test identifies in https://github.com/alibaba/fastjson2/issues/2168
- It is written on top of the flaky test missed by https://github.com/alibaba/fastjson2/pull/2056

### Summary of your change
1. One of the tests identified and explained in the issue was flaky, as determined by the NonDex tool [NonDex](https://github.com/TestingResearchIllinois/NonDex)
2. The flaky behaviour arises due to two things:
2.a: Comparison of static JSON with JSON object, which expects the Object to hold the same order as static JSON
2.b: Comparison of static value like `1L` to iterative keys which do not hold the same order of keys everytime.

To fix:
2.a: In order to carry out the comparison by taking both order of elements and actual presence of elements into account, we can use the jsonAssert function.
2.b: We can simply use `assertTrue` with the method `.containsKey()` to check if the key `1L` exists or not

- 

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
