### PR TITLE
fix enable write string key in ObjectWriterImplMapEntry for issue #2430

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
@@ -5,6 +5,9 @@ import com.alibaba.fastjson2.JSONWriter;
 import java.lang.reflect.Type;
 import java.util.Map;
 
+import static com.alibaba.fastjson2.JSONWriter.Feature.BrowserCompatible;
+import static com.alibaba.fastjson2.JSONWriter.Feature.WriteNonStringKeyAsString;
+
 final class ObjectWriterImplMapEntry
         extends ObjectWriterPrimitiveImpl {
     static final ObjectWriterImplMapEntry INSTANCE = new ObjectWriterImplMapEntry();
@@ -18,7 +21,12 @@ final class ObjectWriterImplMapEntry
         }
 
         jsonWriter.startArray(2);
-        jsonWriter.writeAny(entry.getKey());
+        long contextFeatures = jsonWriter.context.getFeatures();
+        if ((contextFeatures & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0) {
+            jsonWriter.writeAny(entry.getKey().toString());
+        } else {
+            jsonWriter.writeAny(entry.getKey());
+        }
         jsonWriter.writeAny(entry.getValue());
     }
 
@@ -31,8 +39,12 @@ final class ObjectWriterImplMapEntry
         }
 
         jsonWriter.startObject();
-        jsonWriter.writeAny(entry.getKey());
-        jsonWriter.writeColon();
+        long contextFeatures = jsonWriter.context.getFeatures();
+        if ((contextFeatures & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0) {
+            jsonWriter.writeAny(entry.getKey().toString());
+        } else {
+            jsonWriter.writeAny(entry.getKey());
+        }        jsonWriter.writeColon();
         jsonWriter.writeAny(entry.getValue());
         jsonWriter.endObject();
     }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
@@ -24,7 +24,7 @@ final class ObjectWriterImplMapEntry
         Object key = entry.getKey();
         long contextFeatures = jsonWriter.context.getFeatures();
         if ((contextFeatures & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0) {
-            jsonWriter.writeAny(key.toString());
+            jsonWriter.writeAny(key == null ? "null" : key.toString());
         } else {
             jsonWriter.writeAny(key);
         }
@@ -43,7 +43,7 @@ final class ObjectWriterImplMapEntry
         Object key = entry.getKey();
         long contextFeatures = jsonWriter.context.getFeatures();
         if ((contextFeatures & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0) {
-            jsonWriter.writeAny(key.toString());
+            jsonWriter.writeAny(key == null ? "null" : key.toString());
         } else {
             jsonWriter.writeAny(key);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
@@ -44,7 +44,8 @@ final class ObjectWriterImplMapEntry
             jsonWriter.writeAny(entry.getKey().toString());
         } else {
             jsonWriter.writeAny(entry.getKey());
-        }        jsonWriter.writeColon();
+        }
+        jsonWriter.writeColon();
         jsonWriter.writeAny(entry.getValue());
         jsonWriter.endObject();
     }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMapEntry.java
@@ -21,11 +21,12 @@ final class ObjectWriterImplMapEntry
         }
 
         jsonWriter.startArray(2);
+        Object key = entry.getKey();
         long contextFeatures = jsonWriter.context.getFeatures();
         if ((contextFeatures & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0) {
-            jsonWriter.writeAny(entry.getKey().toString());
+            jsonWriter.writeAny(key.toString());
         } else {
-            jsonWriter.writeAny(entry.getKey());
+            jsonWriter.writeAny(key);
         }
         jsonWriter.writeAny(entry.getValue());
     }
@@ -39,11 +40,12 @@ final class ObjectWriterImplMapEntry
         }
 
         jsonWriter.startObject();
