### PR TITLE
fix bug where collection being cast to List when readingReferences, for issue #2302

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -522,6 +522,10 @@ public abstract class JSONReader
     public abstract String readReference();
 
     public boolean readReference(List list, int i) {
+        return readReference((Collection) list, i);
+    }
+
+    public boolean readReference(Collection list, int i) {
         if (!isReference()) {
             return false;
         }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1227,7 +1227,7 @@ final class JSONReaderJSONB
         throw new JSONException("reference not support input " + error(type));
     }
 
-    public boolean readReference(List list, int i) {
+    public boolean readReference(Collection list, int i) {
         if (bytes[offset] != BC_REFERENCE) {
             return false;
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
@@ -97,7 +97,7 @@ public class FieldReaderList<T, V>
                     break;
                 }
 
-                if (jsonReader.readReference((List) list, i)) {
+                if (jsonReader.readReference(list, i)) {
                     continue;
                 }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2300/Issue2302.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2300/Issue2302.java
@@ -1,0 +1,27 @@
+package com.alibaba.fastjson2.issues_2300;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author 张治保
+ * @since 2024/3/8
+ */
+public class Issue2302 {
+    @Test
+    void test() {
+        TestA a = new TestA();
+        a.areaIds.add(1000);
+        String jsonStr = JSON.toJSONString(a);
+        TestA newTest = JSON.parseObject(jsonStr, TestA.class);
+        Assertions.assertEquals(newTest.areaIds, a.areaIds);
+    }
+
+    private static class TestA {
+        public Set<Integer> areaIds = new HashSet<>();
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
fix bug where collection being cast to List when readingReferences, for issue #2302
### Summary of your change
#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
