### PR TITLE
fix BeanUtils#getEnumValueField, for issue #2682

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -26,6 +26,7 @@ import static com.alibaba.fastjson2.util.JDKUtils.JVM_VERSION;
  * @author Bob Lee
  * @author Jesse Wilson
  * @author Shaojin Wen
+ * @author poo0054
  */
 public abstract class BeanUtils {
     static final Type[] EMPTY_TYPE_ARRAY = new Type[]{};
@@ -797,7 +798,15 @@ public abstract class BeanUtils {
                 if (field != null && isJSONField(field)) {
                     if (valueMember == null) {
                         valueMember = method;
-                    } else if (!valueMember.getName().equals(method.getName())) {
+                    } else if (valueMember.getName().equals(method.getName())) {
+                        // Using Subclasses #2682
+                        if (valueMember instanceof Method) {
+                            Method valueMethod = (Method) valueMember;
+                            if (valueMethod.getReturnType().isAssignableFrom(method.getReturnType())) {
+                                valueMember = method;
+                            }
+                        }
+                    } else {
                         // multi annotation
                         return null;
                     }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2682.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2682.java
@@ -58,21 +58,17 @@ public class Issue2682 {
         public String getName() {
             return name;
         }
-
     }
-
 
     public enum RobotActEnum implements IEnum<String> {
         /**
          * 123啊
          */
         CARTON_SCAN("123啊", "我是123"),
-
         /**
          * 456啊
          */
         PALLET_ON_SHELF("456啊", "我是456"),
-
         /**
          * 789啊
          */
@@ -80,15 +76,12 @@ public class Issue2682 {
         /**
          *147啊
          */
-        GET_PICK_BILL("147啊", "我是147"),
-        ;
-
+        GET_PICK_BILL("147啊", "我是147");
 
         @JSONField(value = true)
         private final String value;
 
         private final String message;
-
 
         RobotActEnum(String value, String message) {
             this.value = value;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2682.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2682.java
@@ -1,14 +1,29 @@
 package com.alibaba.fastjson2.issues_2600;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.annotation.JSONField;
 import com.baomidou.mybatisplus.annotation.EnumValue;
 import com.baomidou.mybatisplus.annotation.IEnum;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import org.junit.jupiter.api.Test;
+import sun.misc.VM;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * @author yanxutao89
+ * @author poo00
+ */
 public class Issue2682 {
     @Test
     public void test() {
@@ -17,9 +32,18 @@ public class Issue2682 {
         assertEquals(BizType.COMMON, vm.getBizType());
     }
 
+    @Test
+    public void test1() throws IOException {
+        String str = "{'bizType':'common','baseType':'123啊'}";
+        VM vm = JSON.parseObject(str, VM.class);
+        assertEquals(RobotActEnum.CARTON_SCAN, vm.getBaseType());
+    }
+
     @Data
     public static class VM {
         private BizType bizType;
+
+        private RobotActEnum baseType;
     }
 
     public enum BizType
@@ -45,6 +69,68 @@ public class Issue2682 {
         }
 
         public static void test123() {
+        }
+    }
+
+
+    public enum RobotActEnum implements IEnum<String> {
+        /**
+         * 123啊
+         */
+        CARTON_SCAN("123啊", "我是123"),
+
+        /**
+         * 456啊
+         */
+        PALLET_ON_SHELF("456啊", "我是456"),
+
+        /**
+         * 789啊
+         */
+        OUTBOUND_BIND_DOCK("789啊", "我是789"),
+        /**
+         *147啊
+         */
+        GET_PICK_BILL("147啊", "我是147"),
+        ;
+
+
+        @JSONField(value = true)
+        private final String value;
+
+        private final String message;
+
+
+        RobotActEnum(String value, String message) {
+            this.value = value;
+            this.message = message;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public RobotActEnum getEnum() {
+            return this;
+        }
+
+        public static String staticMessage(RobotActEnum robotActEnum) {
+            if (null == robotActEnum) {
+                return null;
+            }
+            return robotActEnum.getMessage();
+        }
+
+        public static String staticValue(RobotActEnum robotActEnum) {
+            if (null == robotActEnum) {
+                return null;
+            }
+            return robotActEnum.getValue();
         }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2682.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2682.java
@@ -1,22 +1,13 @@
 package com.alibaba.fastjson2.issues_2600;
 
 import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.annotation.JSONField;
 import com.baomidou.mybatisplus.annotation.EnumValue;
 import com.baomidou.mybatisplus.annotation.IEnum;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import org.junit.jupiter.api.Test;
-import sun.misc.VM;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -68,8 +59,6 @@ public class Issue2682 {
             return name;
         }
 
-        public static void test123() {
-        }
     }
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

修复了 [#2682] 。

我碰见了和 [#2682] 一样的问题

> 产生原因前提

如果继承了 `com.baomidou.mybatisplus.annotation.IEnum<T extends Serializable>` 类，并且需要使用 `IEnum#getValue` 方法或者注解上面添加`@JSONField(value = true)`注解。 

> 步骤解析

json反序列化：执行到 `BeanUtils#getEnumValueField` 方法，里面获取所有的`Method`进行循环,这时候继承了`IEnum`接口会找到俩名称个一样的`Method` 方法。只不过`getReturnType`返回类不同，并在` if (methodName.startsWith("get")) {`分支中没有对同名方法做处理。最后到了 `new ObjectReaderImplEnum ` 方法的时候 ，如下代码

```java
   public ObjectReaderImplEnum(
            Class enumClass,
            Method createMethod,
            Member valueField,
            Enum[] enums,
            Enum[] ordinalEnums,
            long[] enumNameHashCodes
    ) {
 ......
 if (valueField instanceof Field) {
            valueFieldType = ((Field) valueField).getType();
        } else if (valueField instanceof Method) {
            valueFieldType = ((Method) valueField).getReturnType();
        }
```

首先获取了`Serializable`(继承了 IEnum 接口) 。然后在如下代码

```java
   public ObjectReaderImplEnum(
            Class enumClass,
            Method createMethod,
            Member valueField,
            Enum[] enums,
            Enum[] ordinalEnums,
            long[] enumNameHashCodes
    ) {
 ......
 if (valueFieldType == String.class) {
                stringValues = new String[enums.length];
            } else {
                intValues = new long[enums.length];
            }
```
中就会使用 intValues  。在下面解析的时候就会出现bug。

> 复原 

如果使用里面的`BizType`枚举是无法复原该bug，在调用`#.getMethods()`获取所有方法的时候，`String getValue()`在 `Serializable getValue`之前。

我创建了 `com.alibaba.fastjson2.issues_2600.Issue2682#RobotActEnum`枚举，该枚举可以保证`Serializable getValue`在 `String getValue()` 之前，然后触发这个bug。请问一下这个`class`反射获取所有方法的时候顺序是怎样造成的。

> 解决思路

我是在`BeanUtils#getEnumValueField` 中的 `  if (methodName.startsWith("get")) {` 里面 如果发现俩个方法名称完全一样，就认为是`重写`方法,然后使用`isAssignableFrom`确认子类的方法是哪个 (枚举中使用子类)

### Summary of your change

修复 BeanUtils#getEnumValueField 


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
