### PR TITLE
[Feature] add a DisableSingleQuote flag for JsonReader

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -1974,6 +1974,9 @@ public abstract class JSONReader
     }
 
     public void read(Map object, long features) {
+        if (ch== '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if ((ch == '"' || ch == '\'') && !typeRedirect) {
             String str = readString();
             if (str.isEmpty()) {
@@ -4555,7 +4558,12 @@ public abstract class JSONReader
          *
          * @since 2.0.51
          */
-        UseLongForInts(1 << 30);
+        UseLongForInts(1 << 30),
+
+        /**
+         * Feature that disables the support for single quote.
+         */
+        DisableSingleQuote(1 << 31);
 
         public final long mask;
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -1974,7 +1974,7 @@ public abstract class JSONReader
     }
 
     public void read(Map object, long features) {
-        if (ch== '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+        if (ch == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
             throw notSupportName();
         }
         if ((ch == '"' || ch == '\'') && !typeRedirect) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
@@ -107,6 +107,9 @@ class JSONReaderASCII
     public final long readFieldNameHashCode() {
         final byte[] bytes = this.bytes;
         int ch = this.ch;
+        if (ch == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (ch != '"' && ch != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0 && isFirstIdentifier(ch)) {
                 return readFieldNameHashCodeUnquote();
@@ -1015,6 +1018,9 @@ class JSONReaderASCII
     @Override
     public final String readFieldName() {
         final char quote = ch;
+        if (quote == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (quote != '"' && quote != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0 && isFirstIdentifier(quote)) {
                 return readFieldNameUnquote();

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -1109,6 +1109,9 @@ class JSONReaderUTF16
     @Override
     public final long readFieldNameHashCode() {
         final char[] chars = this.chars;
+        if (ch == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (ch != '"' && ch != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0 && isFirstIdentifier(ch)) {
                 return readFieldNameHashCodeUnquote();
@@ -1738,6 +1741,9 @@ class JSONReaderUTF16
     @Override
     public final String readFieldName() {
         final char quote = ch;
+        if (quote == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (quote != '"' && quote != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0 && isFirstIdentifier(quote)) {
                 return readFieldNameUnquote();
@@ -2317,6 +2323,10 @@ class JSONReaderUTF16
     @Override
     public final boolean skipName() {
         char quote = ch;
+        if (quote == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
+
         if (quote != '"' && quote != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0) {
                 readFieldNameHashCodeUnquote();

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -2323,6 +2323,9 @@ class JSONReaderUTF8
     public long readFieldNameHashCode() {
         final byte[] bytes = this.bytes;
         int ch = this.ch;
+        if (ch == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (ch != '"' && ch != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0 && isFirstIdentifier(ch)) {
                 return readFieldNameHashCodeUnquote();
@@ -3127,6 +3130,9 @@ class JSONReaderUTF8
     @Override
     public String readFieldName() {
         final char quote = ch;
+        if (quote == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (quote != '"' && quote != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0 && isFirstIdentifier(quote)) {
                 return readFieldNameUnquote();
@@ -4693,6 +4699,9 @@ class JSONReaderUTF8
     @Override
     public final boolean skipName() {
         char quote = ch;
+        if (quote == '\'' && ((context.features & Feature.DisableSingleQuote.mask) != 0)) {
+            throw notSupportName();
+        }
         if (quote != '"' && quote != '\'') {
             if ((context.features & Feature.AllowUnQuotedFieldNames.mask) != 0) {
                 readFieldNameHashCodeUnquote();

--- a/core/src/test/java/com/alibaba/fastjson2/JSONTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONTest.java
@@ -1209,6 +1209,7 @@ public class JSONTest {
         assertFalse(JSON.isValid("{", JSONReader.Feature.AllowUnQuotedFieldNames));
         assertFalse(JSON.isValid("\"", JSONReader.Feature.AllowUnQuotedFieldNames));
         assertFalse(JSON.isValid("'", JSONReader.Feature.AllowUnQuotedFieldNames));
+        assertFalse(JSON.isValid("'", JSONReader.Feature.DisableSingleQuote));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/read/ObjectKeyTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/read/ObjectKeyTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.read;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONReader;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ObjectKeyTest {
     @Test
@@ -29,6 +31,15 @@ public class ObjectKeyTest {
         assertEquals(1, JSON.parseObject(bytes, Bean.class, JSONReader.Feature.AllowUnQuotedFieldNames).items.size());
         assertEquals(1, JSON.parseObject(s.toCharArray(), Bean.class, JSONReader.Feature.AllowUnQuotedFieldNames).items.size());
         assertEquals(1, ((Bean) JSON.parseObject(s.toCharArray(), (Type) Bean.class, JSONReader.Feature.AllowUnQuotedFieldNames)).items.size());
+    }
+
+    @Test
+    public void testDisablingSingleQuote() {
+        String str = "{'key': 'value'}";
+        byte[] bytes = str.getBytes();
+        assertThrows(JSONException.class, () -> {
+            JSON.parseObject(bytes, 0, bytes.length, StandardCharsets.UTF_8, Bean.class, JSONReader.Feature.DisableSingleQuote);
+        });
     }
 
     public static class Bean {

--- a/docs/features_cn.md
+++ b/docs/features_cn.md
@@ -55,7 +55,7 @@ class Model {
 | AllowUnQuotedFieldNames         | 支持不带双引号的字段名                                                                                         |
 | NonStringKeyAsString            | 非String类型的Key当做String处理                                                                             |
 | Base64StringAsByteArray         | 将byte[]序列化为Base64格式的字符串                                                                             |
-
+| DisableSingleQuote              | Do not allow single quote on key and value
 # 5. JSONWriter.Feature介绍
 
 | JSONWriter.Feature                | 介绍                                                                                    |

--- a/docs/features_en.md
+++ b/docs/features_en.md
@@ -58,6 +58,8 @@ class Model {
 | AllowUnQuotedFieldNames         |                                                                                                                                                                                                                                                                          |
 | NonStringKeyAsString            |                                                                                                                                                                                                                                                                          |
 | Base64StringAsByteArray         |                                                                                                                                                                                                                                                                          |
+| DisableSingleQuote              | Do not allow single quote in key name and values.
+
 # 5. JSONWriter.Feature
 
 | JSONWriter.Feature                | Description                                                                                                                                                                                                             |


### PR DESCRIPTION
### What this PR does / why we need it?

We are building a function that relies on fastjson2 but in the meantime we are trying to achieve strict mode on parsing. Single quote should not be allowed in our case.

### Summary of your change

This PR adds a Feature in JSONReader to allow customers to disable single quote support, it throws an exception for single quote when this feature is enabled.

#### Please indicate you've done the following:

- [Done] Made sure tests are passing and test coverage is added if needed.
- [Done] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [Done] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
