### PR TITLE
Issue3259-metaspace内存持续上涨

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -397,6 +397,11 @@ public class ObjectWriterProvider
                 if (objectWriter != null) {
                     return objectWriter;
                 }
+            } else {
+                objectWriter = cache.get(objectType);
+                if (objectWriter != null) {
+                    return objectWriter;
+                }
             }
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/write/ObjectWriterProviderTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/write/ObjectWriterProviderTest.java
@@ -6,7 +6,11 @@ import com.alibaba.fastjson2.modules.ObjectWriterModule;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 import com.alibaba.fastjson2.writer.ObjectWriterProvider;
 import org.junit.jupiter.api.Test;
+import org.springframework.cglib.proxy.Enhancer;
+import org.springframework.cglib.proxy.MethodInterceptor;
+import org.springframework.cglib.proxy.MethodProxy;
 
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -131,7 +135,25 @@ public class ObjectWriterProviderTest {
         assertSame(writer1, JSON.registerIfAbsent(Bean.class, writer, false));
     }
 
+    @Test
+    public void testWriterProxy() throws InterruptedException {
+        Enhancer enhancer = new Enhancer();
+        enhancer.setSuperclass(Bean.class);
+        enhancer.setCallback(new BeanMethodInterceptor());
+        Object proxy1 = enhancer.create();
+        JSON.toJSONString(proxy1);
+        JSON.toJSONString(proxy1);
+    }
+
     public static class Bean {
+    }
+
+    public static class BeanMethodInterceptor
+            implements MethodInterceptor {
+        @Override
+        public Object intercept(Object o, Method method, Object[] objects, MethodProxy methodProxy) throws Throwable {
+            return methodProxy.invokeSuper(o, objects);
+        }
     }
 
     public static class BeanWriter


### PR DESCRIPTION
### What this PR does / why we need it?

issue:https://github.com/alibaba/fastjson2/issues/3259
metaspce内存持续上涨问题

fix pr:https://github.com/alibaba/fastjson2/pull/3299
去除单测中误提交的sleep逻辑，导致单测卡住的问题


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
