### PR TITLE
Fix 2759 and 2640 naming

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -50,12 +50,24 @@ public class JSONPath {
     }
 
     public static Object eval(String rootObject, String path) {
-        return com.alibaba.fastjson2.JSONPath.eval(rootObject, path);
+        Object result = com.alibaba.fastjson2.JSONPath.eval(rootObject, path);
+        if (result instanceof com.alibaba.fastjson2.JSONArray) {
+            result = new com.alibaba.fastjson.JSONArray((com.alibaba.fastjson2.JSONArray) result);
+        } else if (result instanceof com.alibaba.fastjson2.JSONObject) {
+            result = new com.alibaba.fastjson.JSONObject((com.alibaba.fastjson2.JSONObject) result);
+        }
+        return result;
     }
 
     public static Object eval(Object rootObject, String path) {
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
-        return jsonPath.eval(rootObject);
+        Object result = jsonPath.eval(rootObject);
+        if (result instanceof com.alibaba.fastjson2.JSONArray) {
+            result = new com.alibaba.fastjson.JSONArray((com.alibaba.fastjson2.JSONArray) result);
+        } else if (result instanceof com.alibaba.fastjson2.JSONObject) {
+            result = new com.alibaba.fastjson.JSONObject((com.alibaba.fastjson2.JSONObject) result);
+        }
+        return result;
     }
 
     public static boolean set(Object rootObject, String path, Object value) {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue2640.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue2640.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class IssueIssue2640 {
+public class Issue2640 {
     @Test
     public void test() {
         Object val = "#";

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue2748.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue2748.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.v2issues;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2748 {
+    @Test
+    public void test() {
+        User user = JSON.parseObject(str, User.class);
+        JSONArray result = (JSONArray) JSONPath.eval(user, "$.phoneNumbers[?(@.address.city == 'Nara1')]");
+        assertEquals(1, result.size());
+    }
+
+    public static class User {
+        public String firstName;
+        public String lastName;
+        public int age;
+        public List<PhoneNumber> phoneNumbers;
+    }
+
+    public static class Address {
+        public String streetAddress;
+        public String city;
+        public String postalCode;
+    }
+
+    public static class PhoneNumber {
+        public String type;
+        public String number;
+        public Address address;
+    }
+
+    static String str = "{ \"firstName\": \"John\", \"lastName\" : \"doe\", \"age\" : 26, \"address\" : { \"streetAddress\": \"naist street\", \"city\" : \"Nara\", \"postalCode\" : \"630-0192\" }, \"phoneNumbers\": [ { \"type\" : \"iPhone\", \"number\": \"0123-4567-8888\", \"address\" : { \"streetAddress\": \"naist street1\", \"city\" : \"Nara1\", \"postalCode\" : \"630-0192\" } }, { \"type\" : \"home\", \"number\": \"0123-4567-8910\", \"address\" : { \"streetAddress\": \"naist street2\", \"city\" : \"Nara2\", \"postalCode\" : \"630-0192\" } } ] }";
+}

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue2759.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue2759.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson.v2issues;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Issue2759 {
+    @Test
+    public void test1() {
+        String raw = "[[{\"a\":1},{\"a\":2}],[{\"a\":3}]]";
+        assertEquals("{\"a\":2}", ((JSONObject) JSONPath.eval(raw, "$[0][1]")).toJSONString());
+    }
+
+    @Test
+    public void test2() {
+        String testJson2 = "{\"result\":[{\"puid\":\"21025318\"},{\"puid\":\"21482682\"},{\"puid\":\"21025345\"}],\"state\":0}";
+        JSONArray result2 = (JSONArray) JSONPath.eval(testJson2, "$.result[0,2].puid");
+        assertNotNull(result2);
+        assertEquals("[\"21025318\",\"21025345\"]", result2.toJSONString());
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
fix fastjson 1.x jsonpath compatible api return fastjson 2 JSONObject and JSONArrary, for #2759
fix naming for Issue2640 test


### Summary of your change


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
