### PR TITLE
fix enable BeanUtils.getterName to support all naming strategies for …

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -1349,6 +1349,20 @@ public abstract class BeanUtils {
                 }
                 return buf.toString();
             }
+            case "UpperCamelCaseWithUnderScores":
+                return upperCamelWith(methodName, prefixLength, '_');
+            case "UpperCamelCaseWithDashes":
+                return upperCamelWith(methodName, prefixLength, '-');
+            case "UpperCamelCaseWithDots":
+                return upperCamelWith(methodName, prefixLength, '.');
+            case "LowerCase":
+                return methodName.substring(prefixLength).toLowerCase();
+            case "LowerCaseWithUnderScores":
+                return underScores(methodName, prefixLength, false);
+            case "LowerCaseWithDashes":
+                return dashes(methodName, prefixLength, false);
+            case "LowerCaseWithDots":
+                return dots(methodName, prefixLength, false);
             default:
                 throw new JSONException("TODO : " + namingStrategy);
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2459.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2459.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson2.issues_2400;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.PropertyNamingStrategy;
+import com.alibaba.fastjson2.filter.NameFilter;
+import com.alibaba.fastjson2.util.BeanUtils;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2459 {
+    @Test
+    public void test() {
+        User user = new User();
+        user.setFirstName("first");
+        user.setLastName("last");
+        List<String> methodNames = Arrays.stream(User.class.getDeclaredMethods()).sequential().filter(m -> m.getName().startsWith("get")).map(s2 -> s2.getName()).collect(Collectors.toList());
+        Arrays.stream(PropertyNamingStrategy.values()).sequential().forEach(s -> assertEquals(getExpected(user, s), getTest(methodNames, s)));
+    }
+
+    private static String getExpected(User user, PropertyNamingStrategy strategy) {
+        String jsonString = JSON.toJSONString(user, NameFilter.of(strategy));
+        return (String) JSON.parseObject(jsonString, Map.class).keySet().stream().sorted().collect(Collectors.joining(","));
+    }
+
+    private static String getTest(List<String> methodNames, PropertyNamingStrategy strategy) {
+        return methodNames.stream().map(m -> BeanUtils.getterName(m, strategy.name())).collect(Collectors.toSet()).stream().sorted().collect(Collectors.joining(","));
+    }
+
+    @Data
+    static class User {
+        private String firstName;
+        private String lastName;
+    }
+}


### PR DESCRIPTION
…issue #2459

### What this PR does / why we need it?

fix enable BeanUtils.getterName to support all naming strategies

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
