### PR TITLE
perf: android proguard rules

### DIFF
--- a/core/src/main/resources/META-INF/proguard/fastjson2.pro
+++ b/core/src/main/resources/META-INF/proguard/fastjson2.pro
@@ -1,0 +1,26 @@
+-keep, allowoptimization, allowobfuscation
+  @com.alibaba.fastjson2.annotation.JSONType class *
+# Keep the fields and methods with @JSONField
+-keepclassmembers, allowobfuscation class * {
+  @com.alibaba.fastjson2.annotation.JSONField <fields>;
+  @com.alibaba.fastjson2.annotation.JSONField <methods>;
+}
+
+# Ignore warning
+-dontwarn java.beans.Transient
+-dontwarn com.alibaba.fastjson.*
+
+# Keep the fields and methods annotated with
+# @JSONField for classes which are referenced
+-if class * {
+  @com.alibaba.fastjson2.annotation.JSONField <fields>;
+}
+-keep, allowobfuscation, allowoptimization class <1>
+-if class * {
+  @com.alibaba.fastjson2.annotation.JSONField <methods>;
+}
+-keep, allowobfuscation, allowoptimization class <1>
+
+# Keep any (anonymous) classes extending TypeReference
+-keep, allowobfuscation class com.alibaba.fastjson2.TypeReference
+-keep, allowobfuscation class * extends com.alibaba.fastjson2.TypeReference


### PR DESCRIPTION
### What this PR does / why we need it?

生成jar包时增加Android混淆规则, 减少用户手动添加规则

### Summary of your change

针对[issues#2466](https://github.com/alibaba/fastjson2/issues/2466)中警告以及`@JSONType`和`@JSONField`注解引用

规则参考: 
[ProGuard Manual: Usage](https://www.guardsquare.com/manual/configuration/usage) 
[gson.pro](https://github.com/google/gson/blob/main/gson/src/main/resources/META-INF/proguard/gson.pro)
[katplus.pro](https://github.com/katplus/katplus/blob/main/kat/src/main/source/kat.pro)


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
