### PR TITLE
fix JSONReader.Feature.UseBigDecimalForDoubles when exponent != 0 (#3382)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -3099,7 +3099,7 @@ public abstract class JSONReader
                         return Double.parseDouble(
                                 decimalStr + "E" + exponent);
                     }
-                    return new BigDecimal(decimalStr + "E" + exponent);
+                    return decimal.signum() == 0 ? BigDecimal.ZERO : new BigDecimal(decimalStr + "E" + exponent);
                 }
 
                 if ((context.features & Feature.UseDoubleForDecimals.mask) != 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -3093,10 +3093,14 @@ public abstract class JSONReader
                     }
                 }
 
-                if (exponent != 0 && (context.features & (Feature.UseBigDecimalForDoubles.mask | Feature.UseBigDecimalForFloats.mask)) == 0) {
+                if (exponent != 0) {
                     String decimalStr = decimal.toPlainString();
-                    return Double.parseDouble(
-                            decimalStr + "E" + exponent);
+                    if ((context.features & (Feature.UseBigDecimalForDoubles.mask | Feature.UseBigDecimalForFloats.mask)) == 0) {
+                        return Double.parseDouble(
+                                decimalStr + "E" + exponent);
+                    } else {
+                        return new BigDecimal(decimalStr + "E" + exponent);
+                    }
                 }
 
                 if ((context.features & Feature.UseDoubleForDecimals.mask) != 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -3098,9 +3098,8 @@ public abstract class JSONReader
                     if ((context.features & (Feature.UseBigDecimalForDoubles.mask | Feature.UseBigDecimalForFloats.mask)) == 0) {
                         return Double.parseDouble(
                                 decimalStr + "E" + exponent);
-                    } else {
-                        return new BigDecimal(decimalStr + "E" + exponent);
                     }
+                    return new BigDecimal(decimalStr + "E" + exponent);
                 }
 
                 if ((context.features & Feature.UseDoubleForDecimals.mask) != 0) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3300/Issue3382.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3300/Issue3382.java
@@ -1,0 +1,20 @@
+package com.alibaba.fastjson2.issues_3300;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3382 {
+    @Test
+    public void test() throws Exception {
+        String str = "2.503705945562304E-5";
+        BigDecimal expected = new BigDecimal(str).stripTrailingZeros();
+
+        BigDecimal decimal = (BigDecimal) JSON.parse(str, JSONReader.Feature.UseBigDecimalForDoubles);
+        assertEquals(expected, decimal);
+    }
+}


### PR DESCRIPTION
fix #3382 