### PR TITLE
support not skipping transient field, for issue #3659 and #3366

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/annotation/JSONField.java
+++ b/core/src/main/java/com/alibaba/fastjson2/annotation/JSONField.java
@@ -126,4 +126,9 @@ public @interface JSONField {
      * @since 2.0.56
      */
     Class<?> contentAs() default Void.class;
+
+    /**
+     * @since 2.0.58
+     */
+    boolean skipTransient() default true;
 }

--- a/core/src/main/java/com/alibaba/fastjson2/codec/FieldInfo.java
+++ b/core/src/main/java/com/alibaba/fastjson2/codec/FieldInfo.java
@@ -37,6 +37,7 @@ public class FieldInfo {
     public Class<?> readUsing;
     public boolean fieldClassMixIn;
     public boolean isTransient;
+    public boolean skipTransient;
     public String defaultValue;
     public Locale locale;
     public String schema;
@@ -96,6 +97,7 @@ public class FieldInfo {
         readUsing = null;
         fieldClassMixIn = false;
         isTransient = false;
+        skipTransient = true;
         defaultValue = null;
         locale = null;
         schema = null;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -297,7 +297,7 @@ public class ObjectWriterBaseModule
 
             int modifiers = field.getModifiers();
             boolean isTransient = Modifier.isTransient(modifiers);
-            if (isTransient) {
+            if (isTransient && fieldInfo.skipTransient) {
                 fieldInfo.ignore = true;
                 fieldInfo.isTransient = true;
             }
@@ -794,6 +794,7 @@ public class ObjectWriterBaseModule
 
             if (JDKUtils.CLASS_TRANSIENT != null && method.getAnnotation(JDKUtils.CLASS_TRANSIENT) != null) {
                 fieldInfo.ignore = true;
+                fieldInfo.isTransient = true;
             }
 
             if (objectClass != null) {
@@ -884,7 +885,9 @@ public class ObjectWriterBaseModule
                         processJSONField1x(fieldInfo, annotation);
                         break;
                     case "java.beans.Transient":
-                        fieldInfo.ignore = true;
+                        if (fieldInfo.skipTransient) {
+                            fieldInfo.ignore = true;
+                        }
                         fieldInfo.isTransient = true;
                         break;
                     case "com.fasterxml.jackson.annotation.JsonProperty": {
@@ -964,6 +967,13 @@ public class ObjectWriterBaseModule
             boolean ignore = !jsonField.serialize();
             if (!fieldInfo.ignore) {
                 fieldInfo.ignore = ignore;
+            }
+
+            if (!jsonField.skipTransient()) {
+                fieldInfo.skipTransient = false;
+                if (fieldInfo.isTransient) {
+                    fieldInfo.ignore = false;
+                }
             }
 
             if (jsonField.unwrapped()) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -222,7 +222,7 @@ public class ObjectWriterCreatorASM
                 if (!record) {
                     BeanUtils.declaredFields(objectClass, field -> {
                         fieldInfo.init();
-                        fieldInfo.ignore = ((field.getModifiers() & Modifier.PUBLIC) == 0 || (field.getModifiers() & Modifier.TRANSIENT) != 0);
+                        fieldInfo.ignore = (field.getModifiers() & Modifier.PUBLIC) == 0;
 
                         FieldWriter fieldWriter = createFieldWriter(objectClass, writerFieldFeatures, provider, beanInfo, fieldInfo, field);
                         if (fieldWriter != null) {

--- a/core/src/test/java/com/alibaba/fastjson2/annotation/JSONField_skipTransient.java
+++ b/core/src/test/java/com/alibaba/fastjson2/annotation/JSONField_skipTransient.java
@@ -1,0 +1,196 @@
+package com.alibaba.fastjson2.annotation;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Test;
+
+import java.beans.Transient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONField_skipTransient {
+    @Test
+    public void test_A() { // 测试 transient && public field
+        A a = new A();
+        a.id = 100;
+        assertEquals("{}", JSON.toJSONString(a)); // base
+
+        A2 a2 = new A2();
+        a2.id = 200;
+        assertEquals("{\"id\":200}", JSON.toJSONString(a2)); // 注解位于field上
+
+        A3 a3 = new A3();
+        a3.id = 300;
+        assertEquals("{\"id\":300}", JSON.toJSONString(a3)); // 注解位于getter上
+    }
+
+    public static class A {
+        public transient int id;
+    }
+
+    public static class A2 {
+        @JSONField(skipTransient = false)
+        public transient int id;
+    }
+
+    public static class A3 {
+        public transient int id;
+
+        @JSONField(skipTransient = false)
+        public int getId() {
+            return id;
+        }
+    }
+
+    @Test
+    public void test_B() { // 测试 transient && private field
+        B b = new B();
+        b.id = 100;
+        assertEquals("{}", JSON.toJSONString(b)); // base
+
+        B2 b2 = new B2();
+        b2.id = 200;
+        assertEquals("{\"id\":200}", JSON.toJSONString(b2)); // 注解位于field上
+
+        B3 b3 = new B3();
+        b3.id = 300;
+        assertEquals("{\"id\":300}", JSON.toJSONString(b3)); // 注解注解位于getter上
+    }
+
+    public static class B {
+        private transient int id;
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class B2 {
+        @JSONField(skipTransient = false)
+        private transient int id;
+
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class B3 {
+        private transient int id;
+
+        @JSONField(skipTransient = false)
+        public int getId() {
+            return id;
+        }
+    }
+
+    @Test
+    public void test_C() { // 测试 @java.beans.Transient
+        C c = new C();
+        c.id = 100;
+        assertEquals("{}", JSON.toJSONString(c)); // base
+
+        C2 c2 = new C2();
+        c2.id = 200;
+        assertEquals("{\"id\":200}", JSON.toJSONString(c2)); // 注解位于field上
+
+        C3 c3 = new C3();
+        c3.id = 300;
+        assertEquals("{\"id\":300}", JSON.toJSONString(c3)); // 注解位于getter上
+    }
+
+    public static class C {
+        private int id;
+
+        @Transient
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class C2 {
+        @JSONField(skipTransient = false)
+        private int id;
+
+        @Transient
+        public int getId() {
+            return id;
+        }
+    }
+
+    public static class C3 {
+        private int id;
+
+        @JSONField(skipTransient = false)
+        @Transient
+        public int getId() {
+            return id;
+        }
+    }
+
+    @Test
+    public void test_D() { // 测试同时有 transient 和 @Transient
+        D d = new D();
+        d.id = 100;
+        assertEquals("{}", JSON.toJSONString(d));
+    }
+
+    public static class D {
+        private transient int id;
+
+        @Transient
+        public int getId() {
+            return id;
+        }
+    }
+
+    @Test
+    public void test_E() { // 测试显式设置skipTransient=true
+        E e = new E();
+        e.id = 200;
+        assertEquals("{}", JSON.toJSONString(e));
+    }
+
+    public static class E {
+        @JSONField(skipTransient = true)
+        public transient int id;
+    }
+
+    @Test
+    public void test_F() { // 测试非transient字段设置skipTransient=false
+        F f = new F();
+        f.id = 100;
+        assertEquals("{\"id\":100}", JSON.toJSONString(f));
+    }
+
+    public static class F {
+        @JSONField(skipTransient = false)
+        public int id;
+    }
+
+    @Test
+    public void test_Inheritance() { // 测试继承场景
+        Child child = new Child();
+        child.setId(100);
+        assertEquals("{\"id\":100}", JSON.toJSONString(child));
+    }
+
+    public static class Parent {
+        private transient int id;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    public static class Child
+            extends Parent {
+        @Override
+        @JSONField(skipTransient = false)
+        public int getId() {
+            return super.getId();
+        }
+    }
+}

--- a/docs/annotations_cn.md
+++ b/docs/annotations_cn.md
@@ -160,6 +160,25 @@ public void test1() {
 }
 ```
 
+### 1.7 配置序列化时不忽略transient属性
+将@JSONField(skipTransient = false)配置在transient字段或@java.beans.Transient修饰的getter方法上，可以强制序列化transient属性。
+```java
+public class Bean1 {
+    @JSONField(skipTransient = false)
+    public transient int id;
+}
+
+public class Bean2 {
+    private int id;
+
+    @JSONField(skipTransient = false)
+    @java.beans.Transient
+    public int getId() {
+        return id;
+    }
+}
+```
+
 ## 2. @JSONType
 JSONType是配置在类/接口上的注解，可以配置改类的所有字段的NamingStrategy、序列化和反序列化忽略的字段、JSONReader/JSONWriter的Features等。
 

--- a/docs/annotations_en.md
+++ b/docs/annotations_en.md
@@ -172,6 +172,26 @@ public void test1() {
 }
 ```
 
+### 1.7 Don't ignore transient fields when serializing
+
+Configure @JSONField(skipTransient = false) on transient fields or getter methods annotated with @java.beans.Transient. This can force serialization of transient fields.
+```java
+public class Bean1 {
+    @JSONField(skipTransient = false)
+    public transient int id;
+}
+
+public class Bean2 {
+    private int id;
+
+    @JSONField(skipTransient = false)
+    @java.beans.Transient
+    public int getId() {
+        return id;
+    }
+}
+```
+
 ## 2. @JSONType
 
 JSONType is an Annotation configured on Class/Interface, which can configure the NamingStrategy of all fields of the modified class, fields ignored by serialization and deserialization, Features of JSONReader/JSONWriter, etc.


### PR DESCRIPTION
### What this PR does / why we need it?
补充说明：
在 FieldInfo 中新增 skipTransient 字段（原本只有一个 isTransient 字段，若只使用 isTransient，代码可读性太差，故新增 skipTransient；新的代码逻辑中，isTransient 只负责标识字段或 getter 是否被 transient 修饰）；
skipTransient=false 只支持在 @JSONField 中配置，暂不支持 @JSONType；
如有不妥之处，恳请前辈指出。


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
