### PR TITLE
typo in the JSONObject method name: forEchArrayObject -> forEachArrayObject

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -187,8 +187,18 @@ public class JSONObject
      * @since 2.0.52
      * @param key
      * @param action
+     * @deprecated Typo in the method name. Use {@link #forEachArrayObject(String, Consumer) forEachArrayObject} instead
      */
+    @Deprecated(forRemoval = true)
     public void forEchArrayObject(String key, Consumer<JSONObject> action) {
+        forEachArrayObject(key, action);
+    }
+
+    /**
+     * @param key
+     * @param action
+     */
+    public void forEachArrayObject(String key, Consumer<JSONObject> action) {
         JSONArray array = getJSONArray(key);
         if (array == null) {
             return;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -189,7 +189,7 @@ public class JSONObject
      * @param action
      * @deprecated Typo in the method name. Use {@link #forEachArrayObject(String, Consumer) forEachArrayObject} instead
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated
     public void forEchArrayObject(String key, Consumer<JSONObject> action) {
         forEachArrayObject(key, action);
     }


### PR DESCRIPTION
### What this PR does / why we need it?
It's just fixing of a method name which contained a type. The backward compatibility is preserved.

### Summary of your change
This PR changes method name `forEchArrayObject` to `forEachArrayObject` because it contained a typo.
The previous method is left for compatibility, but marked as deprecated.

The method was not used in the tests or documentation.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
