### PR TITLE
#3152 fix: 在使用 JSONObject.toJavaObject 反序列化 JSONObject 到带默认值的 Kotlin 类时遇到问题。

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
@@ -1,9 +1,6 @@
 package com.alibaba.fastjson2.reader;
 
-import com.alibaba.fastjson2.JSONB;
-import com.alibaba.fastjson2.JSONException;
-import com.alibaba.fastjson2.JSONFactory;
-import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.util.Fnv;
 import com.alibaba.fastjson2.util.TypeUtils;
 
@@ -471,9 +468,16 @@ public class ObjectReaderNoneDefaultConstructor<T>
                     Class<?> valueClass = fieldValue.getClass();
                     Class fieldClass = fieldReader.fieldClass;
                     if (valueClass != fieldClass) {
-                        Function typeConvert = provider.getTypeConvert(valueClass, fieldClass);
-                        if (typeConvert != null) {
-                            fieldValue = typeConvert.apply(fieldValue);
+                        if (fieldValue instanceof JSONObject) {
+                            ObjectReader fieldObjectReader = provider.getObjectReader(fieldReader.fieldType);
+                            fieldValue = fieldObjectReader.createInstance((Map) fieldValue, features);
+                        } else if (fieldValue instanceof JSONArray) {
+                            fieldValue = ((JSONArray) fieldValue).to(fieldReader.fieldType, features);
+                        } else {
+                            Function typeConvert = provider.getTypeConvert(valueClass, fieldClass);
+                            if (typeConvert != null) {
+                                fieldValue = typeConvert.apply(fieldValue);
+                            }
                         }
                     }
                 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3100/Issue3152.kt
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3100/Issue3152.kt
@@ -1,0 +1,28 @@
+package com.alibaba.fastjson2.issues_3100
+
+import com.alibaba.fastjson2.JSON
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+
+class Issue3152 {
+
+    data class Foo(val int: Int = 1, val bar: Bar)
+    data class Bar(val text: String)
+
+    @Test
+    fun test() {
+        Assertions.assertEquals(
+            Foo(1, Bar("hello")),
+            JSON.parseObject(
+                """
+                    {
+                        "bar": {
+                            "text" : "hello"
+                        }
+                    }
+                """.trimIndent()
+            ).toJavaObject(Foo::class.java)
+        )
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

在使用 JSONObject.toJavaObject 反序列化 JSONObject 到带默认值的 Kotlin 类时遇到问题。
但直接使用 JSON.parseObject 没有问题。
#3152 

### Summary of your change

使得反序列化结果正常，过程无报错。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
