### PR TITLE
2387: JSONPath eval(string,string) issue fix

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson.parser.ParserConfig;
 import com.alibaba.fastjson.util.TypeUtils;
 import com.alibaba.fastjson2.JSONReader;
 
+
 import java.lang.reflect.Type;
 import java.util.Map;
 
@@ -50,6 +51,11 @@ public class JSONPath {
     public static Object eval(Object rootObject, String path) {
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
         return jsonPath.eval(rootObject);
+    }
+
+    public static Object eval(String rootObject, String path) {
+        com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
+        return jsonPath.extract(rootObject);
     }
 
     public static boolean set(Object rootObject, String path, Object value) {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_2300/Issue2387Test.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_2300/Issue2387Test.java
@@ -1,0 +1,30 @@
+package com.alibaba.fastjson.issue_2300;
+
+import org.junit.jupiter.api.Test;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+import com.alibaba.fastjson.JSONPath;
+
+public class Issue2387Test {
+    @Test
+    public void test_for_issue() throws Exception {
+        String data = "{\"userName\":\"testname\"}";
+        Object userName1 = JSONPath.eval(data, "$.userName");
+        assertEquals(userName1, "testname");
+    }
+    
+    @Test
+    public void test_not_matching() {
+        String data = "{\"userName\":\"testname\"}";
+        Object userName1 = JSONPath.eval(data, "$.userName");
+        assertNotEquals(userName1, "testname1");
+    }
+
+    @Test
+    public void test_null() throws Exception {
+        String data = "{\"userName\":null}";
+        Object userName1 = JSONPath.eval(data, "$.userName");
+        assertNull(userName1);
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
Address the issue:
https://github.com/alibaba/fastjson/issues/4493
https://github.com/alibaba/fastjson2/issues/2387


### Summary of your change
If you are passing string as root object to eval its fail as current eval(Object ..) method can not handle it.
Add new method and using extract method to handle this case.
Also added the test case


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
