### PR TITLE
2413 fix

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -2022,6 +2022,13 @@ public class JSONObject
     }
 
     /**
+     * See {@link JSON#parseObject} for details
+     */
+    public static JSONObject from(String text) {
+        return JSON.parseObject(text);
+    }
+
+    /**
      * See {@link JSON#toJSON} for details
      */
     public static JSONObject from(Object obj) {


### PR DESCRIPTION
### What this PR does / why we need it?

JSONObject.from(Object obj) 
Currently we have only method which expects type Object and getting class cast exception when we pass string

### Summary of your change

Overloaded method for String argument and invoking JSON.parseObject(text) to return JSONObject


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
