### PR TITLE
fix the serialization result of hutool's JSONObject is not expected value when FieldBase is enabled

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -356,6 +356,7 @@ public class ObjectWriterProvider
             switch (className) {
                 case "springfox.documentation.spring.web.json.Json":
                 case "cn.hutool.json.JSONArray":
+                case "cn.hutool.json.JSONObject":
                     fieldBased = false;
                     break;
                 default:

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -352,15 +352,16 @@ public class ObjectWriterProvider
                     && superclass != Object.class
                     && "com.google.protobuf.GeneratedMessageV3".equals(superclass.getName())) {
                 fieldBased = false;
-            }
-            switch (className) {
-                case "springfox.documentation.spring.web.json.Json":
-                case "cn.hutool.json.JSONArray":
-                case "cn.hutool.json.JSONObject":
-                    fieldBased = false;
-                    break;
-                default:
-                    break;
+            } else {
+                switch (className) {
+                    case "springfox.documentation.spring.web.json.Json":
+                    case "cn.hutool.json.JSONArray":
+                    case "cn.hutool.json.JSONObject":
+                        fieldBased = false;
+                        break;
+                    default:
+                        break;
+                }
             }
         } else {
             switch (className) {


### PR DESCRIPTION
### What this PR does / why we need it?
Expected :
```json
 {"id":123}
```
Actual   :
```json
{"config":{"checkDuplicate":false,"ignoreCase":false,"ignoreError":false,"ignoreNullValue":true,"stripTrailingZeros":true,"transientSupport":true},"raw":{"id":123}}
```
Fix that the serialization result of hutool JSONObject is not expected value when FieldBase is enabled，issue #1984 

### Summary of your change

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
