### PR TITLE
父类字段定义了忽略字段后，子类继承get方法忽略字段不生效，导致死循环

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -769,9 +769,9 @@ public class ObjectWriterBaseModule
             if (objectClass != null) {
                 Class superclass = objectClass.getSuperclass();
                 Method supperMethod = BeanUtils.getMethod(superclass, method);
-                boolean ignore = fieldInfo.ignore;
                 if (supperMethod != null) {
                     getFieldInfo(beanInfo, fieldInfo, superclass, supperMethod);
+                    boolean ignore = fieldInfo.ignore;
                     int supperMethodModifiers = supperMethod.getModifiers();
                     if (ignore != fieldInfo.ignore
                             && !Modifier.isAbstract(supperMethodModifiers)

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -769,11 +769,12 @@ public class ObjectWriterBaseModule
             if (objectClass != null) {
                 Class superclass = objectClass.getSuperclass();
                 Method supperMethod = BeanUtils.getMethod(superclass, method);
+                boolean ignore = fieldInfo.ignore;
                 if (supperMethod != null) {
                     getFieldInfo(beanInfo, fieldInfo, superclass, supperMethod);
-                    boolean ignore = fieldInfo.ignore;
+                    Field field = BeanUtils.getField(objectClass, method);
                     int supperMethodModifiers = supperMethod.getModifiers();
-                    if (ignore != fieldInfo.ignore
+                    if (null != field && ignore != fieldInfo.ignore
                             && !Modifier.isAbstract(supperMethodModifiers)
                             && !supperMethod.equals(method)
                     ) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -217,7 +217,7 @@ public class ObjectWriterCreatorASM
                 if (!record) {
                     BeanUtils.declaredFields(objectClass, field -> {
                         fieldInfo.init();
-                        fieldInfo.ignore = (field.getModifiers() & Modifier.PUBLIC) == 0 || (field.getModifiers() & Modifier.TRANSIENT) != 0;
+                        fieldInfo.ignore = ((field.getModifiers() & Modifier.PUBLIC) == 0 || (field.getModifiers() & Modifier.TRANSIENT) != 0);
 
                         FieldWriter fieldWriter = creteFieldWriter(objectClass, writerFieldFeatures, provider, beanInfo, fieldInfo, field);
                         if (fieldWriter != null) {

--- a/core/src/test/java/com/alibaba/fastjson2/writer/InheritMethodWriterTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/InheritMethodWriterTest.java
@@ -1,0 +1,114 @@
+package com.alibaba.fastjson2.writer;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.annotation.JSONField;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * 继承字段忽略
+ */
+public class InheritMethodWriterTest {
+    @Test
+    public void writer() {
+        UrlEntity entity = new UrlEntity("https://www.baidu.com/web/user");
+        entity.setName("rose");
+        String text = JSON.toJSONString(entity);
+        assertEquals(text, "{\"name\":\"rose\"}");
+    }
+
+    @Test
+    public void read() {
+        String text = "{\"name\":\"rose\", \"url\":\"https://www.baidu.com/web/user\"}";
+        UrlEntity entity = JSON.parseObject(text, UrlEntity.class);
+        System.out.println(entity);
+        assertEquals(entity.getName(), "rose");
+        assertEquals(entity.getUrl(), "https://www.baidu.com/web/user?name=rose");
+    }
+    public abstract static class AbstractJsonEntity {
+        @JSONField(serialize = false)
+        private String url;
+
+        public AbstractJsonEntity(String url) {
+            this.url = url;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+    }
+    public class UrlEntity
+            extends AbstractJsonEntity {
+        private String name;
+
+        public UrlEntity(String url) {
+            super(url);
+        }
+
+        // @JSONField(serialize = false)
+        @Override
+        public String getUrl() {
+            String text = JSON.toJSONString(this);
+            JSONObject queryObj = JSONObject.parseObject(text);
+
+            StringBuffer query = new StringBuffer();
+            Set<String> keys = queryObj.keySet();
+            for (String key : keys) {
+                String value = queryObj.getString(key);
+                if (StringUtils.isBlank(value)) {
+                    continue;
+                }
+
+                String encodeKey = "";
+                String encodeValue = "";
+                try {
+                    encodeKey = URLEncoder.encode(key, "UTF-8");
+                    encodeValue = URLEncoder.encode(value, "UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
+
+                if (StringUtils.isBlank(encodeValue)) {
+                    continue;
+                }
+
+                if (StringUtils.isBlank(query)) {
+                    query.append("?");
+                } else {
+                    query.append("&");
+                }
+                query.append(encodeKey).append("=").append(encodeValue);
+            }
+
+            if (StringUtils.isNotBlank(query)) {
+                return super.getUrl() + query;
+            }
+
+            return super.getUrl();
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return "UrlEntity [name=" + name + ", url=" + getUrl() + "]";
+        }
+    }
+}


### PR DESCRIPTION
父类字段定义了忽略字段后，子类继承get方法忽略字段不生效，导致死循环
```
public static abstract class AbstractJsonEntity {
    @JSONField(serialize = false)
    private String url;

    get/set
}


public class UrlEntity extends AbstractJsonEntity {
    private String name;
    
    @Override
    public String getUrl() {
         // 导致死循环
        String text = JSON.toJSONString(this);
    }
}

```