### PR TITLE
Fix flaky test in issue#3096

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/codec/JSONBTableTest3.java
+++ b/core/src/test/java/com/alibaba/fastjson2/codec/JSONBTableTest3.java
@@ -2,11 +2,17 @@ package com.alibaba.fastjson2.codec;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONB;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JSONBTableTest3 {
+    final ObjectMapper mapper = new ObjectMapper();
+
     @Test
     public void test_0() {
         A a = new A();
@@ -26,7 +32,7 @@ public class JSONBTableTest3 {
 
         byte[] bytes = JSONB.toBytes(a);
         A a1 = JSONB.parseObject(bytes, A.class);
-        assertEquals(JSON.toJSONString(a), JSON.toJSONString(a1));
+        assertMapsEqual(a, a1);
     }
 
     @Test
@@ -49,7 +55,17 @@ public class JSONBTableTest3 {
 
         byte[] bytes = JSONB.toBytes(a);
         A a1 = JSONB.parseObject(bytes, A.class);
-        assertEquals(JSON.toJSONString(a), JSON.toJSONString(a1));
+        assertMapsEqual(a, a1);
+    }
+
+    private void assertMapsEqual(A a, A a1) {
+        try {
+            Map<String, Object> mapa = mapper.readValue(JSON.toJSONString(a), Map.class);
+            Map<String, Object> mapa1 = mapper.readValue(JSON.toJSONString(a1), Map.class);
+            assertEquals(mapa, mapa1);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read value as Map", e);
+        }
     }
 
     public static class A {


### PR DESCRIPTION
### What this PR does / why we need it?

The fix for: https://github.com/alibaba/fastjson2/issues/3096

### Summary of your change

This change introduces a helper method, assertMapsEqual(), that reduces test flakiness by serializing two objects to JSON, converting them into maps, and comparing their content. It ensures stable data comparison by avoiding issues with non-deterministic behavior or inconsistent serialization. Error handling is added to manage potential serialization failures.

Can be tested by running:

```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.codec.JSONBTableTest3#test_0


mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.codec.JSONBTableTest3#test_1

```


#### Please indicate you've done the following:

- [yes ] Made sure tests are passing and test coverage is added if needed.
- [yes ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ yes] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
