### PR TITLE
Fix putIfAbsent redundancy in ObjectReaderCreator.java

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
@@ -3305,11 +3305,11 @@ public class ObjectReaderCreator {
     }
 
     private void putIfAbsent(Map<String, List<FieldReader>> fieldReaders, String fieldName, FieldReader fieldReader, Class objectClass) {
-        if (!fieldReaders.containsKey(fieldName)) {
+        List<FieldReader> origin = fieldReaders.get(fieldName);
+        if (origin == null) {
             fieldReaders.put(fieldName, listOf(fieldReader));
             return;
         }
-        List<FieldReader> origin = fieldReaders.get(fieldName);
         if (!fieldReader.isReadOnly()) {
             FieldReader finalReader = fieldReader;
             FieldReader sameReader = origin.stream().filter(o -> o.sameTo(finalReader)).findAny().orElse(null);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreator.java
@@ -3305,8 +3305,12 @@ public class ObjectReaderCreator {
     }
 
     private void putIfAbsent(Map<String, List<FieldReader>> fieldReaders, String fieldName, FieldReader fieldReader, Class objectClass) {
-        List<FieldReader> origin = fieldReaders.putIfAbsent(fieldName, listOf(fieldReader));
-        if (origin != null && !fieldReader.isReadOnly()) {
+        if (!fieldReaders.containsKey(fieldName)) {
+            fieldReaders.put(fieldName, listOf(fieldReader));
+            return;
+        }
+        List<FieldReader> origin = fieldReaders.get(fieldName);
+        if (!fieldReader.isReadOnly()) {
             FieldReader finalReader = fieldReader;
             FieldReader sameReader = origin.stream().filter(o -> o.sameTo(finalReader)).findAny().orElse(null);
             if (sameReader != null) {


### PR DESCRIPTION
### What this PR does / why we need it?

Hi,

We find that there exist redundancy in method `putIfAbsent` in ObjectReaderCreator.java.  In particular, at line 3308, the `putIfAbsent` method of the Map object `fieldReaders` is invoked to retrieve the value associated with an existing key or create a new key along with a value of type List. The `putIfAbsent` method invokes the `listOf` method (line 3301) to create a new list and add the object to it regardless of whether the key exists or not. However, when the key already exists, the value returned by the `listOf` method is discarded, resulting in memory wastage.

We discovered the above containers redundancy by our tool cinst. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.

### Summary of your change

We avoid the invocation of `listOf` when the key is exist.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
