### PR TITLE
fix modules iterator error, again

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -888,8 +888,8 @@ public class ObjectReaderProvider
     }
 
     public void getFieldInfo(FieldInfo fieldInfo, Class objectClass, Method method) {
-        for (ObjectReaderModule module : modules) {
-            ObjectReaderAnnotationProcessor annotationProcessor = module.getAnnotationProcessor();
+        for (int i = 0; i < modules.size(); i++) {
+            ObjectReaderAnnotationProcessor annotationProcessor = modules.get(i).getAnnotationProcessor();
             if (annotationProcessor == null) {
                 continue;
             }


### PR DESCRIPTION
### What this PR does / why we need it?
hello 温少：

这个 PR 是从 https://github.com/alibaba/fastjson2/issues/2358 这个延生过来的。
我根据这个 issue 升级到了 2.0.48，今天发现线上还是有 ConcurrentModificationException。
看了最新代码后发现 2024.7.7 你又改了一次。
我今天堆栈是四个 getFieldInfo 方法中最后一个没有改成下标读取 modules 的了...
两行代码顺手改了下，再提交个 PR。
ps. 我还是不懂为什么这么改， it works...

祝好！


`java.util.ConcurrentModificationException
at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1043)
at java.base/java.util.ArrayList$Itr.next(ArrayList.java:997)
at com.alibaba.fastjson2.reader.ObjectReaderProvider.getFieldInfo(ObjectReaderProvider.java:901)
at com.alibaba.fastjson2.reader.ObjectReaderCreator.createFieldReader(ObjectReaderCreator.java:1411)
at com.alibaba.fastjson2.reader.ObjectReaderCreator.lambda$createFieldReaders$4(ObjectReaderCreator.java:1660)
at com.alibaba.fastjson2.util.BeanUtils.setters(BeanUtils.java:493)
at com.alibaba.fastjson2.reader.ObjectReaderCreator.createFieldReaders(ObjectReaderCreator.java:1656)
at com.alibaba.fastjson2.reader.ObjectReaderCreatorASM.createObjectReader(ObjectReaderCreatorASM.java:260)
at com.alibaba.fastjson2.reader.ObjectReaderProvider.getObjectReaderInternal(ObjectReaderProvider.java:856)
at com.alibaba.fastjson2.reader.ObjectReaderProvider.getObjectReader(ObjectReaderProvider.java:748)
at com.alibaba.fastjson2.JSONReader.readArray(JSONReader.java:2339)
at com.alibaba.fastjson2.JSON.parseArray(JSON.java:2658)`

### Summary of your change
fix ObjectReaderProvider getFieldInfo modules iterator error, again


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
