### PR TITLE
Fix non-determinsm

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2644.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2600/Issue2644.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -28,7 +29,9 @@ public class Issue2644 {
         final String jsonJackson = mapper.writeValueAsString(dto);
         final String jsonFastjson2 = JSON.toJSONString(dto, JSONWriter.Feature.WriteNulls);
 
-        assertEquals(jsonJackson, jsonFastjson2);
+        Map<String, Object> mapJackson = mapper.readValue(jsonJackson, Map.class);
+        Map<String, Object> mapFastjson2 = mapper.readValue(jsonFastjson2, Map.class);
+        assertEquals(mapJackson, mapFastjson2);
     }
 
     static class JsonManagedReferenceDTO {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2800/Issue2836.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2800/Issue2836.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson2.issues_2800;
 import com.alibaba.fastjson2.JSON;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -44,10 +45,14 @@ public class Issue2836 {
         User user = new User("test", Type.B);
         String test = JSON.toJSONString(user);
         String jacksonResult = objectMapper.writeValueAsString(user);
-        assertEquals(jacksonResult, test);
+        ObjectNode testNode = (ObjectNode) objectMapper.readTree(test);
+        ObjectNode jacksonNode = (ObjectNode) objectMapper.readTree(jacksonResult);
+        assertEquals(jacksonNode, testNode);
         String jsonString = JSON.toJSONString(Type.A);
+        ObjectNode typeANode = (ObjectNode) objectMapper.readTree(jsonString);
+        ObjectNode expectedTypeANode = (ObjectNode) objectMapper.readTree(objectMapper.writeValueAsString(Type.A));
         assertEquals(
-                objectMapper.writeValueAsString(Type.A),
-                jsonString);
+                typeANode,
+                expectedTypeANode);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_3800/Issue3831.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_3800/Issue3831.java
@@ -2,7 +2,7 @@ package com.alibaba.fastjson2.v1issues.issue_3800;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,31 +10,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Issue3831 {
     @Test
     public void test_for_issue3831() {
-        Map<String, Object> longType = new HashMap<>();
+        Map<String, Object> longType = new LinkedHashMap<>();
         longType.put("type", "long");
 
-        Map<String, Object> textType = new HashMap<>();
+        Map<String, Object> textType = new LinkedHashMap<>();
         textType.put("type", "text");
         textType.put("analyzer", "standard");
 
-        Map<String, Object> raw = new HashMap<>();
+        Map<String, Object> raw = new LinkedHashMap<>();
         raw.put("type", "keyword");
         raw.put("doc_values", "false");
 
-        Map<String, Object> fields = new HashMap<>();
+        Map<String, Object> fields = new LinkedHashMap<>();
         fields.put("raw", raw);
 
-        Map<String, Object> rawLongType = new HashMap<>();
+        Map<String, Object> rawLongType = new LinkedHashMap<>();
         rawLongType.put("type", "long");
         rawLongType.put("fields", fields);
 
-        Map<String, Object> properties = new HashMap<>();
+        Map<String, Object> properties = new LinkedHashMap<>();
         properties.put("id", longType);
         properties.put("name", textType);
         properties.put("cityId", longType);
         properties.put("categoryId", rawLongType);
 
-        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> result = new LinkedHashMap<>();
         result.put("properties", properties);
 
         assertEquals(com.alibaba.fastjson2.JSON.toJSONString(result), new com.google.gson.Gson().toJson(result));


### PR DESCRIPTION
### What this PR does / why we need it?
This PR addresses three non-deterministic tests found in the following files, which lead to non deterministic test results and inconsistent builds.

### Summary of your change
- **Modified Flaky Tests:**
  - **Issue3831.java:**
    - Updated `test_for_issue3831()` to ensure consistent ordering of properties in the expected output.
    
  - **Issue2644.java:**
    - Adjusted `testJsonBackReference()` to fix the ordering of fields in the expected JSON output, ensuring that the test matches the actual output format.
    
  - **Issue2836.java:**
    - Revised `test()` to standardize the structure of the expected output, aligning it with the actual output to eliminate discrepancies.

Can be tested using:
```
mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.v1issues.issue_3800.Issue3831#test_for_issue3831

mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.issues_2600.Issue2644#testJsonBackReference

mvn -pl core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.issues_2800.Issue2836#test
```

#### Please indicate you've done the following:

- [Yes ] Made sure tests are passing and test coverage is added if needed.
- [ Yes] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [Yes ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
