### PR TITLE
fix JSONReaderUTF8 nameValue1 for issue 2049

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -3355,7 +3355,7 @@ class JSONReaderUTF8
                                 + (((long) bytes[nameBegin + 10]) << 32)
                                 + (((long) bytes[nameBegin + 9]) << 24)
                                 + (((long) bytes[nameBegin + 8]) << 16)
-                                + (((long) bytes[nameBegin + 8]) << 8)
+                                + (((long) bytes[nameBegin + 7]) << 8)
                                 + ((long) bytes[nameBegin + 6]);
                         break;
                     case 15:

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2409.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2409.java
@@ -1,0 +1,22 @@
+package com.alibaba.fastjson2.issues_2400;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author milabi
+ * @since 2024-04-08
+ */
+public class Issue2409 {
+    @Test
+    void test() {
+        String s = "{\"CABCB9281415LR\":{\"key\":\"CABCB9281415LR\",\"type\":\"分类1\"},\"CABCB9261415LR\":{\"key\":\"CABCB9261415LR\",\"type\":\"分类2\"}}";
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+        JSONObject jsonObject = JSON.parseObject(bytes);
+        Assertions.assertEquals(s, JSON.toJSONString(jsonObject));
+    }
+}


### PR DESCRIPTION
fix(JSONReaderUTF8): 修复name的length=14位时，nameValue1计算

### What this PR does / why we need it?
#2409 


### Summary of your change
map反序列化时，14位的key在对nameValue1计算有误，其第8位计算下标应为7，而不是8


#### Please indicate you've done the following:

- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
