### PR TITLE
fix replace readInt32Value with readInt64Value for ObjectReaderImplFr…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplFromLong.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplFromLong.java
@@ -21,7 +21,7 @@ public final class ObjectReaderImplFromLong<T>
         }
 
         return creator.apply(
-                jsonReader.readInt32Value()
+                jsonReader.readInt64Value()
         );
     }
 
@@ -32,7 +32,7 @@ public final class ObjectReaderImplFromLong<T>
         }
 
         return creator.apply(
-                jsonReader.readInt32Value()
+                jsonReader.readInt64Value()
         );
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2615.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2615.java
@@ -1,0 +1,16 @@
+package com.alibaba.fastjson2.issues_2600;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2615 {
+    @Test
+    public void test() {
+        AtomicLong atomicLong = JSON.parseObject("8924992445", AtomicLong.class);
+        assertEquals(8924992445L, atomicLong.get());
+    }
+}


### PR DESCRIPTION
…omLong

### What this PR does / why we need it?

fix replace readInt32Value with readInt64Value for ObjectReaderImplFromLong

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
