### PR TITLE
fix support Queue for JSONPathSegmentIndex.eval, for issue #2602

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentIndex.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentIndex.java
@@ -70,7 +70,7 @@ final class JSONPathSegmentIndex
             return;
         }
 
-        if ((object instanceof SortedSet || object instanceof LinkedHashSet)
+        if ((object instanceof SortedSet || object instanceof LinkedHashSet || object instanceof Queue)
                 || (index == 0 && object instanceof Collection && ((Collection<?>) object).size() == 1)
         ) {
             Collection collection = (Collection) object;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2602.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2602.java
@@ -1,0 +1,24 @@
+package com.alibaba.fastjson2.issues_2600;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2602 {
+    @Test
+    public void test() {
+        String json = "[{\"a\":998982405},{\"a\":998992165},{\"$ref\":\"$[1]\"}]";
+        ArrayList list = JSON.parseObject(json, new TypeReference<ArrayList>() {
+        }.getType());
+        ConcurrentLinkedQueue queue = JSON.parseObject(json, new TypeReference<ConcurrentLinkedQueue>() {
+        }.getType());
+        assertEquals(list.get(0), queue.poll());
+        assertEquals(list.get(1), queue.poll());
+        assertEquals(list.get(2), queue.poll());
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

fix support Queue for JSONPathSegmentIndex.eval

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
