### PR TITLE
fix adjust readNumber0 for decimal with suffix of B,S or L

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -4070,17 +4070,17 @@ class JSONReaderUTF16
         if (ch == 'L' || ch == 'F' || ch == 'D' || ch == 'B' || ch == 'S') {
             switch (ch) {
                 case 'B':
-                    if (!intOverflow) {
+                    if (!intOverflow && valueType != JSON_TYPE_DEC) {
                         valueType = JSON_TYPE_INT8;
                     }
                     break;
                 case 'S':
-                    if (!intOverflow) {
+                    if (!intOverflow && valueType != JSON_TYPE_DEC) {
                         valueType = JSON_TYPE_INT16;
                     }
                     break;
                 case 'L':
-                    if (offset - start < 19) {
+                    if (offset - start < 19 && valueType != JSON_TYPE_DEC) {
                         valueType = JSON_TYPE_INT64;
                     }
                     break;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -5535,17 +5535,17 @@ class JSONReaderUTF8
         if (ch == 'L' || ch == 'F' || ch == 'D' || ch == 'B' || ch == 'S') {
             switch (ch) {
                 case 'B':
-                    if (!intOverflow) {
+                    if (!intOverflow && valueType != JSON_TYPE_DEC) {
                         valueType = JSON_TYPE_INT8;
                     }
                     break;
                 case 'S':
-                    if (!intOverflow) {
+                    if (!intOverflow && valueType != JSON_TYPE_DEC) {
                         valueType = JSON_TYPE_INT16;
                     }
                     break;
                 case 'L':
-                    if (offset - start < 19) {
+                    if (offset - start < 19 && valueType != JSON_TYPE_DEC) {
                         valueType = JSON_TYPE_INT64;
                     }
                     break;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2700/Issue2769.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2700/Issue2769.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson2.issues_2700;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue2769 {
+    @Test
+    public void testWithSuffixB() {
+        String str = "{\"k1\":123.456,\"k2\":12.34B}";
+        test(JSON.parseObject(str));
+        test(JSON.parseObject(str.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testWithSuffixS() {
+        String str = "{\"k1\":123.456,\"k2\":12.34S}";
+        test(JSON.parseObject(str));
+        test(JSON.parseObject(str.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testWithSuffixL() {
+        String str = "{\"k1\":123.456,\"k2\":12.34L}";
+        test(JSON.parseObject(str));
+        test(JSON.parseObject(str.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private void test(JSONObject jsonObject) {
+        assertEquals((byte) 12, jsonObject.getByte("k2"));
+        assertEquals((short) 12, jsonObject.getShort("k2"));
+        assertEquals(12, jsonObject.getInteger("k2"));
+        assertEquals(12, jsonObject.getLong("k2"));
+        assertEquals(12.34F, jsonObject.getFloat("k2"));
+        assertEquals(12.34, jsonObject.getDouble("k2"));
+    }
+}


### PR DESCRIPTION
… #2769 and #2768

### What this PR does / why we need it?

fix adjust readNumber0 for decimal with suffix of B,S or L

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
