### PR TITLE
Add a JSONReader.Feature that can convert empty string to null

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -4424,7 +4424,7 @@ public abstract class JSONReader
          *  empty string "" convert to null
          * since 2.0.48
          */
-        EmptyStringToNull(1 << 27);
+        EmptyStringAsNull(1 << 27);
 
         public final long mask;
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -4418,7 +4418,13 @@ public abstract class JSONReader
         /**
          * @since 2.0.42
          */
-        ErrorOnUnknownProperties(1 << 26);
+        ErrorOnUnknownProperties(1 << 26),
+
+        /**
+         *  empty string "" convert to null
+         * since 2.0.48
+         */
+        EmptyStringToNull(1 << 27);
 
         public final long mask;
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
@@ -1541,6 +1541,10 @@ class JSONReaderASCII
             if ((context.features & Feature.TrimString.mask) != 0) {
                 str = str.trim();
             }
+            // empty string to null
+            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                str = null;
+            }
 
             int ch = ++offset == end ? EOI : bytes[offset++];
             while (ch <= ' ' && (1L << ch & SPACE) != 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
@@ -1542,7 +1542,7 @@ class JSONReaderASCII
                 str = str.trim();
             }
             // empty string to null
-            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                 str = null;
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1011,6 +1011,10 @@ final class JSONReaderJSONB
                         if ((context.features & Feature.TrimString.mask) != 0) {
                             str = str.trim();
                         }
+                        // empty string to null
+                        if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                            str = null;
+                        }
                         return str;
                     } else if (STRING_CREATOR_JDK11 != null) {
                         byte[] chars = new byte[strlen];
@@ -1021,6 +1025,10 @@ final class JSONReaderJSONB
                         if ((context.features & Feature.TrimString.mask) != 0) {
                             str = str.trim();
                         }
+                        // empty string to null
+                        if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                            str = null;
+                        }
                         return str;
                     }
 
@@ -1029,6 +1037,10 @@ final class JSONReaderJSONB
 
                     if ((context.features & Feature.TrimString.mask) != 0) {
                         str = str.trim();
+                    }
+                    // empty string to null
+                    if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                        str = null;
                     }
                     return str;
                 }
@@ -2993,6 +3005,10 @@ final class JSONReaderJSONB
                 if ((context.features & Feature.TrimString.mask) != 0) {
                     str = str.trim();
                 }
+                // empty string to null
+                if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                    str = null;
+                }
                 return str;
             }
         }
@@ -3033,6 +3049,10 @@ final class JSONReaderJSONB
             if ((context.features & Feature.TrimString.mask) != 0) {
                 str = str.trim();
             }
+            // empty string to null
+            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                str = null;
+            }
             return str;
         }
 
@@ -3068,6 +3088,10 @@ final class JSONReaderJSONB
         if ((context.features & Feature.TrimString.mask) != 0) {
             str = str.trim();
         }
+        // empty string to null
+        if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            str = null;
+        }
 
         return str;
     }
@@ -3093,6 +3117,10 @@ final class JSONReaderJSONB
 
             if ((context.features & Feature.TrimString.mask) != 0) {
                 str = str.trim();
+            }
+            // empty string to null
+            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                str = null;
             }
 
             return str;
@@ -3127,6 +3155,10 @@ final class JSONReaderJSONB
 
             if ((context.features & Feature.TrimString.mask) != 0) {
                 str = str.trim();
+            }
+            // empty string to null
+            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                str = null;
             }
             return str;
         }
@@ -3169,6 +3201,10 @@ final class JSONReaderJSONB
 
                 if ((context.features & Feature.TrimString.mask) != 0) {
                     str = str.trim();
+                }
+                // empty string to null
+                if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                    str = null;
                 }
 
                 return str;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1012,7 +1012,7 @@ final class JSONReaderJSONB
                             str = str.trim();
                         }
                         // empty string to null
-                        if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                        if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                             str = null;
                         }
                         return str;
@@ -1026,7 +1026,7 @@ final class JSONReaderJSONB
                             str = str.trim();
                         }
                         // empty string to null
-                        if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                        if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                             str = null;
                         }
                         return str;
@@ -1039,7 +1039,7 @@ final class JSONReaderJSONB
                         str = str.trim();
                     }
                     // empty string to null
-                    if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                    if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                         str = null;
                     }
                     return str;
@@ -3006,7 +3006,7 @@ final class JSONReaderJSONB
                     str = str.trim();
                 }
                 // empty string to null
