### PR TITLE
method-name startsWith 'set' have higher priority than method-name with non-startsWith 'set',for issue #2230

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReader.java
@@ -253,16 +253,17 @@ public abstract class FieldReader<T>
         if (this.method != null && o.method != null) {
             Class<?> thisDeclaringClass = this.method.getDeclaringClass();
             Class<?> otherDeclaringClass = o.method.getDeclaringClass();
-
-            for (Class s = thisDeclaringClass.getSuperclass(); s != null && s != Object.class; s = s.getSuperclass()) {
-                if (s == otherDeclaringClass) {
-                    return -1;
+            //declaring class compare
+            if (thisDeclaringClass != otherDeclaringClass) {
+                for (Class s = thisDeclaringClass.getSuperclass(); s != null && s != Object.class; s = s.getSuperclass()) {
+                    if (s == otherDeclaringClass) {
+                        return -1;
+                    }
                 }
-            }
-
-            for (Class s = otherDeclaringClass.getSuperclass(); s != null && s != Object.class; s = s.getSuperclass()) {
-                if (s == thisDeclaringClass) {
-                    return 1;
+                for (Class s = otherDeclaringClass.getSuperclass(); s != null && s != Object.class; s = s.getSuperclass()) {
+                    if (s == thisDeclaringClass) {
+                        return 1;
+                    }
                 }
             }
 
@@ -286,16 +287,12 @@ public abstract class FieldReader<T>
                     if (otherParamType.isEnum() && (thisParamType == Integer.class || thisParamType == int.class)) {
                         return -1;
                     }
-
+                    //JSONField annotation priority over non JSONField annotation
                     JSONField thisAnnotation = BeanUtils.findAnnotation(this.method, JSONField.class);
                     JSONField otherAnnotation = BeanUtils.findAnnotation(o.method, JSONField.class);
-
-                    if (thisAnnotation != null && otherAnnotation == null) {
-                        return -1;
-                    }
-
-                    if (thisAnnotation == null && otherAnnotation != null) {
-                        return 1;
+                    boolean thisAnnotatedWithJsonFiled = thisAnnotation != null;
+                    if (thisAnnotatedWithJsonFiled == (otherAnnotation == null)) {
+                        return thisAnnotatedWithJsonFiled ? -1 : 1;
                     }
                 }
             }
@@ -303,13 +300,17 @@ public abstract class FieldReader<T>
             String thisMethodName = this.method.getName();
             String otherMethodName = o.method.getName();
             if (!thisMethodName.equals(otherMethodName)) {
+                //setter priority over non setter
+                boolean thisMethodNameSetStart = thisMethodName.startsWith("set");
+                if (thisMethodNameSetStart != otherMethodName.startsWith("set")) {
+                    return thisMethodNameSetStart ? -1 : 1;
+                }
+                //different field name priority over same field name
                 String thisName = BeanUtils.setterName(thisMethodName, null);
                 String otherName = BeanUtils.setterName(otherMethodName, null);
-                if (this.fieldName.equals(thisName) && !o.fieldName.equals(otherName)) {
-                    return 1;
-                }
-                if (o.fieldName.equals(otherName) && !this.fieldName.equals(thisName)) {
-                    return -1;
+                boolean thisFieldNameEquals = this.fieldName.equals(thisName);
+                if (thisFieldNameEquals != o.fieldName.equals(otherName)) {
+                    return thisFieldNameEquals ? 1 : -1;
                 }
             }
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2230.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2230.java
@@ -1,0 +1,52 @@
+package com.alibaba.fastjson2.issues_2200;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * @author 张治保
+ * @since 2024/2/5
+ */
+public class Issue2230 {
+    @Test
+    void  test(){
+        JSONObject dfDtoJson = new JSONObject();
+        dfDtoJson.put(
+                "componentList",
+                new JSONArray().fluentAdd(
+                        new JSONObject().fluentPut(
+                                "props",
+                                new JSONObject()
+                                        .fluentPut("compTypeName", "test11")
+                                        .fluentPut("name", "test22")
+                        )
+                )
+        );
+        DynFormDto newDfDto = dfDtoJson.toJavaObject(DynFormDto.class);
+        System.out.println(newDfDto.getComponentList().get(0).getProps());
+    }
+    @Data
+    static class DynFormDto {
+        private List<DynFormComponentDto> componentList;
+        private String notes;
+    }
+    @Data
+    static class DynFormComponentDto implements Serializable {
+        private JSONObject props; // 组件完整配置
+        // 这个方法会导致props字段反序列化结果出现{"h":{***}}结构
+        public DynFormComponentDto props(IFormComponent comp) {
+            this.props = (JSONObject) JSONObject.from(comp, JSONWriter.Feature.FieldBased);
+            return this;
+        }
+    }
+    interface  IFormComponent {
+        String getCompTypeName();
+        String getName();
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2230.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2230.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONWriter;
 import lombok.Data;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
@@ -15,21 +16,21 @@ import java.util.List;
  */
 public class Issue2230 {
     @Test
-    void  test(){
+    void test() {
         JSONObject dfDtoJson = new JSONObject();
+        JSONObject value = new JSONObject()
+                .fluentPut("compTypeName", "test11")
+                .fluentPut("name", "test22");
         dfDtoJson.put(
                 "componentList",
                 new JSONArray().fluentAdd(
-                        new JSONObject().fluentPut(
-                                "props",
-                                new JSONObject()
-                                        .fluentPut("compTypeName", "test11")
-                                        .fluentPut("name", "test22")
-                        )
+                        new JSONObject()
+                                .fluentPut("props", value)
                 )
         );
         DynFormDto newDfDto = dfDtoJson.toJavaObject(DynFormDto.class);
-        System.out.println(newDfDto.getComponentList().get(0).getProps());
+        JSONObject props = newDfDto.getComponentList().get(0).getProps();
+        Assertions.assertEquals(value, props);
     }
     @Data
     static class DynFormDto {
@@ -37,15 +38,17 @@ public class Issue2230 {
         private String notes;
     }
     @Data
-    static class DynFormComponentDto implements Serializable {
+    static class DynFormComponentDto
+            implements Serializable {
         private JSONObject props; // 组件完整配置
         // 这个方法会导致props字段反序列化结果出现{"h":{***}}结构
         public DynFormComponentDto props(IFormComponent comp) {
-            this.props = (JSONObject) JSONObject.from(comp, JSONWriter.Feature.FieldBased);
+            this.props = JSONObject.from(comp, JSONWriter.Feature.FieldBased);
             return this;
         }
     }
-    interface  IFormComponent {
+
+    interface IFormComponent {
         String getCompTypeName();
         String getName();
     }


### PR DESCRIPTION
### What this PR does / why we need it?
method-name startsWith 'set' have higher priority than method-name with non-startsWith 'set',for issue #2230
### Summary of your change
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
