### PR TITLE
数组类型转json字符串设置WriteClassName后反序列化失败

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplObject.java
@@ -102,8 +102,8 @@ public final class ObjectReaderImplObject
                                         contextClass = classLoader.loadClass(typeName);
                                     } catch (ClassNotFoundException ignored) {
                                     }
-
-                                    if (!objectClass.equals(contextClass)) {
+                                    //明确contextClass类型与objectClass不一致时才更改reader
+                                    if (contextClass != null && !objectClass.equals(contextClass)) {
                                         autoTypeObjectReader = context.getObjectReader(contextClass);
                                     }
                                 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3200/Issue3208.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3200/Issue3208.java
@@ -1,19 +1,27 @@
 package com.alibaba.fastjson2.issues_3200;
 
 import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializeConfig;
 import com.alibaba.fastjson.serializer.SerializerFeature;
+import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
 public class Issue3208 {
-
     @Test
     public void testArray() {
         byte[] bytes = new byte[]{1, 2, 3};
-        String jsonString = JSON.toJSONString(bytes, SerializerFeature.WriteClassName);
+        String jsonString = JSON.toJSONString(new byte[]{1, 2, 3}, SerializerFeature.WriteClassName);
         byte[] bytes1 = (byte[]) JSON.parse(jsonString);
         Assertions.assertTrue(Arrays.equals(bytes, bytes1));
+    }
+
+    @Test
+    public void testObjectArray() {
+        byte[] jsonBytes = JSON.toJSONBytes(new Object[]{JSON.toJSONString(ImmutableMap.of("a", 1))}, new SerializeConfig(true), JSON.DEFAULT_GENERATE_FEATURE, SerializerFeature.WriteClassName);
+        Object parsed = JSON.parse(new String(jsonBytes));
+        Assertions.assertNotNull(parsed);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3200/Issue3208.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3200/Issue3208.java
@@ -1,0 +1,19 @@
+package com.alibaba.fastjson2.issues_3200;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.serializer.SerializerFeature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class Issue3208 {
+
+    @Test
+    public void testArray() {
+        byte[] bytes = new byte[]{1, 2, 3};
+        String jsonString = JSON.toJSONString(bytes, SerializerFeature.WriteClassName);
+        byte[] bytes1 = (byte[]) JSON.parse(jsonString);
+        Assertions.assertTrue(Arrays.equals(bytes, bytes1));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
使用JSON.toJSONString将一个数组类型转换为JSON字符串，如果设置了WriteClassName
`String jsonString = JSON.toJSONString(new Object[]{1, 2, 3}, SerializerFeature.WriteClassName);`
输出结果为
`{"@type":"[O", "@value":"[1,2,3]"}`
这会导致反序列化失败或结果错误

### Summary of your change

ObjectReaderImplObject第106行应判断contextClass是否为null，为null时不更改autoTypeObjectReader类型

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