+        Object key = entry.getKey();
         long contextFeatures = jsonWriter.context.getFeatures();
         if ((contextFeatures & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0) {
-            jsonWriter.writeAny(entry.getKey().toString());
+            jsonWriter.writeAny(key.toString());
         } else {
-            jsonWriter.writeAny(entry.getKey());
+            jsonWriter.writeAny(key);
         }
         jsonWriter.writeColon();
         jsonWriter.writeAny(entry.getValue());

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
@@ -15,9 +15,9 @@ public class Issue2430 {
     void test() {
         Map.Entry<Integer, Integer> entry = new AbstractMap.SimpleEntry<>(1, 2);
         String jsonString = JSON.toJSONString(entry, JSONWriter.Feature.WriteNonStringKeyAsString);
-        assertEquals("{\"1\": 2}", jsonString);
+        assertEquals("{\"1\":2}", jsonString);
         jsonString = JSON.toJSONString(entry, JSONWriter.Feature.BrowserCompatible);
-        assertEquals("{\"1\": 2}", jsonString);
+        assertEquals("{\"1\":2}", jsonString);
         jsonString = JSONB.toJSONString(JSONB.toBytes(entry, JSONWriter.Feature.WriteNonStringKeyAsString));
         assertEquals("[\n" +
                 "\t\"1\",\n" +

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
@@ -15,9 +15,9 @@ public class Issue2430 {
     void test() {
         Map.Entry<Integer, Integer> entry = new AbstractMap.SimpleEntry<>(1, 2);
         String jsonString = JSON.toJSONString(entry, JSONWriter.Feature.WriteNonStringKeyAsString);
-        assertEquals("{\"1\": 2}",jsonString);
+        assertEquals("{\"1\": 2}", jsonString);
         jsonString = JSON.toJSONString(entry, JSONWriter.Feature.BrowserCompatible);
-        assertEquals("{\"1\": 2}",jsonString);
+        assertEquals("{\"1\": 2}", jsonString);
         jsonString = JSONB.toJSONString(JSONB.toBytes(entry, JSONWriter.Feature.WriteNonStringKeyAsString));
         assertEquals("[\n" +
                 "\t\"1\",\n" +

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
@@ -15,18 +15,18 @@ public class Issue2430 {
     void test() {
         Map.Entry<Integer, Integer> entry = new AbstractMap.SimpleEntry<>(1, 2);
         String jsonString = JSON.toJSONString(entry, JSONWriter.Feature.WriteNonStringKeyAsString);
-        assertEquals("{\"1\":2}",jsonString);
+        assertEquals("{\"1\": 2}",jsonString);
         jsonString = JSON.toJSONString(entry, JSONWriter.Feature.BrowserCompatible);
-        assertEquals("{\"1\":2}",jsonString);
+        assertEquals("{\"1\": 2}",jsonString);
         jsonString = JSONB.toJSONString(JSONB.toBytes(entry, JSONWriter.Feature.WriteNonStringKeyAsString));
         assertEquals("[\n" +
                 "\t\"1\",\n" +
                 "\t2\n" +
-                "]",jsonString);
+                "]", jsonString);
         jsonString = JSONB.toJSONString(JSONB.toBytes(entry, JSONWriter.Feature.BrowserCompatible));
         assertEquals("[\n" +
                 "\t\"1\",\n" +
                 "\t2\n" +
-                "]",jsonString);
+                "]", jsonString);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2430.java
@@ -1,0 +1,32 @@
+package com.alibaba.fastjson2.issues_2400;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Issue2430 {
+    @Test
+    void test() {
+        Map.Entry<Integer, Integer> entry = new AbstractMap.SimpleEntry<>(1, 2);
+        String jsonString = JSON.toJSONString(entry, JSONWriter.Feature.WriteNonStringKeyAsString);
+        assertEquals("{\"1\":2}",jsonString);
+        jsonString = JSON.toJSONString(entry, JSONWriter.Feature.BrowserCompatible);
+        assertEquals("{\"1\":2}",jsonString);
+        jsonString = JSONB.toJSONString(JSONB.toBytes(entry, JSONWriter.Feature.WriteNonStringKeyAsString));
+        assertEquals("[\n" +
+                "\t\"1\",\n" +
+                "\t2\n" +
+                "]",jsonString);
+        jsonString = JSONB.toJSONString(JSONB.toBytes(entry, JSONWriter.Feature.BrowserCompatible));
+        assertEquals("[\n" +
+                "\t\"1\",\n" +
+                "\t2\n" +
+                "]",jsonString);
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

fix enable write string key in ObjectWriterImplMapEntry

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
