### PR TITLE
JSON Object of method adds dynamic parameters

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -2048,7 +2048,7 @@ public class JSONObject
             throw new JSONException("The value corresponding to the even bit index of kvArray is key and cannot be duplicated");
         }
         List<Object> valueList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 != 0).mapToObj(i -> kvArray[i]).collect(Collectors.toList());
-        JSONObject object = new JSONObject(kvArrayLength / 2);
+        JSONObject object = new JSONObject(kvArrayLength / 4);
         for (int i = 0; i < keyList.size(); i++) {
             object.put(keyList.get(i).toString(), valueList.get(i));
         }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -2018,7 +2018,7 @@ public class JSONObject
         object.put(k5, v5);
         return object;
     }
-    
+
     /**
      * Pack multiple key-value pairs as {@link JSONObject}
      *

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -23,6 +23,8 @@ import java.time.temporal.TemporalAccessor;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.alibaba.fastjson2.JSONWriter.Feature.*;
 import static com.alibaba.fastjson2.util.BeanUtils.getAnnotations;
@@ -2016,6 +2018,46 @@ public class JSONObject
         object.put(k5, v5);
         return object;
     }
+    
+	/**
+	 * Pack multiple key-value pairs as {@link JSONObject}
+	 *
+	 * <pre>
+	 * JSONObject jsonObject = JSONObject.of(Object... kvArray);
+	 * </pre>
+	 *
+	 * @param kvArray key-value
+	 * @since 2.0.53
+	 */
+	public static JSONObject of(Object... kvArray) {
+		if (kvArray == null || kvArray.length <= 0) {
+			throw new JSONException("The kvArray cannot be empty");
+		}
+		int kvArrayLength = kvArray.length;
+		if ((kvArrayLength & 1) == 1) {
+			throw new JSONException("The length of kvArray cannot be odd");
+		}
+		List<Object> keyList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 == 0).mapToObj(i -> kvArray[i])
+				.collect(Collectors.toList());
+		keyList.forEach(key -> {
+			if (key == null || !(key instanceof String)) {
+				throw new JSONException(
+						"The value corresponding to the even bit index of kvArray is key, which cannot be null and must be of type string");
+			}
+		});
+		List<Object> distinctKeyList = keyList.stream().distinct().collect(Collectors.toList());
+		if (keyList.size() != distinctKeyList.size()) {
+			throw new JSONException(
+					"The value corresponding to the even bit index of kvArray is key and cannot be duplicated");
+		}
+		List<Object> valueList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 != 0).mapToObj(i -> kvArray[i])
+				.collect(Collectors.toList());
+		JSONObject object = new JSONObject(kvArrayLength / 2);
+		for (int i = 0; i < keyList.size(); i++) {
+			object.put(keyList.get(i).toString(), valueList.get(i));
+		}
+		return object;
+	}
 
     /**
      * See {@link JSON#parseObject} for details

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -2019,45 +2019,41 @@ public class JSONObject
         return object;
     }
     
-	/**
-	 * Pack multiple key-value pairs as {@link JSONObject}
-	 *
-	 * <pre>
-	 * JSONObject jsonObject = JSONObject.of(Object... kvArray);
-	 * </pre>
-	 *
-	 * @param kvArray key-value
-	 * @since 2.0.53
-	 */
-	public static JSONObject of(Object... kvArray) {
-		if (kvArray == null || kvArray.length <= 0) {
-			throw new JSONException("The kvArray cannot be empty");
-		}
-		int kvArrayLength = kvArray.length;
-		if ((kvArrayLength & 1) == 1) {
-			throw new JSONException("The length of kvArray cannot be odd");
-		}
-		List<Object> keyList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 == 0).mapToObj(i -> kvArray[i])
-				.collect(Collectors.toList());
-		keyList.forEach(key -> {
-			if (key == null || !(key instanceof String)) {
-				throw new JSONException(
-						"The value corresponding to the even bit index of kvArray is key, which cannot be null and must be of type string");
-			}
-		});
-		List<Object> distinctKeyList = keyList.stream().distinct().collect(Collectors.toList());
-		if (keyList.size() != distinctKeyList.size()) {
-			throw new JSONException(
-					"The value corresponding to the even bit index of kvArray is key and cannot be duplicated");
-		}
-		List<Object> valueList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 != 0).mapToObj(i -> kvArray[i])
-				.collect(Collectors.toList());
-		JSONObject object = new JSONObject(kvArrayLength / 2);
-		for (int i = 0; i < keyList.size(); i++) {
-			object.put(keyList.get(i).toString(), valueList.get(i));
-		}
-		return object;
-	}
+    /**
+     * Pack multiple key-value pairs as {@link JSONObject}
+     *
+     * <pre>
+     * JSONObject jsonObject = JSONObject.of(Object... kvArray);
+     * </pre>
+     *
+     * @param kvArray key-value
+     * @since 2.0.53
+     */
+    public static JSONObject of(Object... kvArray) {
+        if (kvArray == null || kvArray.length <= 0) {
+            throw new JSONException("The kvArray cannot be empty");
+        }
+        int kvArrayLength = kvArray.length;
+        if ((kvArrayLength & 1) == 1) {
+            throw new JSONException("The length of kvArray cannot be odd");
+        }
+        List<Object> keyList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 == 0).mapToObj(i -> kvArray[i]).collect(Collectors.toList());
+        keyList.forEach(key -> {
+            if (key == null || !(key instanceof String)) {
+                throw new JSONException("The value corresponding to the even bit index of kvArray is key, which cannot be null and must be of type string");
+            }
+        });
+        List<Object> distinctKeyList = keyList.stream().distinct().collect(Collectors.toList());
+        if (keyList.size() != distinctKeyList.size()) {
+            throw new JSONException("The value corresponding to the even bit index of kvArray is key and cannot be duplicated");
+        }
+        List<Object> valueList = IntStream.range(0, kvArrayLength).filter(i -> i % 2 != 0).mapToObj(i -> kvArray[i]).collect(Collectors.toList());
+        JSONObject object = new JSONObject(kvArrayLength / 2);
+        for (int i = 0; i < keyList.size(); i++) {
+            object.put(keyList.get(i).toString(), valueList.get(i));
+        }
+        return object;
+    }
 
     /**
      * See {@link JSON#parseObject} for details


### PR DESCRIPTION
### What this PR does / why we need it?

At present, the JSONObject of method supports up to 5 pairs of key values, and in development, it is often encountered that there are more than 5 pairs of key values. Therefore, the of method that can pass dynamic parameters has been added to make it more convenient and flexible to use.

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
