### PR TITLE
Fix issue #3293 and issue #3328

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text eol=lf
+*.zip binary
+*.jpg binary
+*.png binary

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
@@ -393,11 +393,9 @@ public final class ObjectWriterImplMap
     }
 
     static boolean isWriteAsString(Object val, long features) {
-        boolean writeAsString = (features & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0 && ObjectWriterProvider.isPrimitiveOrEnum(val.getClass());
-        if (writeAsString && (val instanceof Temporal || val instanceof Date)) {
-            writeAsString = false;
-        }
-        return writeAsString;
+        return (features & (WriteNonStringKeyAsString.mask | BrowserCompatible.mask)) != 0
+                && ObjectWriterProvider.isPrimitiveOrEnum(val.getClass())
+                && !(val instanceof Temporal || val instanceof Date);
     }
 
     String mapKeyToString(Object key, JSONWriter jsonWriter, long features) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3200/Issue3293.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3200/Issue3293.java
@@ -1,0 +1,86 @@
+package com.alibaba.fastjson2.issues_3200;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.ValueFilter;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue3293 {
+    public interface ValueEnum<V> {
+        /**
+         * 获取枚举的 value 值
+         */
+        V getValue();
+    }
+
+    public enum MemberType implements ValueEnum<Integer> {
+        USER(1),
+        ADMIN(2),
+        AGENT(3);
+
+        final Integer value;
+
+        MemberType(Integer value) {
+            this.value = value;
+        }
+
+        @Override
+        public Integer getValue() {
+            return value;
+        }
+    }
+
+    @Test
+    public void test() {
+        final ValueFilter valueFilter = (object, name, value) -> {
+            if (value instanceof Enum<?>) {
+                if (value instanceof ValueEnum<?>) {
+                    return ((ValueEnum<?>) value).getValue();
+                }
+                return ((Enum<?>) value).ordinal();
+            }
+            return value;
+        };
+        LocalDateTime localDateTime = LocalDateTime.of(2006, 1, 2, 15, 4, 5);
+        Map<Object, Object> map = new HashMap<>(4);
+        map.put(MemberType.USER, 1);
+        map.put(MemberType.ADMIN, 2);
+        map.put(123, "a");
+        map.put("key", "value");
+        map.put(localDateTime, false);
+        Date date = Date.from(localDateTime.plusDays(1).atZone(ZoneId.systemDefault()).toInstant());
+        map.put(date, true);
+        map.put(BigDecimal.TEN, 10);
+        map.put(Collections.emptyList(), 3L);
+        map.put(Collections.emptyMap(), "null");
+
+        // {"USER":1,{}:"null",[]:3,"ADMIN":2,"2006-01-03 15:04:05":true,10:10,123:"a","2006-01-02 15:04:05":false,"key":"value"}
+        String rawJsonStr = JSON.toJSONString(map);
+        // System.out.println(rawJsonStr);
+        assertTrue(rawJsonStr.contains("\"USER\""));
+        assertTrue(rawJsonStr.contains("{}:"));
+        assertTrue(rawJsonStr.contains("[]:"));
+        assertTrue(rawJsonStr.contains("10:"));
+        assertTrue(rawJsonStr.contains("\"2006-01-02 15:04:05\":"));
+
+        // {"USER":1,"{}":"null","[]":3,"ADMIN":2,"2006-01-03 15:04:05":true,"10":10,"123":"a","2006-01-02 15:04:05":false,"key":"value"}
+        String jsonStr1 = JSON.toJSONString(map, JSONWriter.Feature.WriteNonStringKeyAsString);
+        String jsonStr2 = JSON.toJSONString(map, valueFilter, JSONWriter.Feature.BrowserCompatible);
+        // System.out.println(jsonStr1);
+        assertEquals(jsonStr1, jsonStr2);
+
+        assertTrue(jsonStr1.contains("\"USER\""));
+        assertTrue(jsonStr1.contains("\"[]\":"));
+        assertTrue(jsonStr1.contains("\"{}\":"));
+        assertTrue(jsonStr1.contains("\"10\":"));
+        assertTrue(jsonStr1.contains("\"2006-01-02 15:04:05\":"));
+    }
+}

--- a/core/src/test/java/org/apache/dubbo/jsonb/rw/BigDecimalUtil.java
+++ b/core/src/test/java/org/apache/dubbo/jsonb/rw/BigDecimalUtil.java
@@ -15,16 +15,16 @@ public class BigDecimalUtil {
         }
 
         int scale = value.scale();
-        DecimalFormat decimalFormat = null;
+        DecimalFormat decimalFormat;
         if (scale <= 2) {
             decimalFormat = DF_TWO;
-        } else if (scale > 2 && scale <= 4) {
+        } else if (scale <= 4) {
             // 保留四位小数
             decimalFormat = DF_FOUR;
-        } else if (scale > 4 && scale <= 6) {
+        } else if (scale <= 6) {
             // 保留六位小数
             decimalFormat = DF_SIX;
-        } else if (scale > 6 && scale <= 8) {
+        } else if (scale <= 8) {
             decimalFormat = EIGHT_SIX;
         } else {
             decimalFormat = null;
@@ -32,37 +32,32 @@ public class BigDecimalUtil {
 
         if (null == decimalFormat) {
             return value.toString();
-        } else {
-            return decimalFormat.format(value);
         }
+        // FIXME: decimalFormat is NOT thread safe
+        return decimalFormat.format(value);
     }
 
     public static BigDecimal castToBigDecimal(String value) {
-        if (null == value || value.length() < 1) {
+        final int len;
+        if (value == null || (len = value.length()) == 0) {
             return null;
         }
 
         // 只保留数字和小数点
-        StringBuilder sb = new StringBuilder();
-        char[] charArr = value.toCharArray();
-        for (char c : charArr) {
-            // 0-9
-            if (c >= 48 && c <= 57) {
-                sb.append((char) c);
-            }
-
-            // .
-            if (c == 46) {
-                sb.append((char) c);
+        final char[] validChars = new char[len];
+        int i = 0;
+        for (int j = 0; j < len; j++) {
+            final char c = value.charAt(j);
+            if (c >= '0' && c <= '9' || c == '.') {
+                validChars[i++] = c;
             }
         }
 
-        if (sb.length() < 1) {
+        if (i == 0) {
             return null;
         }
 
-        String decimal = sb.toString();
-        BigDecimal result = new BigDecimal(decimal);
-        return result;
+        // new BigDecimal( stringBuilder.toString() ) will call new BigDecimal( str.toCharArray() ) internally
+        return new BigDecimal(validChars);
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

之前 Fastjson 2.0.53 是可以将**非字符串**形式的自动 `toString()`， 后来 Fastjson 2.0.54 调整之后，就不支持了。
我看了下，这次调整是为了修复 Issue #3264 。

如果只需要支持字符串形式的 key 的话，那么 #3264 其实也是无需修复的。
这次调整后，就导致部分key输出会附带额外的 单引号 或 双引号。

虽然 `Map` 具有**非字符串形式** 的 key 并不符合严格的 JSON 规范，但是在实际开发过程中，非字符串形式的 key 还是客观且普遍存在的。

比如：
- `EnumMap` 的 key 是一个枚举，这是一种比较常见的用法，如果要转换为字符串，就需要将所有数据额外转换并迁移到其他 `Map` 类型。
- `TreeMap<Integer, Object>` 的 key 是一个整型，整型的排序规则和字符串也是**不一样**的，所以要保持相同的排序规则，也需要额外再多作一次转换，并且还不能用错 `Map` 类型，否则会破坏业务排序。


### Summary of your change

修复 bug #3293 和 bug #3328

实现思路是：

1. 为了让有 `Filter` 时 和 无 `Filter` 的表现一致，最好的方式是两边共用相同的 `isWriteAsString` 判断逻辑 和 `writeName` 写入处理代码。
2. 但是 `writeName` 的代码是分散在多个类的多个方法里面，且夹杂其他与 name 无关的业务逻辑，无法统一抽取封装，难以实现全部共用。
3. 对于 `null`、`String`、`Integer`、`Long` 等常见类型，可直接复用。
4. 设置了 `WriteNonStringKeyAsString` 或 `BrowserCompatible` 等 Feature，**且属于内置简单类型**的，直接 `key.toString()`。
5. 对于其他自定义类型（或没有设置上述 Feature 的），仍然调用之前的 `JSON.toJSONString()`，如果返回的字符串两侧带了引号的，就会被手动去掉。实际上自定义类型序列化的结果无非就是三种：数组`[]`、对象`{}` 和 字符串`""`，目前主要还是 `Enum` 和 时间类型，对应的JSON输出会被额外加引号。

这只是第一版的实现方案，**先确保加了 `WriteNonStringKeyAsString` 或 `BrowserCompatible` Feature 的，还是可以正常使用**。
毕竟，**最常见的一般就只有 字符串、整型、枚举**。只要恢复对这些类型的支持，就满足了绝大多数场景下的需求。

至于上面第5步，可能会多耗费一点性能。但和之前相比，也只有在两侧多了引号时才会增加性能开销，并且这种场景在前端输出时非常少见。

此外，我也已经完成了第二版实现，着重优化第5点的性能，能够实现无需调用 `JSON.toJSONString()` 和 去除引号 的额外开销。
第二版也已经通过了单元测试。不过有一个细节我还要再斟酌一下，需要覆盖更多场景，所以暂时先提交第一版。


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
