### PR TITLE
Optimize FastJsonHttpMessageConverter configuration document

### DIFF
--- a/docs/spring_support_cn.md
+++ b/docs/spring_support_cn.md
@@ -87,7 +87,7 @@ symbolTable | JSONB.SymbolTable | JSONB序列化和反序列化的符号表，�
 
 **Package**: `com.alibaba.fastjson2.support.spring.http.converter.FastJsonHttpMessageConverter`
 
-**Example**:
+**Before Spring 5 Example**:
 
 ```java
 
@@ -111,13 +111,40 @@ public class WebMvcConfigurer extends WebMvcConfigurerAdapter {
 }
 ```
 
+从Spring5.0版本开始，`WebMvcConfigurerAdapter` 已被弃用，您可以直接实现`WebMvcConfigurer`接口，而无需使用此适配器。
+
+**After Spring 5 Example**:
+
+```java
+
+@Configuration
+@EnableWebMvc
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+        //自定义配置...
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+        config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
+        config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
+        converter.setFastJsonConfig(config);
+        converter.setDefaultCharset(StandardCharsets.UTF_8);
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.APPLICATION_JSON));
+        converters.add(0, converter);
+    }
+
+}
+```
+
 ## 2.2  Spring Web MVC View
 
 使用 `FastJsonJsonView` 来设置 Spring MVC 默认的视图模型解析器，以提高 `@Controller` `@ResponseBody` `ModelAndView` JSON序列化速度。
 
 **Package**: `com.alibaba.fastjson2.support.spring.webservlet.view.FastJsonJsonView`
 
-**Example**:
+**Before Spring 5 Example**:
 
 ```java
 
@@ -134,6 +161,29 @@ public class WebMvcConfigurer extends WebMvcConfigurerAdapter {
         //fastJsonJsonView.setFastJsonConfig(config);
         registry.enableContentNegotiation(fastJsonJsonView);
     }
+}
+```
+
+从Spring5.0版本开始，`WebMvcConfigurerAdapter` 已被弃用，您可以直接实现`WebMvcConfigurer`接口，而无需使用此适配器。
+
+**After Spring 5 Example**:
+
+```java
+
+@Configuration
+@EnableWebMvc
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void configureViewResolvers(ViewResolverRegistry registry) {
+        FastJsonJsonView fastJsonJsonView = new FastJsonJsonView();
+        //自定义配置...
+        //FastJsonConfig config = new FastJsonConfig();
+        //config.set...
+        //fastJsonJsonView.setFastJsonConfig(config);
+        registry.enableContentNegotiation(fastJsonJsonView);
+    }
+
 }
 ```
 

--- a/docs/spring_support_en.md
+++ b/docs/spring_support_en.md
@@ -88,7 +88,7 @@ and deserialization speed of `@RestController` `@ResponseBody` `@RequestBody` an
 
 **Package**: `com.alibaba.fastjson2.support.spring.http.converter.FastJsonHttpMessageConverter`
 
-**Example**:
+**Before Spring 5 Example**:
 
 ```java
 
@@ -112,6 +112,33 @@ public class WebMvcConfigurer extends WebMvcConfigurerAdapter {
 }
 ```
 
+Starting from Spring 5.0, `WebMvcConfigurerAdapter` has been deprecated, you can directly implement the `WebMvcConfigurer` interface without using this adapter.
+
+**After Spring 5 Example**:
+
+```java
+
+@Configuration
+@EnableWebMvc
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+        FastJsonHttpMessageConverter converter = new FastJsonHttpMessageConverter();
+        //custom configuration...
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+        config.setReaderFeatures(JSONReader.Feature.FieldBased, JSONReader.Feature.SupportArrayToBean);
+        config.setWriterFeatures(JSONWriter.Feature.WriteMapNullValue, JSONWriter.Feature.PrettyFormat);
+        converter.setFastJsonConfig(config);
+        converter.setDefaultCharset(StandardCharsets.UTF_8);
+        converter.setSupportedMediaTypes(Collections.singletonList(MediaType.APPLICATION_JSON));
+        converters.add(0, converter);
+    }
+
+}
+```
+
 ## 2.2  Spring Web MVC View
 
 Use `FastJsonJsonView` to set Spring MVC's default view model resolver to improve the speed
@@ -119,7 +146,7 @@ of `@Controller` `@ResponseBody` `ModelAndView` JSON serialization.
 
 **Package**: `com.alibaba.fastjson2.support.spring.webservlet.view.FastJsonJsonView`
 
-**Example**:
+**Before Spring 5 Example**:
 
 ```java
 
@@ -136,6 +163,28 @@ public class WebMvcConfigurer extends WebMvcConfigurerAdapter {
         //fastJsonJsonView.setFastJsonConfig(config);
         registry.enableContentNegotiation(fastJsonJsonView);
     }
+}
+```
+
+Starting from Spring 5.0, `WebMvcConfigurerAdapter` has been deprecated, you can directly implement the `WebMvcConfigurer` interface without using this adapter.
+**After Spring 5 Example**:
+
+```java
+
+@Configuration
+@EnableWebMvc
+public class CustomWebMvcConfigurer implements WebMvcConfigurer {
+
+    @Override
+    public void configureViewResolvers(ViewResolverRegistry registry) {
+        FastJsonJsonView fastJsonJsonView = new FastJsonJsonView();
+        //custom configuration...
+        //FastJsonConfig config = new FastJsonConfig();
+        //config.set...
+        //fastJsonJsonView.setFastJsonConfig(config);
+        registry.enableContentNegotiation(fastJsonJsonView);
+    }
+
 }
 ```
 


### PR DESCRIPTION
### What this PR does / why we need it?

Starting from Spring 5.0, `WebMvcConfigurerAdapter` has been deprecated. 

This PR adds a direct implementation of the `WebMvcConfigurer` interface configuration method. There is no need to use the WebMvcConfigurerAdapter adapter.
