### PR TITLE
fix only reuse initObjectWriter initialized by JSONField and add miss…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -855,6 +855,7 @@ public abstract class JSONWriter
 
     public final void writeNameValue(String name, Object value) {
         writeName(name);
+        writeColon();
         writeAny(value);
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterObject.java
@@ -25,6 +25,7 @@ public class FieldWriterObject<T>
     final boolean unwrapped;
     final boolean array;
     final boolean number;
+    protected boolean writeUsing;
 
     static final AtomicReferenceFieldUpdater<FieldWriterObject, Class> initValueClassUpdater = AtomicReferenceFieldUpdater.newUpdater(
             FieldWriterObject.class,
@@ -76,7 +77,7 @@ public class FieldWriterObject<T>
             return getObjectWriterVoid(jsonWriter, valueClass);
         } else {
             boolean typeMatch = initValueClass == valueClass
-                    || (initValueClass.isAssignableFrom(valueClass) && !jsonWriter.isEnabled(WriteClassName) && fieldType instanceof Class)
+                    || (writeUsing && initValueClass.isAssignableFrom(valueClass))
                     || (initValueClass == Map.class && initValueClass.isAssignableFrom(valueClass))
                     || (initValueClass == List.class && initValueClass.isAssignableFrom(valueClass));
             if (!typeMatch && initValueClass.isPrimitive()) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
@@ -353,6 +353,9 @@ public class ObjectWriterCreator {
                 fieldInfo.init();
                 FieldWriter fieldWriter = creteFieldWriter(objectClass, writerFieldFeatures, provider, beanInfo, fieldInfo, field);
                 if (fieldWriter != null) {
+                    if (fieldInfo.writeUsing != null && fieldWriter instanceof FieldWriterObject) {
+                        ((FieldWriterObject) fieldWriter).writeUsing = true;
+                    }
                     fieldWriterMap.put(fieldWriter.fieldName, fieldWriter);
                 }
             });
@@ -376,6 +379,9 @@ public class ObjectWriterCreator {
                         fieldInfo.ignore = (field.getModifiers() & Modifier.PUBLIC) == 0;
                         FieldWriter fieldWriter = creteFieldWriter(objectClass, writerFieldFeatures, provider, beanInfo, fieldInfo, field);
                         if (fieldWriter != null) {
+                            if (fieldInfo.writeUsing != null && fieldWriter instanceof FieldWriterObject) {
+                                ((FieldWriterObject) fieldWriter).writeUsing = true;
+                            }
                             FieldWriter origin = fieldWriterMap.putIfAbsent(fieldWriter.fieldName, fieldWriter);
 
                             if (origin != null && origin.compareTo(fieldWriter) > 0) {
@@ -490,6 +496,9 @@ public class ObjectWriterCreator {
                         );
                     }
 
+                    if (fieldInfo.writeUsing != null && fieldWriter instanceof FieldWriterObject) {
+                        ((FieldWriterObject) fieldWriter).writeUsing = true;
+                    }
                     FieldWriter origin = fieldWriterMap.putIfAbsent(fieldWriter.fieldName, fieldWriter);
 
                     if (origin != null && origin.compareTo(fieldWriter) > 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -226,6 +226,9 @@ public class ObjectWriterCreatorASM
 
                         FieldWriter fieldWriter = creteFieldWriter(objectClass, writerFieldFeatures, provider, beanInfo, fieldInfo, field);
                         if (fieldWriter != null) {
+                            if (fieldInfo.writeUsing != null && fieldWriter instanceof FieldWriterObject) {
+                                ((FieldWriterObject) fieldWriter).writeUsing = true;
+                            }
                             FieldWriter origin = fieldWriterMap.putIfAbsent(fieldWriter.fieldName, fieldWriter);
                             if (origin != null) {
                                 int cmp = origin.compareTo(fieldWriter);
@@ -347,6 +350,9 @@ public class ObjectWriterCreatorASM
                         );
                     }
 
+                    if (fieldInfo.writeUsing != null && fieldWriter instanceof FieldWriterObject) {
+                        ((FieldWriterObject) fieldWriter).writeUsing = true;
+                    }
                     FieldWriter origin = fieldWriterMap.putIfAbsent(fieldName, fieldWriter);
 
                     if (origin != null && origin.compareTo(fieldWriter) > 0) {
@@ -374,6 +380,9 @@ public class ObjectWriterCreatorASM
                 fieldInfo.init();
                 FieldWriter fieldWriter = creteFieldWriter(objectClass, writerFieldFeatures, provider, beanInfo, fieldInfo, field);
                 if (fieldWriter != null) {
+                    if (fieldInfo.writeUsing != null && fieldWriter instanceof FieldWriterObject) {
+                        ((FieldWriterObject) fieldWriter).writeUsing = true;
+                    }
                     fieldWriterMap.put(fieldWriter.fieldName, fieldWriter);
                 }
             });

--- a/core/src/test/java/com/alibaba/fastjson2/features/PrettyFormatTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/features/PrettyFormatTest.java
@@ -242,14 +242,14 @@ public class PrettyFormatTest {
         jsonWriter.close();
 
         assertEquals("{\n" +
-                "\t\"id\"123\n" +
+                "\t\"id\":123\n" +
                 "}", jsonWriter.toString());
 
         jsonWriter.incrementIndent();
         assertEquals(1, jsonWriter.level());
         jsonWriter.println();
         assertEquals("{\n" +
-                "\t\"id\"123\n" +
+                "\t\"id\":123\n" +
                 "}\n\t", jsonWriter.toString());
         jsonWriter.decrementIdent();
         assertEquals(0, jsonWriter.level());
@@ -266,14 +266,14 @@ public class PrettyFormatTest {
         jsonWriter.close();
 
         assertEquals("{\n" +
-                "\t\"id\"123\n" +
+                "\t\"id\":123\n" +
                 "}", jsonWriter.toString());
 
         jsonWriter.incrementIndent();
         assertEquals(1, jsonWriter.level());
         jsonWriter.println();
         assertEquals("{\n" +
-                "\t\"id\"123\n" +
+                "\t\"id\":123\n" +
                 "}\n\t", jsonWriter.toString());
         jsonWriter.decrementIdent();
         assertEquals(0, jsonWriter.level());

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2286.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2286.java
@@ -8,14 +8,14 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class Issue2286 {
     @Test
     public void test() {
         Bean bean = new Bean();
         bean.animal = new Cat();
-
-        String str = JSON.toJSONString(bean);
-        System.out.println(str);
+        assertEquals("{\"animal\":{\"type\":\"Cat\"}}", JSON.toJSONString(bean));
     }
 
     public static class Bean {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3500/Issue3546.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3500/Issue3546.java
@@ -1,0 +1,47 @@
+package com.alibaba.fastjson2.issues_3500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3546 {
+    @Test
+    public void test() {
+        TextMessage textMsg = new TextMessage();
+
+        // 第一次设置父类实例
+        textMsg.setData(new Message());
+        assertEquals("{\"data\":{\"channel\":null}}", JSON.toJSONString(textMsg, JSONWriter.Feature.WriteNulls));
+
+        // 第二次设置子类实例
+        AssignMessage am = new AssignMessage();
+        am.setAssignee("assignee");
+        textMsg.setData(am);
+
+        assertEquals("{\"data\":{\"assignee\":\"assignee\",\"channel\":null}}", JSON.toJSONString(textMsg, JSONWriter.Feature.WriteNulls));
+    }
+
+    @Getter
+    @Setter
+    class Message {
+        private String channel;
+        // getter/setter...
+    }
+
+    @Getter
+    @Setter
+    class AssignMessage
+            extends Message {
+        private String assignee;
+    }
+
+    @Getter
+    @Setter
+    class TextMessage {
+        private Object data;
+    }
+}


### PR DESCRIPTION
…ing colon, for issue #3546 and issue #2286

### What this PR does / why we need it?

fix only reuse initObjectWriter initialized by JSONField and add missing colon

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
