### PR TITLE
fix parse error when seeAlsoDefault is specified and @type is missing

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
@@ -243,7 +243,7 @@ final class ObjectReaderSeeAlso<T>
             JSONReader.Context context = jsonReader.getContext();
             long features3, hash = jsonReader.readFieldNameHashCode();
             JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
-            if ((hash == getTypeKeyHash() || seeAlsoDefault != null)
+            if ((hash == getTypeKeyHash() || (seeAlsoDefault != null && seeAlsoDefault != Void.class))
                     && ((((features3 = (features | getFeatures() | context.getFeatures())) & JSONReader.Feature.SupportAutoType.mask) != 0) || autoTypeFilter != null)
             ) {
                 ObjectReader reader = null;

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
@@ -243,7 +243,7 @@ final class ObjectReaderSeeAlso<T>
             JSONReader.Context context = jsonReader.getContext();
             long features3, hash = jsonReader.readFieldNameHashCode();
             JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
-            if (hash == getTypeKeyHash()
+            if ((hash == getTypeKeyHash() || seeAlsoDefault != null)
                     && ((((features3 = (features | getFeatures() | context.getFeatures())) & JSONReader.Feature.SupportAutoType.mask) != 0) || autoTypeFilter != null)
             ) {
                 ObjectReader reader = null;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3500/Issue3540.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3500/Issue3540.java
@@ -1,0 +1,73 @@
+package com.alibaba.fastjson2.issues_3500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.annotation.JSONType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3540 {
+    @Test
+    public void exceptUseSeeAlsoDefault() {
+        final String json = "                {\n" +
+                "                    \"name\": \"tom\",\n" +
+                "                    \"age\": 18\n" +
+                "                }";
+        IAnimal animal = JSON.parseObject(json, IAnimal.class);
+        assertEquals(Dog.class, animal.getClass());
+    }
+
+    @Test
+    public void exceptUseSeeAlsoDefault2() {
+        final String json = "                {\n" +
+                "                    \"@type\": \"\",\n" +
+                "                    \"name\": \"tom\",\n" +
+                "                    \"age\": 18\n" +
+                "                }";
+        IAnimal animal = JSON.parseObject(json, IAnimal.class);
+        assertEquals(Dog.class, animal.getClass());
+    }
+
+    @Test
+    public void useTypeForSeeAlso() {
+        final String json = "                {\n" +
+                "                    \"@type\": \"Dog\",\n" +
+                "                    \"name\": \"tom\",\n" +
+                "                    \"age\": 18\n" +
+                "                }";
+        IAnimal animal = JSON.parseObject(json, IAnimal.class);
+        assertEquals(Dog.class, animal.getClass());
+    }
+
+    @JSONType(seeAlso = Dog.class, seeAlsoDefault = Dog.class)
+    public interface IAnimal {
+        String getName();
+
+        int getAge();
+    }
+
+    @JSONType(typeName = "Dog")
+    public static class Dog
+            implements IAnimal {
+        private String name;
+        private int age;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public int getAge() {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

fix parse error when seeAlsoDefault is specified and @type is missing

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
