### PR TITLE
refactor: 同步 `mark` 为 `true/false` 的两个分支的代码的逻辑

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
@@ -180,14 +180,21 @@ final class ConstructorFunction<T>
         if (marker) {
             int i = 0, flag = 0;
             for (int n; i < size; i = n) {
+                Parameter parameter = parameters[i];
+                Class<?> paramClass = parameter.getType();
+                Type paramType = parameter.getParameterizedType();
                 Object arg = values.get(hashCodes[i]);
                 if (arg != null) {
+                    if (!paramClass.isInstance(arg)) {
+                        arg = TypeUtils.cast(arg, paramClass);
+                    } else if (paramType instanceof ParameterizedType) {
+                        arg = TypeUtils.cast(arg, paramType);
+                    }
                     args[i] = arg;
                 } else {
                     flag |= (1 << i);
-                    Class<?> paramType = parameters[i].getType();
-                    if (paramType.isPrimitive()) {
-                        args[i] = TypeUtils.getDefaultValue(paramType);
+                    if (paramClass.isPrimitive()) {
+                        args[i] = TypeUtils.getDefaultValue(paramClass);
                     }
                 }
                 n = i + 1;

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
@@ -468,16 +468,9 @@ public class ObjectReaderNoneDefaultConstructor<T>
                     Class<?> valueClass = fieldValue.getClass();
                     Class fieldClass = fieldReader.fieldClass;
                     if (valueClass != fieldClass) {
-                        if (fieldValue instanceof JSONObject) {
-                            ObjectReader fieldObjectReader = provider.getObjectReader(fieldReader.fieldType);
-                            fieldValue = fieldObjectReader.createInstance((Map) fieldValue, features);
-                        } else if (fieldValue instanceof JSONArray) {
-                            fieldValue = ((JSONArray) fieldValue).to(fieldReader.fieldType, features);
-                        } else {
-                            Function typeConvert = provider.getTypeConvert(valueClass, fieldClass);
-                            if (typeConvert != null) {
-                                fieldValue = typeConvert.apply(fieldValue);
-                            }
+                        Function typeConvert = provider.getTypeConvert(valueClass, fieldClass);
+                        if (typeConvert != null) {
+                            fieldValue = typeConvert.apply(fieldValue);
                         }
                     }
                 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3100/Issue3152.kt
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3100/Issue3152.kt
@@ -8,12 +8,13 @@ import org.junit.jupiter.api.Test
 class Issue3152 {
 
     data class Foo(val int: Int = 1, val bar: Bar)
+    data class Foo2(val int: Int, val bar: Bar)
     data class Bar(val text: String)
 
     @Test
     fun test() {
         Assertions.assertEquals(
-            Foo(1, Bar("hello")),
+            Foo(bar = Bar("hello")),
             JSON.parseObject(
                 """
                     {
@@ -23,6 +24,20 @@ class Issue3152 {
                     }
                 """.trimIndent()
             ).toJavaObject(Foo::class.java)
+        )
+
+        Assertions.assertEquals(
+            Foo2(1, Bar("hello")),
+            JSON.parseObject(
+                """
+                    {
+                        "int": 1,
+                        "bar": {
+                            "text" : "hello"
+                        }
+                    }
+                """.trimIndent()
+            ).to(Foo2::class.java)
         )
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

`v2.0.53` 在使用 `JSONObject#toJavaObject` 函数将 `JSONObject` 转换为 `Kotlin` 的对象时，如果构造函数带有默认值，转换将会出现错误。

该 bug 已经在 [pull#3175](https://github.com/alibaba/fastjson2/pull/3175) 中修复，但我认为最合理的修复方式应当是将 `ConstructorFunction.java` 中两个分支的代码逻辑改成一样的，所以换了一种修复方法。

在这个 issue 中我们进行了一些讨论：https://github.com/alibaba/fastjson2/issues/3152#issuecomment-2570040419

### Summary of your change

1. 回滚了 pull #3175 中对 `ObjectReaderNoneDefaultConstructor.java` 的修复
2. 为 `ConstructorFunction.java` 将 `mark = true` 时的分支的代码添加类型检查和转换逻辑（与为 `false` 时逻辑一致）
3. 补充了一组测试样例

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
