### PR TITLE
Fix non deterministic test for issue#3098

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2672.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2672.java
@@ -5,7 +5,7 @@ import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.PropertyPreFilter;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,9 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Issue2672 {
     @Test
     public void test() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("k", "v");
+        Map<String, Object> map = new LinkedHashMap<>();
         map.put("selfRef", map);
+        map.put("k", "v");
         assertEquals("{\"selfRef\":{\"$ref\":\"..\"},\"k\":\"v\"}",
                 JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection));
 


### PR DESCRIPTION
### What this PR does / why we need it?

This is a fix for: [ #3098](https://github.com/alibaba/fastjson2/issues/3098)

### Summary of your change
Changed the HashMap to a Linked HashMap to avoid the non determinism introduced due to Hash Map.

This fix can be checked using:

`mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.issues_2600.Issue2672#test
`

#### Please indicate you've done the following:

- [yes ] Made sure tests are passing and test coverage is added if needed.
- [yes ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ yes] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.