### PR TITLE
#3172 Fix: 枚举类 ValueField 的类型为 Integer 时，无法反序列化 String 类型的值

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplEnum.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplEnum.java
@@ -49,9 +49,8 @@ public final class ObjectReaderImplEnum
         this.valueFieldType = valueFieldType;
 
         if (valueFieldType != null) {
-            if (valueFieldType == String.class) {
-                stringValues = new String[enums.length];
-            } else {
+            stringValues = new String[enums.length];
+            if (valueFieldType != String.class) {
                 intValues = new long[enums.length];
             }
 
@@ -67,8 +66,11 @@ public final class ObjectReaderImplEnum
 
                     if (valueFieldType == String.class) {
                         stringValues[i] = (String) fieldValue;
-                    } else if (fieldValue instanceof Number) {
-                        intValues[i] = ((Number) fieldValue).longValue();
+                    } else {
+                        stringValues[i] = fieldValue == null ? null : fieldValue.toString();
+                        if (fieldValue instanceof Number) {
+                            intValues[i] = ((Number) fieldValue).longValue();
+                        }
                     }
                 } catch (Exception ignored) {
                     // ignored

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3100/Issue3172Kt.kt
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3100/Issue3172Kt.kt
@@ -1,0 +1,21 @@
+package com.alibaba.fastjson2.issues_3100
+
+import com.alibaba.fastjson2.JSON
+import com.fasterxml.jackson.annotation.JsonValue
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+enum class UserStatus(@JsonValue val value: Int, val label: String) {
+    NORMAL(1, "正常"),
+    LOCKED(2, "锁定"),
+}
+
+class EnumTest {
+    @Test
+    fun testEnum() {
+        val value = "\"2\""
+        val status = JSON.parseObject(value, UserStatus::class.java)
+        println("Enum Item: $status") // null, version=2.0.53
+        Assertions.assertEquals(UserStatus.LOCKED, status)
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
当枚举类 ValueField 的类型为非 String 类型时，无法通过 String 类型的值反序列化，在一些参数接收枚举类型时不方便


### Summary of your change
当枚举类 ValueField 的类型为非 String 类型时，在 `ObjectReaderImplEnum` 类中也会缓存一份 String 化的值，在反序列化时，如果其他类型匹配失败，可以使用 String 类型的值进行匹配，从而获取正确的枚举元素。


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
