### PR TITLE
Fix non determinism and timezone dependency for issue#3158

### DIFF
--- a/codegen-test/src/test/java/com/alibaba/fastjson2/internal/processor/annotation/MapTest.java
+++ b/codegen-test/src/test/java/com/alibaba/fastjson2/internal/processor/annotation/MapTest.java
@@ -1,11 +1,12 @@
 package com.alibaba.fastjson2.internal.processor.annotation;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.annotation.JSONCompiled;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -13,7 +14,7 @@ public class MapTest {
     @Test
     public void test() {
         Bean bean = new Bean();
-        bean.values = new HashMap<>();
+        bean.values = new TreeMap<>();
         bean.values.put("a", "101");
         bean.values.put("b", "201");
 
@@ -21,7 +22,9 @@ public class MapTest {
         Bean bean1 = JSON.parseObject(str, Bean.class);
         assertEquals(bean.values.size(), bean1.values.size());
         String str1 = JSON.toJSONString(bean1);
-        assertEquals(str, str1);
+        JSONObject json1 = JSON.parseObject(str);
+        JSONObject json2 = JSON.parseObject(str1);
+        assertEquals(json1, json2);
     }
 
     @JSONCompiled
@@ -32,7 +35,7 @@ public class MapTest {
     @Test
     public void test1() {
         Bean1 bean = new Bean1();
-        bean.values = new HashMap<>();
+        bean.values = new TreeMap<>();
         bean.values.put("a", "101");
         bean.values.put("b", "201");
 
@@ -40,7 +43,9 @@ public class MapTest {
         Bean1 bean1 = JSON.parseObject(str, Bean1.class);
         assertEquals(bean.values.size(), bean1.values.size());
         String str1 = JSON.toJSONString(bean1);
-        assertEquals(str, str1);
+        JSONObject json1 = JSON.parseObject(str);
+        JSONObject json2 = JSON.parseObject(str1);
+        assertEquals(json1, json2);
     }
 
     @JSONCompiled
@@ -51,7 +56,7 @@ public class MapTest {
     @Test
     public void test2() {
         Bean2 bean = new Bean2();
-        bean.values = new HashMap<>();
+        bean.values = new TreeMap<>();
         bean.values.put("a", "101");
         bean.values.put("b", "201");
 
@@ -59,7 +64,9 @@ public class MapTest {
         Bean2 bean1 = JSON.parseObject(str, Bean2.class);
         assertEquals(bean.values.size(), bean1.values.size());
         String str1 = JSON.toJSONString(bean1);
-        assertEquals(str, str1);
+        JSONObject json1 = JSON.parseObject(str);
+        JSONObject json2 = JSON.parseObject(str1);
+        assertEquals(json1, json2);
     }
 
     @JSONCompiled

--- a/codegen-test/src/test/java/com/alibaba/fastjson2/internal/processor/primitives/DateTypeTest.java
+++ b/codegen-test/src/test/java/com/alibaba/fastjson2/internal/processor/primitives/DateTypeTest.java
@@ -4,11 +4,14 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.annotation.JSONCompiled;
 import org.junit.jupiter.api.Test;
 
+import java.util.TimeZone;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class DateTypeTest {
     @Test
     public void test() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Shanghai"));
         Bean bean = new Bean();
         bean.v01 = new java.util.Date();
         bean.v02 = java.util.Calendar.getInstance();


### PR DESCRIPTION
### What this PR does / why we need it

This PR fixes non-deterministic behavior in two specific files, ensuring consistent and reliable results across different builds. This resolves issue #3158

### Summary of Changes

- **Modified Flaky Tests**:
  - **MapTest.java**:
    - Updated `test()`, `test1()` and `test2()` to enforce a consistent ordering of map entries in the expected output, aligning it with the actual output format.
  
  - **DateTypeTest.java**:
    - Adjusted `test()` to correct the expected timestamp value, ensuring it matches the actual output. This was timezone dependent issue that is now fixed. 

### Testing Instructions

The changes can be validated using the NonDex plugin to simulate non-deterministic behavior:

```bash
mvn -pl codegen-test edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.internal.processor.annotation.MapTest#test
mvn -pl codegen-test edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.internal.processor.annotation.MapTest#test1
mvn -pl codegen-test edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.internal.processor.annotation.MapTest#test2
mvn -pl codegen-test edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.alibaba.fastjson2.internal.processor.primitives.DateTypeTest#test
```


#### Checklist

- [x] Ensured all tests are passing and test coverage is added where necessary.
- [x] Verified that commit messages adhere to the [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the documentation impact, and if needed, created or updated documentation accordingly.