-                if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                     str = null;
                 }
                 return str;
@@ -3050,7 +3050,7 @@ final class JSONReaderJSONB
                 str = str.trim();
             }
             // empty string to null
-            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                 str = null;
             }
             return str;
@@ -3089,7 +3089,7 @@ final class JSONReaderJSONB
             str = str.trim();
         }
         // empty string to null
-        if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+        if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
             str = null;
         }
 
@@ -3119,7 +3119,7 @@ final class JSONReaderJSONB
                 str = str.trim();
             }
             // empty string to null
-            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                 str = null;
             }
 
@@ -3157,7 +3157,7 @@ final class JSONReaderJSONB
                 str = str.trim();
             }
             // empty string to null
-            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                 str = null;
             }
             return str;
@@ -3203,7 +3203,7 @@ final class JSONReaderJSONB
                     str = str.trim();
                 }
                 // empty string to null
-                if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                     str = null;
                 }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3514,7 +3514,7 @@ class JSONReaderUTF16
                 str = str.trim();
             }
             // empty string to null
-            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                 str = null;
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3513,6 +3513,10 @@ class JSONReaderUTF16
             if ((context.features & Feature.TrimString.mask) != 0) {
                 str = str.trim();
             }
+            // empty string to null
+            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                str = null;
+            }
 
             int ch = ++offset == end ? EOI : chars[offset++];
             while (ch <= ' ' && (1L << ch & SPACE) != 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -5276,6 +5276,10 @@ class JSONReaderUTF8
             if ((context.features & Feature.TrimString.mask) != 0) {
                 str = str.trim();
             }
+            // empty string to null
+            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+                str = null;
+            }
 
             int ch = ++offset == end ? EOI : bytes[offset++];
             while (ch <= ' ' && (1L << ch & SPACE) != 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -5277,7 +5277,7 @@ class JSONReaderUTF8
                 str = str.trim();
             }
             // empty string to null
