### PR TITLE
Add JSONLargeObjectException for handling large object serialization errors

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONLargeObjectException.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONLargeObjectException.java
@@ -1,0 +1,17 @@
+package com.alibaba.fastjson2;
+
+/**
+ * Exception thrown when attempting to serialize an object that exceeds size limits
+ * and the LargeObject feature is not enabled.
+ *
+ * @since 2.0.55
+ */
+public class JSONLargeObjectException
+        extends JSONException {
+    public JSONLargeObjectException(String message) {
+        super(message);
+    }
+    public JSONLargeObjectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/com/alibaba/fastjson2/JSONLargeObjectException.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONLargeObjectException.java
@@ -4,7 +4,7 @@ package com.alibaba.fastjson2;
  * Exception thrown when attempting to serialize an object that exceeds size limits
  * and the LargeObject feature is not enabled.
  *
- * @since 2.0.55
+ * @since 2.0.58
  */
 public class JSONLargeObjectException
         extends JSONException {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -2728,7 +2728,8 @@ public abstract class JSONWriter
             if (minCapacity < maxArraySize) {
                 newCapacity = maxArraySize;
             } else {
-                throw new OutOfMemoryError("try enabling LargeObject feature instead");
+                throw new JSONLargeObjectException("Maximum array size exceeded. Try enabling LargeObject feature instead. "
+                        + "Requested size: " + minCapacity + ", max size: " + maxArraySize);
             }
         }
         return newCapacity;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2300/Issue2323.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2300/Issue2323.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson2.issues_2300;
 
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONLargeObjectException;
 import com.alibaba.fastjson2.JSONWriter;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -12,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Issue2323 {
-    String errMsg = "try enabling LargeObject feature instead";
+    String errMsgStart = "Maximum array size exceeded. Try enabling LargeObject feature instead. Requested size: ";
 
     @Test
     public void test() throws Exception {
@@ -32,20 +33,23 @@ public class Issue2323 {
 
         try {
             JSONWriter.ofUTF16().write(params);
-        } catch (OutOfMemoryError error) {
-            Assertions.assertEquals(errMsg, error.getMessage());
+        } catch (JSONLargeObjectException error) {
+            Assertions.assertTrue(error.getMessage().startsWith(errMsgStart),
+                    "Error message should start with: " + errMsgStart + ", but was: " + error.getMessage());
         }
 
         try {
             JSONWriter.ofUTF8().write(params);
-        } catch (OutOfMemoryError error) {
-            Assertions.assertEquals(errMsg, error.getMessage());
+        } catch (JSONLargeObjectException error) {
+            Assertions.assertTrue(error.getMessage().startsWith(errMsgStart),
+                    "Error message should start with: " + errMsgStart + ", but was: " + error.getMessage());
         }
 
         try {
             JSONWriter.ofJSONB().write(params);
-        } catch (OutOfMemoryError error) {
-            Assertions.assertEquals(errMsg, error.getMessage());
+        } catch (JSONLargeObjectException error) {
+            Assertions.assertTrue(error.getMessage().startsWith(errMsgStart),
+                    "Error message should start with: " + errMsgStart + ", but was: " + error.getMessage());
         }
     }
 }


### PR DESCRIPTION
Introduce JSONLargeObjectException to provide clear error messages when the maximum array size is exceeded during JSON serialization. The exception message includes the requested size and the maximum allowed size, and suggests enabling the LargeObject feature for larger payloads.

Closes #3588.