### PR TITLE
fix: MapSortField feature does not behave as expected when serializin…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
@@ -420,7 +420,7 @@ public final class ObjectWriterImplMap
 
         features |= jsonWriter.getFeatures();
         if ((features & JSONWriter.Feature.MapSortField.mask) != 0) {
-            if (!(map instanceof SortedMap) && map.getClass() != LinkedHashMap.class) {
+            if (!(map instanceof SortedMap)) {
                 map = new TreeMap<>(map);
             }
         }
@@ -584,7 +584,7 @@ public final class ObjectWriterImplMap
 
         features |= jsonWriter.getFeatures();
         if ((features & JSONWriter.Feature.MapSortField.mask) != 0) {
-            if (!(map instanceof SortedMap) && map.getClass() != LinkedHashMap.class) {
+            if (!(map instanceof SortedMap)) {
                 map = new TreeMap<>(map);
             }
         }


### PR DESCRIPTION
…g LinkedHashMap.

Closes #2318

### What this PR does / why we need it?
1. 既然feature叫MapSortField，理应对所有Map生效，不然会有歧义。
2. 我不知道什么原因要排除LinkedHashMap的排序特性，但如果不同的Map有不同的排序表现，那用户侧就能通过传入的类型来决定是否排序了，那这个feature又有什么意义
更奇怪的是代码中只对LinkedHashMap不进行排序，为什么LinkedHashMap的子类又支持排序了，就算基于什么原因考虑LinkedHashMap不支持MapSortField，那不是也应该LinkedHashMap的子类也不支持这个feature么？


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
