### PR TITLE
BugFix: 修复JSONWriterUTF8.writeStringEscaped申请数组长度不够问题

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
@@ -878,7 +878,7 @@ class JSONWriterUTF8
     }
 
     protected final void writeStringEscaped(byte[] values) {
-        int minCapacity = off + values.length * 4 + 2;
+        int minCapacity = off + values.length * 6 + 2;
         if (minCapacity >= this.bytes.length) {
             ensureCapacity(minCapacity);
         }

--- a/core/src/test/java/com/alibaba/fastjson2/JSONWriterUTF8Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONWriterUTF8Test.java
@@ -1,5 +1,6 @@
 package com.alibaba.fastjson2;
 
+import com.alibaba.fastjson2.JSONWriter.Context;
 import com.alibaba.fastjson2.annotation.JSONField;
 import org.junit.jupiter.api.Test;
 
@@ -670,6 +671,20 @@ public class JSONWriterUTF8Test {
         String str = new String(bytes, 0, bytes.length, StandardCharsets.ISO_8859_1);
         Object parse = JSON.parse(json);
         assertEquals(str, parse);
+    }
+
+    @Test
+    public void writeStringEscaped() {
+        byte[] bytes = new byte[1024 * 128];
+        Arrays.fill(bytes, (byte) 1);
+        Context context = JSONFactory.createWriteContext(JSONWriter.Feature.PrettyFormat);
+        try (JSONWriterUTF8 jsonWriter = new JSONWriterUTF8(context)) {
+            jsonWriter.writeStringEscaped(bytes);
+            String json = jsonWriter.toString();
+            String str = new String(bytes, 0, bytes.length, StandardCharsets.ISO_8859_1);
+            Object parse = JSON.parse(json);
+            assertEquals(str, parse);
+        }
     }
 
     @Test


### PR DESCRIPTION
int minCapacity = off + values.length * 4 + 2;
修改为:
int minCapacity = off + values.length * 6 + 2;

### What this PR does / why we need it?



### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
