### PR TITLE
buffer may overflow in JSONWriterUTF8 and JSONWriterUTF16

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
@@ -1061,7 +1061,7 @@ class JSONWriterUTF16
         boolean writeAsString = isWriteAsString(value, features);
 
         int off = this.off;
-        int minCapacity = off + precision + value.scale() + 7;
+        int minCapacity = off + precision + Math.abs(value.scale()) + 7;
         char[] chars = this.chars;
         if (minCapacity > chars.length) {
             chars = grow(minCapacity);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
@@ -2387,7 +2387,7 @@ final class JSONWriterUTF8
         boolean writeAsString = isWriteAsString(value, features);
 
         int off = this.off;
-        int minCapacity = off + precision + value.scale() + 7;
+        int minCapacity = off + precision + Math.abs(value.scale()) + 7;
         byte[] bytes = this.bytes;
         if (minCapacity > bytes.length) {
             bytes = grow(minCapacity);


### PR DESCRIPTION
use absolute value for scale in minCapacity calculation in JSONWriterUTF8 and JSONWriterUTF16 otherwise buffer may overflow

### What this PR does / why we need it?



### Summary of your change

use abs value of scale in writeDecimal

#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
