### PR TITLE
fix array multi jsonpath extract NullOnError not work.

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathTypedMultiNames.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathTypedMultiNames.java
@@ -113,19 +113,27 @@ class JSONPathTypedMultiNames
                     continue;
                 }
 
-                Object result = fieldWriter.getFieldValue(object);
+                Object result;
+                try {
+                    result = fieldWriter.getFieldValue(object);
 
-                Type type = types[i];
-                if (result != null && result.getClass() != type) {
-                    if (type == Long.class) {
-                        result = TypeUtils.toLong(result);
-                    } else if (type == BigDecimal.class) {
-                        result = TypeUtils.toBigDecimal(result);
-                    } else if (type == String[].class) {
-                        result = TypeUtils.toStringArray(result);
-                    } else {
-                        result = TypeUtils.cast(result, type);
+                    Type type = types[i];
+                    if (result != null && result.getClass() != type) {
+                        if (type == Long.class) {
+                            result = TypeUtils.toLong(result);
+                        } else if (type == BigDecimal.class) {
+                            result = TypeUtils.toBigDecimal(result);
+                        } else if (type == String[].class) {
+                            result = TypeUtils.toStringArray(result);
+                        } else {
+                            result = TypeUtils.cast(result, type);
+                        }
                     }
+                } catch (Exception e) {
+                    if (!ignoreError(i)) {
+                        throw new JSONException("jsonpath eval path, path : " + paths[i] + ", msg : " + e.getMessage(), e);
+                    }
+                    result = null;
                 }
                 array[i] = result;
             }

--- a/core/src/test/java/com/alibaba/fastjson2/jsonpath/JSONPathTypedMultiNamesTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/jsonpath/JSONPathTypedMultiNamesTest.java
@@ -86,6 +86,24 @@ public class JSONPathTypedMultiNamesTest {
         assertThrows(JSONException.class, () -> jsonPath.extract("["));
     }
 
+    @Test
+    public void testArrayNullOnError() {
+        JSONPath jsonPath = JSONPath.of(
+                new String[]{"$.a[0].x0", "$.a[0].x1"},
+                new Type[]{Long.class, String.class},
+                null,
+                new long[]{
+                        NullOnError.mask,
+                        NullOnError.mask
+                },
+                ZoneId.systemDefault()
+        );
+
+        Object[] result = (Object[]) jsonPath.extract("{\"a\":[{\"x0\":\"xx\",\"x1\":\"xx\"}]}");
+        assertNull(result[0]);
+        assertNotNull(result[1]);
+    }
+
     static class Bean {
         int f0;
         int f1;


### PR DESCRIPTION
### What this PR does / why we need it?

NullOnError feature not work in multi jsonpath extract when using array jsonpath


### Summary of your change
add NullOnError check in `ObjectReaderAdapter` and `JSONPathTypedMultiNames`


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
