### PR TITLE
fix enable BeanUtils.setterName to support all naming strategies for …

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -1159,6 +1159,51 @@ public abstract class BeanUtils {
                 }
                 return new String(chars);
             }
+            case "CamelCase1x": {
+                char[] chars = new char[methodNameLength - prefixLength];
+                methodName.getChars(prefixLength, methodNameLength, chars, 0);
+                char c0 = chars[0];
+                if (c0 >= 'A' && c0 <= 'Z') {
+                    chars[0] = (char) (c0 + 32);
+                }
+                return new String(chars);
+            }
+            case "UpperCamelCaseWithSpaces":
+                return upperCamelWith(methodName, prefixLength, ' ');
+            case "UpperCamelCaseWithUnderScores":
+                return upperCamelWith(methodName, prefixLength, '_');
+            case "UpperCamelCaseWithDashes":
+                return upperCamelWith(methodName, prefixLength, '-');
+            case "UpperCamelCaseWithDots":
+                return upperCamelWith(methodName, prefixLength, '.');
+            case "KebabCase": {
+                StringBuilder buf = new StringBuilder();
+                final int firstIndex = prefixLength;
+
+                for (int i = prefixLength; i < methodName.length(); ++i) {
+                    char ch = methodName.charAt(i);
+                    if (ch >= 'A' && ch <= 'Z') {
+                        ch = (char) (ch + 32);
+                        if (i > firstIndex) {
+                            buf.append('-');
+                        }
+                    }
+                    buf.append(ch);
+                }
+                return buf.toString();
+            }
+            case "UpperCaseWithDashes":
+                return dashes(methodName, prefixLength, true);
+            case "UpperCaseWithDots":
+                return dots(methodName, prefixLength, true);
+            case "LowerCase":
+                return methodName.substring(prefixLength).toLowerCase();
+            case "LowerCaseWithUnderScores":
+                return underScores(methodName, prefixLength, false);
+            case "LowerCaseWithDashes":
+                return dashes(methodName, prefixLength, false);
+            case "LowerCaseWithDots":
+                return dots(methodName, prefixLength, false);
             default:
                 throw new JSONException("TODO : " + namingStrategy);
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2459.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2400/Issue2459.java
@@ -20,8 +20,13 @@ public class Issue2459 {
         User user = new User();
         user.setFirstName("first");
         user.setLastName("last");
-        List<String> methodNames = Arrays.stream(User.class.getDeclaredMethods()).sequential().filter(m -> m.getName().startsWith("get")).map(s2 -> s2.getName()).collect(Collectors.toList());
-        Arrays.stream(PropertyNamingStrategy.values()).sequential().forEach(s -> assertEquals(getExpected(user, s), getTest(methodNames, s)));
+        List<String> getMethodNames = Arrays.stream(User.class.getDeclaredMethods()).sequential().filter(m -> m.getName().startsWith("get")).map(s2 -> s2.getName()).collect(Collectors.toList());
+        List<String> setMethodNames = Arrays.stream(User.class.getDeclaredMethods()).sequential().filter(m -> m.getName().startsWith("set")).map(s2 -> s2.getName()).collect(Collectors.toList());
+        Arrays.stream(PropertyNamingStrategy.values()).sequential().forEach(s -> {
+            String expected = getExpected(user, s);
+            assertEquals(expected, getterTest(getMethodNames, s));
+            assertEquals(expected, setterTest(setMethodNames, s));
+        });
     }
 
     private static String getExpected(User user, PropertyNamingStrategy strategy) {
@@ -29,8 +34,12 @@ public class Issue2459 {
         return (String) JSON.parseObject(jsonString, Map.class).keySet().stream().sorted().collect(Collectors.joining(","));
     }
 
-    private static String getTest(List<String> methodNames, PropertyNamingStrategy strategy) {
+    private static String getterTest(List<String> methodNames, PropertyNamingStrategy strategy) {
         return methodNames.stream().map(m -> BeanUtils.getterName(m, strategy.name())).collect(Collectors.toSet()).stream().sorted().collect(Collectors.joining(","));
+    }
+
+    private static String setterTest(List<String> methodNames, PropertyNamingStrategy strategy) {
+        return methodNames.stream().map(m -> BeanUtils.setterName(m, strategy.name())).collect(Collectors.toSet()).stream().sorted().collect(Collectors.joining(","));
     }
 
     @Data


### PR DESCRIPTION
…issue #2459

### What this PR does / why we need it?

fix enable BeanUtils.setterName to support all naming strategies

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
