### PR TITLE
fix getBigDecimal with Boolean, for issue #2745

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -490,6 +490,10 @@ public class JSONArray
             return Integer.parseInt(str);
         }
 
+        if (value instanceof Boolean) {
+            return (boolean) value ? Integer.valueOf(1) : Integer.valueOf(0);
+        }
+
         throw new JSONException("Can not cast '" + value.getClass() + "' to Integer");
     }
 
@@ -766,6 +770,10 @@ public class JSONArray
             }
 
             return new BigInteger(str);
+        }
+
+        if (value instanceof Boolean) {
+            return (boolean) value ? BigInteger.ONE : BigInteger.ZERO;
         }
 
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigInteger");

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -620,6 +620,10 @@ public class JSONObject
             return Integer.parseInt(str);
         }
 
+        if (value instanceof Boolean) {
+            return (boolean) value ? Integer.valueOf(1) : Integer.valueOf(0);
+        }
+
         throw new JSONException("Can not cast '" + value.getClass() + "' to Integer");
     }
 
@@ -976,6 +980,10 @@ public class JSONObject
             }
 
             return new BigInteger(str);
+        }
+
+        if (value instanceof Boolean) {
+            return (boolean) value ? BigInteger.ONE : BigInteger.ZERO;
         }
 
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigInteger");

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2700/Issue2745.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2700/Issue2745.java
@@ -1,7 +1,7 @@
-package com.alibaba.fastjson.issues_compatible;
+package com.alibaba.fastjson2.issues_2700;
 
-import com.alibaba.fastjson.JSONArray;
-import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -265,6 +265,10 @@ public class JSONArray
             return Integer.parseInt(str);
         }
 
+        if (value instanceof Boolean) {
+            return (Boolean) value ? Integer.valueOf(1) : Integer.valueOf(0);
+        }
+
         throw new JSONException("Can not cast '" + value.getClass() + "' to Integer");
     }
 
@@ -652,6 +656,10 @@ public class JSONArray
             }
 
             return new BigInteger(str);
+        }
+
+        if (value instanceof Boolean) {
+            return (Boolean) value ? BigInteger.ONE : BigInteger.ZERO;
         }
 
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigInteger");

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -210,6 +210,10 @@ public class JSONArray
             return toBigDecimal(str);
         }
 
+        if (value instanceof Boolean) {
+            return (Boolean) value ? BigDecimal.ONE : BigDecimal.ZERO;
+        }
+
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigDecimal");
     }
 

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -525,6 +525,10 @@ public class JSONObject
             return Integer.parseInt(str);
         }
 
+        if (value instanceof Boolean) {
+            return (Boolean) value ? Integer.valueOf(1) : Integer.valueOf(0);
+        }
+
         throw new JSONException("Can not cast '" + value.getClass() + "' to Integer");
     }
 
@@ -756,6 +760,10 @@ public class JSONObject
             return toBigDecimal((String) value);
         }
 
+        if (value instanceof Boolean) {
+            return (Boolean) value ? BigDecimal.ONE : BigDecimal.ZERO;
+        }
+
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigDecimal");
     }
 
@@ -787,6 +795,10 @@ public class JSONObject
             }
 
             return new BigInteger(str);
+        }
+
+        if (value instanceof Boolean) {
+            return (Boolean) value ? BigInteger.ONE : BigInteger.ZERO;
         }
 
         throw new JSONException("Can not cast '" + value.getClass() + "' to BigInteger");

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issues_compatible/Issue2745.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issues_compatible/Issue2745.java
@@ -1,0 +1,17 @@
+package com.alibaba.fastjson.issues_compatible;
+
+import com.alibaba.fastjson.JSONArray;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2745 {
+    @Test
+    public void mutatedTest() throws Exception {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(true);
+        assertEquals(BigDecimal.ONE, jsonArray.getBigDecimal(0));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
Improve fastjson-compatible, fix getBigDecimal with Boolean, for issue #2745
support Boolean for getInteger, getBigInteger and getBigDecimal.

### Summary of your change

fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
core/src/main/java/com/alibaba/fastjson2/JSONObject.java
core/src/main/java/com/alibaba/fastjson2/JSONArray.java

support Boolean for getInteger, getBigInteger and getBigDecimal.

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
