### PR TITLE
fix: resolve SIGBUS crash on Android ARM due to memory #3636

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/IOUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/IOUtils.java
@@ -1742,7 +1742,10 @@ public class IOUtils {
     }
 
     public static long getLongUnaligned(char[] buf, int offset) {
-        return UNSAFE.getLong(buf, ARRAY_CHAR_BASE_OFFSET + ((long) offset << 1));
+        return ((long) buf[offset]) |
+                ((long) buf[offset + 1] << 16) |
+                ((long) buf[offset + 2] << 32) |
+                ((long) buf[offset + 3] << 48);
     }
 
     public static long getLongLE(byte[] buf, int offset) {


### PR DESCRIPTION
### What this PR does / why we need it?

Replace UNSAFE.getLong with safe char array access in getLongUnaligned(char[])
Prevents memory alignment issues on ARM architecture
Add test cases for various offset scenarios
Resolves Signal 7(SIGBUS), Code 1(BUS_ADRALN) crash on Android 10

### Summary of your change



#### Please indicate you've done the following:

- [√] Made sure tests are passing and test coverage is added if needed.
- [√] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

