### PR TITLE
:wrench: use Maven Central Portal

### DIFF
--- a/android-test/build.gradle
+++ b/android-test/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         google()
         mavenCentral()
     }
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         mavenLocal()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         google()
         mavenCentral()
     }

--- a/docs/maven_deploy_guide.md
+++ b/docs/maven_deploy_guide.md
@@ -4,12 +4,12 @@
 
 ## 0. 前置准备与配置
 
-在`Maven`的`settting.xml`中配置`oss.sonatype.org`账号：
+在`Maven`的`settting.xml`中配置`https://central.sonatype.com`账号：
 
 ```xml
 <servers>
     <server>
-        <id>ossrh</id>
+        <id>central</id>
         <username>__YOUR_USERNAME__</username>
         <password>__YOUR_PASSWORD__</password>
     </server>
@@ -18,15 +18,15 @@
 
 更多发布操作说明（如用于`GPG`签名的`GPG`安装与配置），参见：
 
-- OSSRH Guide  
-  https://central.sonatype.org/pages/ossrh-guide.html
-- Deploying to OSSRH with Apache Maven - Introduction  
-  https://central.sonatype.org/pages/apache-maven.html
+- Maven Central Portal Getting Started
+  https://central.sonatype.org/publish/publish-portal-guide/
+- Maven Central Portal Publishing By Using the Maven Plugin
+  https://central.sonatype.org/publish/publish-portal-maven/
 
 发布过程与发布文件的查看地址：
 
-- sonatype的发布控制台  
-  https://oss.sonatype.org/index.html
+- Maven Central Portal 的发布控制台  
+  https://central.sonatype.com
 - Maven中央库的文件查看  
   https://repo1.maven.org/maven2/com/alibaba/fastjson2/
 

--- a/example-solon-test/pom.xml
+++ b/example-solon-test/pom.xml
@@ -30,7 +30,7 @@
 
         <repository>
             <id>snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </repository>
     </repositories>
 

--- a/example-spring-test/pom.xml
+++ b/example-spring-test/pom.xml
@@ -38,7 +38,7 @@
         </repository>
         <repository>
             <id>snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,9 @@
         <kotest.version>5.5.5</kotest.version>
         <jmh.version>1.37</jmh.version>
 
+        <!-- Maven Central Portal -->
+        <central.publishing.maven.version>0.7.0</central.publishing.maven.version>
+
         <!-- overridden by submodule that need skip deploy -->
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
@@ -123,17 +126,6 @@
             <url>https://github.com/kraity</url>
         </developer>
     </developers>
-
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <dependencyManagement>
         <dependencies>
@@ -1049,39 +1041,12 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central.publishing.maven.version}</version>
                         <extensions>true</extensions>
-                        <!--
-                            In multi-module builds using the deploy-at-end feature,
-                            the deployment of all components is performed in the last module based on the reactor order.
-                            If this property is set to true in the last module,
-                            all staging deployment for all modules will be skipped.
-                            so, we'll config nexus deploy after deploy phase of every module
-                            see: https://github.com/sonatype/nexus-maven-plugins/tree/master/staging/maven-plugin#configuring-the-plugin
-                        -->
-                        <executions>
-                            <execution>
-                                <id>default-deploy</id>
-                                <phase>deploy</phase>
-                                <goals>
-                                    <goal>deploy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <!--
-                            If you are deploying to Maven Central,
-                            it is the Nexus Staging Plugin that is doing the deployment instead of the `deploy` plugin,
-                            so the configuration of the `deploy` plugin has no effect.
-                            To make the Nexus deploy plugin skip,
-                            set skipNexusStagingDeployMojo in its configuration to true.
-                            see: https://stackoverflow.com/questions/59552549/preventing-maven-modules-from-being-deployed
-                        -->
-                            <skipNexusStagingDeployMojo>${maven.deploy.skip}</skipNexusStagingDeployMojo>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
https://github.com/alibaba/nacos/issues/13358

settings.xml servers use:

```
<server>
  <id>central</id>
  <username>${CENTRAL_USERNAME}</username>
  <password>${CENTRAL_PASSWORD}</password>
</server>
```

### What this PR does / why we need it?

Announcement of the End-of-Life Sunset Date for Maven OSSRH
宣布 Maven OSSRH 的生命周期终止日期 ︎

https://central.sonatype.org/news/20250326_ossrh_sunset/#announcement-of-the-end-of-life-sunset-date-for-ossrh

Maven Central Portal Publish Example：https://central.sonatype.com/artifact/cn.ac.xxw/xxw-rsa
Publish command：`./mvnw clean && ./mvnw deploy -DperformRelease -DskipTests=true`

使用与 https://oss.sonatype.org 相同的账户有效在 https://central.sonatype.com/ 登录，即可一键将域名迁移到新平台。

两者密码相同（如果无法登录，可以在 https://central.sonatype.com/ 平台重置密码）

快照功能需要在 https://central.sonatype.com/ 平台的命名空间下手动开启

![Image](https://github.com/user-attachments/assets/fff81c21-c8fe-453f-b67e-c56236eff7b2)


```
NOTE: If you have already migrated your namespace(s) to Maven Central this email does not apply to you and thank you for your initiative.

Greetings OSSRH Publisher,

As you may have heard, OSSRH is reaching end of life on June 30, 2025. OSSRH users need to migrate their namespaces to the Central Portal as soon as possible.

Instructions for self migration are located here: https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration

To make the transition smoother we will be automatically migrating publishers that have not used oss.sonatype.org or s01.sonatype.org to publish artifacts in some time starting with the oldest and working our way forward. To avoid disruption to your publishing processes we strongly encourage migrating before the June 30, 2025 deadline.

Thank you for your assistance,

The Central Team
```

```
注意：如果您已将命名空间迁移到 Maven Central，则此电子邮件不适用于您，感谢您的主动性。

问候 OSSRH 发布者，

如您所知，OSSRH将于2025年6月30日终止。OSSRH用户需要尽快将命名空间迁移到中央门户。

自迁移说明位于此处：https://central.sonatype.com/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration

为了使过渡更加顺畅，我们将自动迁移在一段时间内未使用 oss.sonatype.org 或 s01.sonatype.org 发布软件包的发布者，从最旧的开始，然后逐步进行。为了避免对您的发布过程造成干扰，我们强烈建议在2025年6月30日截止日期之前进行迁移。

感谢您的帮助，

中央团队
```

### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
