### PR TITLE
Fix non deterministic tests for issue#3094

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/jackson_support/JsonManagedReferenceTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/jackson_support/JsonManagedReferenceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -28,7 +29,9 @@ public class JsonManagedReferenceTest {
         final String jsonJackson = mapper.writeValueAsString(dto);
         final String jsonFastjson2 = JSON.toJSONString(dto, JSONWriter.Feature.WriteNulls);
 
-        assertEquals(jsonJackson, jsonFastjson2);
+        Map<String, Object> mapJackson = mapper.readValue(jsonJackson, Map.class);
+        Map<String, Object> mapFastjson2 = mapper.readValue(jsonFastjson2, Map.class);
+        assertEquals(mapJackson, mapFastjson2);
     }
 
     public static class Bean {
@@ -90,7 +93,9 @@ public class JsonManagedReferenceTest {
         final String jsonJackson = mapper.writeValueAsString(dto);
         final String jsonFastjson2 = JSON.toJSONString(dto, JSONWriter.Feature.WriteNulls);
 
-        assertEquals(jsonJackson, jsonFastjson2);
+        Map<String, Object> mapJackson = mapper.readValue(jsonJackson, Map.class);
+        Map<String, Object> mapFastjson2 = mapper.readValue(jsonFastjson2, Map.class);
+        assertEquals(mapJackson, mapFastjson2);
     }
 
     static class Bean1 {


### PR DESCRIPTION
### What this PR does / why we need it?

This is a fix for this flaky test issue:

https://github.com/alibaba/fastjson2/issues/3094

### Summary of your change

There were 2 non deterministic tests that were changed using a simple fix. The code compares the deserialization of two JSON strings (jsonJackson and jsonFastjson2) into Map<String, Object> objects using the mapper.readValue() method. Once both JSON strings are converted into maps, the assertEquals() method is used to check if the two resulting maps are identical. This ensures that the JSON content from both sources is equivalent, regardless of the order.

#### Please indicate you've done the following:

- [ Yes] Made sure tests are passing and test coverage is added if needed.
- [ yes] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ yes] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