-            if (str.isEmpty() && (context.features & Feature.EmptyStringToNull.mask) != 0) {
+            if (str.isEmpty() && (context.features & Feature.EmptyStringAsNull.mask) != 0) {
                 str = null;
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderStringField.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderStringField.java
@@ -10,10 +10,12 @@ import static com.alibaba.fastjson2.util.JDKUtils.UNSAFE;
 class FieldReaderStringField<T>
         extends FieldReaderObjectField<T> {
     final boolean trim;
+    final boolean emptyToNull;
 
     FieldReaderStringField(String fieldName, Class fieldType, int ordinal, long features, String format, String defaultValue, JSONSchema schema, Field field) {
         super(fieldName, fieldType, fieldType, ordinal, features, format, defaultValue, schema, field);
         trim = "trim".equals(format) || (features & JSONReader.Feature.TrimString.mask) != 0;
+        emptyToNull = (features & JSONReader.Feature.EmptyStringToNull.mask) != 0;
     }
 
     @Override
@@ -69,7 +71,10 @@ class FieldReaderStringField<T>
         if (trim && fieldValue != null) {
             fieldValue = fieldValue.trim();
         }
-
+        // empty string to null
+        if (emptyToNull && fieldValue != null && fieldValue.isEmpty()) {
+            fieldValue = null;
+        }
         if (schema != null) {
             schema.assertValidate(fieldValue);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderStringField.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderStringField.java
@@ -15,7 +15,7 @@ class FieldReaderStringField<T>
     FieldReaderStringField(String fieldName, Class fieldType, int ordinal, long features, String format, String defaultValue, JSONSchema schema, Field field) {
         super(fieldName, fieldType, fieldType, ordinal, features, format, defaultValue, schema, field);
         trim = "trim".equals(format) || (features & JSONReader.Feature.TrimString.mask) != 0;
-        emptyToNull = (features & JSONReader.Feature.EmptyStringToNull.mask) != 0;
+        emptyToNull = (features & JSONReader.Feature.EmptyStringAsNull.mask) != 0;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplListStr.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplListStr.java
@@ -182,12 +182,15 @@ public final class ObjectReaderImplListStr
         if (ch == '[') {
             jsonReader.next();
             while (!jsonReader.nextIfArrayEnd()) {
-                list.add(
-                        jsonReader.readString());
+                String str = jsonReader.readString();
+                if (str == null) {
+                    continue;
+                }
+                list.add(str);
             }
         } else if (ch == '"' || ch == '\'' || ch == '{') {
             String str = jsonReader.readString();
-            if (!str.isEmpty()) {
+            if (str != null && !str.isEmpty()) {
                 list.add(str);
             }
         } else {

--- a/core/src/test/java/com/alibaba/fastjson2/features/EmptyStringAsNullTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/features/EmptyStringAsNullTest.java
@@ -12,7 +12,7 @@ import java.util.*;
  * @author 张治保
  * @since 2024/3/13
  */
-public class EmptyStringToNullTest {
+public class EmptyStringAsNullTest {
     @Test
     void testString() {
         String json = "\"\"";
@@ -20,7 +20,7 @@ public class EmptyStringToNullTest {
         String value = JSON.parseObject(json, String.class);
         Assertions.assertEquals("", value);
         //null
-        value = JSON.parseObject(json, String.class, JSONReader.Feature.EmptyStringToNull);
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.EmptyStringAsNull);
         Assertions.assertNull(value);
 
         //reset json
@@ -29,7 +29,7 @@ public class EmptyStringToNullTest {
         value = JSON.parseObject(json, String.class);
         Assertions.assertEquals("  ", value);
         //"  "
-        value = JSON.parseObject(json, String.class, JSONReader.Feature.EmptyStringToNull);
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.EmptyStringAsNull);
         Assertions.assertEquals("  ", value);
 
         //""
@@ -37,7 +37,7 @@ public class EmptyStringToNullTest {
         Assertions.assertEquals("", value);
 
         //null
-        value = JSON.parseObject(json, String.class, JSONReader.Feature.TrimString, JSONReader.Feature.EmptyStringToNull);
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.TrimString, JSONReader.Feature.EmptyStringAsNull);
         Assertions.assertNull(value);
     }
 
@@ -45,7 +45,7 @@ public class EmptyStringToNullTest {
     void testBean() {
         //test String field& map field
         String beanJson = "{\"name\":\"\",\"map\":{\"emptyValue\":\"\"}}";
-        StringBean bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        StringBean bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringAsNull);
         Assertions.assertNotNull(bean);
         Assertions.assertNull(bean.getName());
         Map<String, String> map = bean.getMap();
@@ -55,7 +55,7 @@ public class EmptyStringToNullTest {
         //test list field
         //todo collection 是否需要过滤空值
         beanJson = "{\"list\":[\"emptyValue\",\"\"]}";
-        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringAsNull);
         Assertions.assertNotNull(bean);
         List<String> list = bean.getList();
         Assertions.assertFalse(list == null || list.size() != 2);
@@ -64,7 +64,7 @@ public class EmptyStringToNullTest {
 
         //test set field
         beanJson = "{\"set\":[\"emptyValue\",\"\"]}";
-        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringAsNull);
         Assertions.assertNotNull(bean);
         Set<String> set = bean.getSet();
         Assertions.assertFalse(set == null || set.size() != 1);
@@ -72,7 +72,7 @@ public class EmptyStringToNullTest {
         System.out.println(1);
 
         beanJson = "{\"treeSet\":[\"emptyValue\",\"\"]}";
-        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringAsNull);
 
         Assertions.assertNotNull(bean);
         Set<String> treeSet = bean.getTreeSet();
@@ -86,7 +86,7 @@ public class EmptyStringToNullTest {
         Assertions.assertNull(
                 JSONB.parseObject(
                         new ByteArrayInputStream(jsonbBytes),
-                        new JSONReader.Context(JSONReader.Feature.TrimString, JSONReader.Feature.EmptyStringToNull)
+                        new JSONReader.Context(JSONReader.Feature.TrimString, JSONReader.Feature.EmptyStringAsNull)
                 ).getString("value")
         );
 
@@ -94,7 +94,7 @@ public class EmptyStringToNullTest {
         Assertions.assertNull(
                 JSONB.parseObject(
                         new ByteArrayInputStream(jsonbBytes),
-                        new JSONReader.Context(JSONReader.Feature.EmptyStringToNull)
+                        new JSONReader.Context(JSONReader.Feature.EmptyStringAsNull)
                 ).getString("value")
         );
     }

--- a/core/src/test/java/com/alibaba/fastjson2/features/EmptyStringToNullTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/features/EmptyStringToNullTest.java
@@ -53,7 +53,7 @@ public class EmptyStringToNullTest {
         Assertions.assertNull(map.get("emptyValue"));
 
         //test list field
-        //是否需要过滤空值
+        //todo collection 是否需要过滤空值
         beanJson = "{\"list\":[\"emptyValue\",\"\"]}";
         bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
         Assertions.assertNotNull(bean);

--- a/core/src/test/java/com/alibaba/fastjson2/features/EmptyStringToNullTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/features/EmptyStringToNullTest.java
@@ -1,0 +1,110 @@
+package com.alibaba.fastjson2.features;
+
+import com.alibaba.fastjson2.*;
+import lombok.Data;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.*;
+
+/**
+ * @author 张治保
+ * @since 2024/3/13
+ */
+public class EmptyStringToNullTest {
+    @Test
+    void testString() {
+        String json = "\"\"";
+        //""
+        String value = JSON.parseObject(json, String.class);
+        Assertions.assertEquals("", value);
+        //null
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.EmptyStringToNull);
+        Assertions.assertNull(value);
+
+        //reset json
+        json = "\"  \"";
+        //"  "
+        value = JSON.parseObject(json, String.class);
+        Assertions.assertEquals("  ", value);
+        //"  "
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.EmptyStringToNull);
+        Assertions.assertEquals("  ", value);
+
+        //""
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.TrimString);
+        Assertions.assertEquals("", value);
+
+        //null
+        value = JSON.parseObject(json, String.class, JSONReader.Feature.TrimString, JSONReader.Feature.EmptyStringToNull);
+        Assertions.assertNull(value);
+    }
+
+    @Test
+    void testBean() {
+        //test String field& map field
+        String beanJson = "{\"name\":\"\",\"map\":{\"emptyValue\":\"\"}}";
+        StringBean bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        Assertions.assertNotNull(bean);
+        Assertions.assertNull(bean.getName());
+        Map<String, String> map = bean.getMap();
+        Assertions.assertFalse(map == null || map.isEmpty());
+        Assertions.assertNull(map.get("emptyValue"));
+
+        //test list field
+        //是否需要过滤空值
+        beanJson = "{\"list\":[\"emptyValue\",\"\"]}";
+        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        Assertions.assertNotNull(bean);
+        List<String> list = bean.getList();
+        Assertions.assertFalse(list == null || list.size() != 2);
+        Assertions.assertEquals("emptyValue", list.get(0));
+        Assertions.assertNull(list.get(1));
+
+        //test set field
+        beanJson = "{\"set\":[\"emptyValue\",\"\"]}";
+        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+        Assertions.assertNotNull(bean);
+        Set<String> set = bean.getSet();
+        Assertions.assertFalse(set == null || set.size() != 1);
+        Assertions.assertTrue(set.contains("emptyValue"));
+        System.out.println(1);
+
+        beanJson = "{\"treeSet\":[\"emptyValue\",\"\"]}";
+        bean = JSON.parseObject(beanJson, StringBean.class, JSONReader.Feature.EmptyStringToNull);
+
+        Assertions.assertNotNull(bean);
+        Set<String> treeSet = bean.getTreeSet();
+        Assertions.assertFalse(treeSet == null || treeSet.size() != 1);
+        Assertions.assertTrue(treeSet.contains("emptyValue"));
+    }
+
+    @Test
+    void testJSONB() {
+        byte[] jsonbBytes = JSONObject.of("value", "   ").toJSONBBytes();
+        Assertions.assertNull(
+                JSONB.parseObject(
+                        new ByteArrayInputStream(jsonbBytes),
+                        new JSONReader.Context(JSONReader.Feature.TrimString, JSONReader.Feature.EmptyStringToNull)
+                ).getString("value")
+        );
+
+        jsonbBytes = JSONObject.of("value", "").toJSONBBytes();
+        Assertions.assertNull(
+                JSONB.parseObject(
+                        new ByteArrayInputStream(jsonbBytes),
+                        new JSONReader.Context(JSONReader.Feature.EmptyStringToNull)
+                ).getString("value")
+        );
+    }
+
+    @Data
+    private static class StringBean {
+        private String name;
+        private Map<String, String> map;
+        private List<String> list;
+        private Set<String> set;
+        private TreeSet<String> treeSet;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Add a JSONReader.Feature that can convert empty string to null ,for issue #2317 #2060

### Summary of your change
需要注意这里的实现，有些集合不支持 null，而且我觉得直接过滤 null 值也合适，我这里直接过滤了，看下这么做否合适
但是动态字节码的逻辑里并没有过滤null值，不太敢改这一块，
`FieldReaderStringField`
![image](https://github.com/alibaba/fastjson2/assets/100893704/f36abba2-aa76-4b5b-b8e4-9e7c39476fba)

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
