### PR TITLE
support for Spring's reactor codec, #3691 #1501

### DIFF
--- a/extension-spring5/pom.xml
+++ b/extension-spring5/pom.xml
@@ -211,6 +211,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>3.1.0.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>test</scope>

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
@@ -60,8 +60,11 @@ public final class Fastjson2Encoder
     public DataBuffer encodeValue(@Nullable Object value, @NonNull DataBufferFactory bufferFactory, @NonNull ResolvableType valueType, MimeType mimeType, Map<String, Object> hints) {
         byte[] bytes = null;
         // Check if the value is a valid JSON string or byte array
-        if (value instanceof String && JSON.isValidObject((String) value)) {
-            bytes = ((String) value).getBytes(config.getCharset());
+        if (value instanceof String) {
+            String str = (String) value;
+            if (JSON.isValidObject(str)) {
+                bytes = str.getBytes(config.getCharset());
+            }
         } else if (value instanceof byte[] && JSON.isValid((byte[]) value)) {
             bytes = (byte[]) value;
         }

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
@@ -1,0 +1,93 @@
+package com.alibaba.fastjson2.support.spring.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.reactivestreams.Publisher;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.AbstractEncoder;
+import org.springframework.core.codec.EncodingException;
+import org.springframework.core.codec.Hints;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+import reactor.core.publisher.Flux;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * spring message codec encoder for Fastjson2.
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+
+public final class Fastjson2Encoder
+        extends AbstractEncoder<Object> {
+    private final FastJsonConfig config;
+
+    /**
+     * default constructor
+     */
+    public Fastjson2Encoder() {
+        this(new FastJsonConfig(), MediaType.ALL);
+    }
+
+    /**
+     * Constructor with custom configs
+     *
+     * @param config    FastJsonConfig
+     * @param mimeTypes the mime types to support
+     */
+    public Fastjson2Encoder(FastJsonConfig config, MimeType... mimeTypes) {
+        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
+        this.config = config;
+    }
+
+    @Override
+    @NonNull
+    public Flux<DataBuffer> encode(@NonNull Publisher<?> inputStream, @NonNull DataBufferFactory bufferFactory, @NonNull ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
+        return Flux.from(inputStream)
+                .map(val -> encodeValue(val, bufferFactory, elementType, mimeType, hints));
+    }
+
+    @Override
+    @NonNull
+    public DataBuffer encodeValue(@Nullable Object value, @NonNull DataBufferFactory bufferFactory, @NonNull ResolvableType valueType, MimeType mimeType, Map<String, Object> hints) {
+        byte[] bytes = null;
+        // Check if the value is a valid JSON string or byte array
+        if (value instanceof String && JSON.isValidObject((String) value)) {
+            bytes = ((String) value).getBytes(config.getCharset());
+        } else if (value instanceof byte[] && JSON.isValid((byte[]) value)) {
+            bytes = (byte[]) value;
+        }
+        // If bytes is not null, write it to a DataBuffer
+        if (bytes != null) {
+            int length = bytes.length;
+            DataBuffer buffer = bufferFactory.allocateBuffer(length)
+                    .write(bytes, 0, length);
+            Hints.touchDataBuffer(buffer, hints, logger);
+            return buffer;
+        }
+        //@see JSON.writeTo
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            JSON.writeTo(
+                    baos,
+                    value,
+                    config.getDateFormat(),
+                    config.getWriterFilters(),
+                    config.getWriterFeatures()
+            );
+            DataBuffer buffer = bufferFactory.allocateBuffer(baos.size());
+            baos.writeTo(buffer.asOutputStream());
+            Hints.touchDataBuffer(buffer, hints, logger);
+            return buffer;
+        } catch (IOException e) {
+            throw new EncodingException("JSON#writeTo cannot serialize '" + value + "' to 'OutputStream'", e);
+        }
+    }
+}

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
@@ -65,8 +65,11 @@ public final class Fastjson2Encoder
             if (JSON.isValidObject(str)) {
                 bytes = str.getBytes(config.getCharset());
             }
-        } else if (value instanceof byte[] && JSON.isValid((byte[]) value)) {
-            bytes = (byte[]) value;
+        } else if (value instanceof byte[]) {
+            byte[] curBytes = (byte[]) value;
+            if (JSON.isValid(curBytes)) {
+                bytes = (byte[]) value;
+            }
         }
         // If bytes is not null, write it to a DataBuffer
         if (bytes != null) {

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Decoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Decoder.java
@@ -27,7 +27,9 @@ import java.util.Map;
  *
  * @author Xi.Liu
  * @see AbstractJackson2Decoder
+ * @deprecated in favor of {@link com.alibaba.fastjson2.support.spring.codec.Fastjson2Encoder} and {@link com.alibaba.fastjson2.support.spring.codec.Fastjson2Decoder}
  */
+@Deprecated
 public class Fastjson2Decoder
         extends AbstractJackson2Decoder {
     private final FastJsonConfig config;

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Encoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/codec/Fastjson2Encoder.java
@@ -27,7 +27,9 @@ import java.util.Map;
  *
  * @author Xi.Liu
  * @see AbstractJackson2Decoder
+ * @deprecated in favor of {@link com.alibaba.fastjson2.support.spring.codec.Fastjson2Encoder} and {@link com.alibaba.fastjson2.support.spring.codec.Fastjson2Decoder}
  */
+@Deprecated
 public class Fastjson2Encoder
         extends AbstractJackson2Encoder {
     private final FastJsonConfig config;

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2CodecTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2CodecTest.java
@@ -1,0 +1,353 @@
+package com.alibaba.fastjson2.spring.codec;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.codec.Fastjson2Decoder;
+import com.alibaba.fastjson2.support.spring.codec.Fastjson2Encoder;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Fastjson2Encoder 和 Fastjson2Decoder 集成测试
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+public class Fastjson2CodecTest {
+    private Fastjson2Encoder encoder;
+    private Fastjson2Decoder decoder;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        encoder = new Fastjson2Encoder();
+        decoder = new Fastjson2Decoder();
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    @Test
+    void testEncodeThenDecodeSimpleObject() {
+        // 准备测试数据
+        TestVO original = new TestVO();
+        original.setId(123);
+        original.setName("test object");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVO.class, decoded);
+        TestVO result = (TestVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+    }
+
+    @Test
+    void testEncodeThenDecodeComplexObject() {
+        // 准备复杂测试数据
+        ComplexVO original = new ComplexVO();
+        original.setId(1);
+        original.setName("complex test");
+        original.setTags(Arrays.asList("tag1", "tag2", "tag3"));
+        //Map.of("key1", "value1", "key2", "value2")
+        original.setMetadata(
+                new HashMap<String, String>() {
+                    {
+                        put("key1", "value1");
+                        put("key2", "value2");
+                    }
+                }
+        );
+
+        ResolvableType type = ResolvableType.forClass(ComplexVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(ComplexVO.class, decoded);
+        ComplexVO result = (ComplexVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getTags(), result.getTags());
+        assertEquals(original.getMetadata(), result.getMetadata());
+    }
+
+    @Test
+    void testEncodeThenDecodeFlux() {
+        // 准备测试数据
+        TestVO vo1 = new TestVO();
+        vo1.setId(1);
+        vo1.setName("first");
+
+        TestVO vo2 = new TestVO();
+        vo2.setId(2);
+        vo2.setName("second");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 编码 Flux
+        Flux<DataBuffer> encodedFlux = encoder.encode(Flux.just(vo1, vo2), bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码 Flux
+        Flux<Object> decodedFlux = decoder.decode(encodedFlux, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(decodedFlux)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO resultVO = (TestVO) result;
+                    return resultVO.getId() == 1 && "first".equals(resultVO.getName());
+                })
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO resultVO = (TestVO) result;
+                    return resultVO.getId() == 2 && "second".equals(resultVO.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testEncodeThenDecodeMono() {
+        // 准备测试数据
+        TestVO original = new TestVO();
+        original.setId(456);
+        original.setName("mono test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码为 Mono
+        Mono<Object> decodedMono = decoder.decodeToMono(Flux.just(encodedBuffer), type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(decodedMono)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO resultVO = (TestVO) result;
+                    return resultVO.getId() == 456 && "mono test".equals(resultVO.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testEncodeThenDecodeWithCustomConfig() {
+        // 创建自定义配置
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        Fastjson2Encoder customEncoder = new Fastjson2Encoder(config, MediaType.APPLICATION_JSON);
+        Fastjson2Decoder customDecoder = new Fastjson2Decoder(config, MediaType.APPLICATION_JSON);
+
+        // 准备测试数据
+        TestVOWithDate original = new TestVOWithDate();
+        original.setId(1);
+        original.setName("custom config test");
+        original.setDate("2023-01-01 12:00:00");
+
+        ResolvableType type = ResolvableType.forClass(TestVOWithDate.class);
+
+        // 编码
+        DataBuffer encodedBuffer = customEncoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = customDecoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVOWithDate.class, decoded);
+        TestVOWithDate result = (TestVOWithDate) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getDate(), result.getDate());
+    }
+
+    @Test
+    void testEncodeThenDecodePrimitiveTypes() {
+        // 测试整数
+        testEncodeThenDecodePrimitive(123, Integer.class);
+
+        // 测试字符串
+        testEncodeThenDecodePrimitive("hello world", String.class);
+
+        // 测试布尔值
+        testEncodeThenDecodePrimitive(true, Boolean.class);
+
+        // 测试浮点数
+        testEncodeThenDecodePrimitive(123.45, Double.class);
+    }
+
+    private <T> void testEncodeThenDecodePrimitive(T original, Class<T> clazz) {
+        ResolvableType type = ResolvableType.forClass(clazz);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertEquals(original, decoded);
+    }
+
+    @Test
+    void testEncodeThenDecodeNull() {
+        ResolvableType type = ResolvableType.forClass(Object.class);
+
+        // 编码 null
+        DataBuffer encodedBuffer = encoder.encodeValue(null, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNull(decoded);
+    }
+
+    @Test
+    void testEncodeThenDecodeWithHints() {
+        // 准备测试数据
+        TestVO original = new TestVO();
+        original.setId(789);
+        original.setName("hints test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        //Map.of("test", "value")
+        Map<String, Object> hints = new HashMap<String, Object>() {
+            {
+                put("test", "value");
+            }
+        };
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, hints);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, hints);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVO.class, decoded);
+        TestVO result = (TestVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+    }
+
+    @Test
+    void testEncodeThenDecodeLargeObject() {
+        // 准备大型测试数据
+        LargeVO original = new LargeVO();
+        original.setId(1);
+        original.setName("large test");
+        original.setDescription("This is a large object for testing purposes");
+        //"x".repeat(1000)
+        char[] chars = new char[1000];
+        Arrays.fill(chars, 'x');
+        original.setData(new String(chars)); // 1KB 的数据
+
+        ResolvableType type = ResolvableType.forClass(LargeVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(LargeVO.class, decoded);
+        LargeVO result = (LargeVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getDescription(), result.getDescription());
+        assertEquals(original.getData(), result.getData());
+    }
+
+    @Test
+    void testEncodeThenDecodeWithSpecialCharacters() {
+        // 准备包含特殊字符的测试数据
+        TestVO original = new TestVO();
+        original.setId(1);
+        original.setName("特殊字符测试: 中文, English, 123, !@#$%^&*()");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVO.class, decoded);
+        TestVO result = (TestVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+    }
+
+    // 测试用的 VO 类
+    @Setter
+    @Getter
+    private static class TestVO {
+        private int id;
+        private String name;
+    }
+
+    // 带日期的测试 VO 类
+    @Setter
+    @Getter
+    private static class TestVOWithDate {
+        private int id;
+        private String name;
+        private String date;
+    }
+
+    // 复杂对象测试类
+    @Setter
+    @Getter
+    private static class ComplexVO {
+        private int id;
+        private String name;
+        private List<String> tags;
+        private Map<String, String> metadata;
+    }
+
+    // 大型对象测试类
+    @Setter
+    @Getter
+    private static class LargeVO {
+        private int id;
+        private String name;
+        private String description;
+        private String data;
+    }
+}

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2DecoderTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2DecoderTest.java
@@ -1,0 +1,240 @@
+package com.alibaba.fastjson2.spring.codec;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.codec.Fastjson2Decoder;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Fastjson2Decoder 单元测试
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+public class Fastjson2DecoderTest {
+    private Fastjson2Decoder decoderAll;
+    private Fastjson2Decoder decoderJson;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        decoderAll = new Fastjson2Decoder();
+        decoderJson = new Fastjson2Decoder(new FastJsonConfig(), MediaType.APPLICATION_JSON);
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        Fastjson2Decoder defaultDecoder = new Fastjson2Decoder();
+        assertNotNull(defaultDecoder);
+        assertTrue(defaultDecoder.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testConstructorWithConfig() {
+        FastJsonConfig config = new FastJsonConfig();
+        Fastjson2Decoder customDecoder = new Fastjson2Decoder(config, MediaType.APPLICATION_JSON);
+        assertNotNull(customDecoder);
+        assertTrue(customDecoder.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testDecodeSimpleObject() {
+        // 准备测试数据
+        String json = "{\"id\":123,\"name\":\"test\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行解码
+        Object result = decoderAll.decode(buffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(result);
+        assertInstanceOf(TestVO.class, result);
+        TestVO vo = (TestVO) result;
+        assertEquals(123, vo.getId());
+        assertEquals("test", vo.getName());
+    }
+
+    @Test
+    void testDecodeToMono() {
+        // 准备测试数据
+        String json = "{\"id\":456,\"name\":\"mono test\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行解码
+        Mono<Object> mono = decoderAll.decodeToMono(Flux.just(buffer), type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(mono)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO vo = (TestVO) result;
+                    return vo.getId() == 456 && "mono test".equals(vo.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testDecodeFlux() {
+        // 准备测试数据
+        String json1 = "{\"id\":1,\"name\":\"first\"}";
+        String json2 = "{\"id\":2,\"name\":\"second\"}";
+
+        DataBuffer buffer1 = bufferFactory.wrap(json1.getBytes(StandardCharsets.UTF_8));
+        DataBuffer buffer2 = bufferFactory.wrap(json2.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行解码
+        Flux<Object> flux = decoderAll.decode(Flux.just(buffer1, buffer2), type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(flux)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO vo = (TestVO) result;
+                    return vo.getId() == 1 && "first".equals(vo.getName());
+                })
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO vo = (TestVO) result;
+                    return vo.getId() == 2 && "second".equals(vo.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testDecodePrimitiveTypes() {
+        // 测试整数
+        DataBuffer intBuffer = bufferFactory.wrap("123".getBytes(StandardCharsets.UTF_8));
+        Object intResult = decoderAll.decode(intBuffer, ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON, null);
+        assertEquals(123, intResult);
+
+        // 测试字符串
+        DataBuffer stringBuffer = bufferFactory.wrap("\"hello world\"".getBytes(StandardCharsets.UTF_8));
+        Object stringResult = decoderAll.decode(stringBuffer, ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON, null);
+        assertEquals("hello world", stringResult);
+
+        // 测试布尔值
+        DataBuffer boolBuffer = bufferFactory.wrap("true".getBytes(StandardCharsets.UTF_8));
+        Object boolResult = decoderAll.decode(boolBuffer, ResolvableType.forClass(Boolean.class), MediaType.APPLICATION_JSON, null);
+        assertEquals(true, boolResult);
+    }
+
+    @Test
+    void testDecodeWithCustomConfig() {
+        // 创建自定义配置
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+        Fastjson2Decoder customDecoder = new Fastjson2Decoder(config, MediaType.APPLICATION_JSON);
+
+        // 测试带日期的对象
+        String json = "{\"id\":1,\"name\":\"test\",\"date\":\"2023-01-01 12:00:00\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVOWithDate.class);
+        Object result = customDecoder.decode(buffer, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        assertInstanceOf(TestVOWithDate.class, result);
+    }
+
+    @Test
+    void testDecodeInvalidJson() {
+        // 准备无效的 JSON 数据
+        String invalidJson = "{\"id\":123,\"name\":}";
+        DataBuffer buffer = bufferFactory.wrap(invalidJson.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 验证抛出异常
+        assertThrows(DecodingException.class, () -> {
+            decoderAll.decode(buffer, type, MediaType.APPLICATION_JSON, null);
+        });
+    }
+
+    @Test
+    void testDecodeEmptyBuffer() {
+        // 准备空数据
+        DataBuffer emptyBuffer = bufferFactory.wrap(new byte[0]);
+
+        ResolvableType type = ResolvableType.forClass(String.class);
+
+        // 验证空数据解码
+        Object result = decoderAll.decode(emptyBuffer, type, MediaType.APPLICATION_JSON, null);
+        assertNull(result);
+    }
+
+    @Test
+    void testCanDecode() {
+        // 测试支持的媒体类型
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
+
+        // 测试不支持的媒体类型
+        assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
+        assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+    }
+
+    @Test
+    void testDecodeWithHints() {
+        // 准备测试数据
+        String json = "{\"id\":789,\"name\":\"hints test\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        Map<String, Object> hints = new HashMap<String, Object>() {{
+                put("test", "value");
+            }};
+
+        // 执行解码
+        Object result = decoderAll.decode(buffer, type, MediaType.APPLICATION_JSON, hints);
+
+        // 验证结果
+        assertNotNull(result);
+        assertInstanceOf(TestVO.class, result);
+        TestVO vo = (TestVO) result;
+        assertEquals(789, vo.getId());
+        assertEquals("hints test", vo.getName());
+    }
+
+    // 测试用的 VO 类
+    @Setter
+    @Getter
+    private static class TestVO {
+        private int id;
+        private String name;
+    }
+
+    // 带日期的测试 VO 类
+    @Getter
+    @Setter
+    private static class TestVOWithDate {
+        private int id;
+        private String name;
+        private String date;
+    }
+}

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2EncoderTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2EncoderTest.java
@@ -1,0 +1,330 @@
+package com.alibaba.fastjson2.spring.codec;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.codec.Fastjson2Encoder;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Fastjson2Encoder 单元测试
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+public class Fastjson2EncoderTest {
+    private Fastjson2Encoder encoderAll;
+    private Fastjson2Encoder encoderJson;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        encoderAll = new Fastjson2Encoder();
+        encoderJson = new Fastjson2Encoder(new FastJsonConfig(), MediaType.APPLICATION_JSON);
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        Fastjson2Encoder defaultEncoder = new Fastjson2Encoder();
+        assertNotNull(defaultEncoder);
+        assertTrue(defaultEncoder.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testConstructorWithConfig() {
+        FastJsonConfig config = new FastJsonConfig();
+        Fastjson2Encoder customEncoder = new Fastjson2Encoder(config, MediaType.APPLICATION_JSON);
+        assertNotNull(customEncoder);
+        assertTrue(customEncoder.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testEncodeSimpleObject() {
+        // 准备测试数据
+        TestVO vo = new TestVO();
+        vo.setId(123);
+        vo.setName("test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行编码
+        DataBuffer result = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":123"));
+        assertTrue(json.contains("\"name\":\"test\""));
+    }
+
+    @Test
+    void testEncodeFlux() {
+        // 准备测试数据
+        TestVO vo1 = new TestVO();
+        vo1.setId(1);
+        vo1.setName("first");
+
+        TestVO vo2 = new TestVO();
+        vo2.setId(2);
+        vo2.setName("second");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行编码
+        Flux<DataBuffer> flux = encoderAll.encode(Flux.just(vo1, vo2), bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(flux)
+                .expectNextMatches(buffer -> {
+                    String json = buffer.toString(StandardCharsets.UTF_8);
+                    return json.contains("\"id\":1") && json.contains("\"name\":\"first\"");
+                })
+                .expectNextMatches(buffer -> {
+                    String json = buffer.toString(StandardCharsets.UTF_8);
+                    return json.contains("\"id\":2") && json.contains("\"name\":\"second\"");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testEncodePrimitiveTypes() {
+        // 测试整数
+        ResolvableType intType = ResolvableType.forClass(Integer.class);
+        DataBuffer intBuffer = encoderAll.encodeValue(123, bufferFactory, intType, MediaType.APPLICATION_JSON, null);
+        assertEquals("123", intBuffer.toString(StandardCharsets.UTF_8));
+
+        // 测试字符串
+        ResolvableType stringType = ResolvableType.forClass(String.class);
+        DataBuffer stringBuffer = encoderAll.encodeValue("hello world", bufferFactory, stringType, MediaType.APPLICATION_JSON, null);
+        assertEquals("\"hello world\"", stringBuffer.toString(StandardCharsets.UTF_8));
+
+        // 测试布尔值
+        ResolvableType boolType = ResolvableType.forClass(Boolean.class);
+        DataBuffer boolBuffer = encoderAll.encodeValue(true, bufferFactory, boolType, MediaType.APPLICATION_JSON, null);
+        assertEquals("true", boolBuffer.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testEncodeWithCustomConfig() {
+        // 创建自定义配置
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+        Fastjson2Encoder customEncoder = new Fastjson2Encoder(config, MediaType.APPLICATION_JSON);
+
+        // 测试带日期的对象
+        TestVOWithDate vo = new TestVOWithDate();
+        vo.setId(1);
+        vo.setName("test");
+        vo.setDate("2023-01-01 12:00:00");
+
+        ResolvableType type = ResolvableType.forClass(TestVOWithDate.class);
+        DataBuffer result = customEncoder.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":1"));
+        assertTrue(json.contains("\"name\":\"test\""));
+        assertTrue(json.contains("\"date\":\"2023-01-01 12:00:00\""));
+    }
+
+    @Test
+    void testEncodeValidJsonString() {
+        // 测试有效的 JSON 字符串
+        String validJson = "{\"id\":123,\"name\":\"test\"}";
+        ResolvableType type = ResolvableType.forClass(String.class);
+
+        DataBuffer result = encoderAll.encodeValue(validJson, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals(validJson, encoded);
+    }
+
+    @Test
+    void testEncodeValidJsonBytes() {
+        // 测试有效的 JSON 字节数组
+        String jsonString = "{\"id\":123,\"name\":\"test\"}";
+        byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+        ResolvableType type = ResolvableType.forClass(byte[].class);
+
+        DataBuffer result = encoderAll.encodeValue(jsonBytes, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals(jsonString, encoded);
+    }
+
+    @Test
+    void testEncodeInvalidJsonString() {
+        // 测试无效的 JSON 字符串（不是有效的 JSON 对象）
+        String invalidJson = "not a json object";
+        ResolvableType type = ResolvableType.forClass(String.class);
+
+        // 应该正常编码，因为不是有效的 JSON 对象
+        DataBuffer result = encoderAll.encodeValue(invalidJson, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals("\"not a json object\"", encoded);
+    }
+
+    @Test
+    void testEncodeNull() {
+        // 测试 null 值
+        ResolvableType type = ResolvableType.forClass(Object.class);
+
+        DataBuffer result = encoderAll.encodeValue(null, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals("null", encoded);
+    }
+
+    @Test
+    void testEncodeComplexObject() {
+        // 测试复杂对象
+        ComplexVO complex = new ComplexVO();
+        complex.setId(1);
+        complex.setName("complex");
+        complex.setTags(Arrays.asList("tag1", "tag2"));
+        complex.setMetadata(
+                new HashMap<String, String>() {
+                    {
+                        put("key1", "value1");
+                        put("key2", "value2");
+                    }
+                }
+        );
+
+        ResolvableType type = ResolvableType.forClass(ComplexVO.class);
+
+        DataBuffer result = encoderAll.encodeValue(complex, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":1"));
+        assertTrue(json.contains("\"name\":\"complex\""));
+        assertTrue(json.contains("\"tag1\""));
+        assertTrue(json.contains("\"tag2\""));
+        assertTrue(json.contains("\"key1\":\"value1\""));
+        assertTrue(json.contains("\"key2\":\"value2\""));
+    }
+
+    @Test
+    void testCanEncode() {
+        // 测试支持的媒体类型
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
+
+        // 测试不支持的媒体类型
+        assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
+        assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+    }
+
+    @Test
+    void testEncodeWithHints() {
+        // 准备测试数据
+        TestVO vo = new TestVO();
+        vo.setId(789);
+        vo.setName("hints test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        //Map.of("test", "value");
+        Map<String, Object> hints = new HashMap<String, Object>() {
+            {
+                put("test", "value");
+            }
+        };
+
+        // 执行编码
+        DataBuffer result = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, hints);
+
+        // 验证结果
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":789"));
+        assertTrue(json.contains("\"name\":\"hints test\""));
+    }
+
+    @Test
+    void testEncodeWithDifferentMimeTypes() {
+        // 测试不同的 MIME 类型
+        TestVO vo = new TestVO();
+        vo.setId(1);
+        vo.setName("test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 测试 APPLICATION_JSON
+        DataBuffer jsonBuffer = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+        assertNotNull(jsonBuffer);
+
+        // 测试 ALL
+        DataBuffer allBuffer = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.ALL, null);
+        assertNotNull(allBuffer);
+    }
+
+    @Test
+    void testEncodeExceptionHandling() {
+        // 测试编码异常处理
+        // 创建一个可能导致编码异常的对象（如果有的话）
+        // 这里我们测试一个正常情况，因为 Fastjson2 通常能处理大多数对象
+
+        TestVO vo = new TestVO();
+        vo.setId(1);
+        vo.setName("test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 正常情况下不应该抛出异常
+        assertDoesNotThrow(() -> {
+            encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+        });
+    }
+
+    // 测试用的 VO 类
+    @Setter
+    @Getter
+    private static class TestVO {
+        private int id;
+        private String name;
+    }
+
+    // 带日期的测试 VO 类
+    @Setter
+    @Getter
+    private static class TestVOWithDate {
+        private int id;
+        private String name;
+        private String date;
+    }
+
+    // 复杂对象测试类
+    @Setter
+    @Getter
+    private static class ComplexVO {
+        private int id;
+        private String name;
+        private List<String> tags;
+        private Map<String, String> metadata;
+    }
+}

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -219,6 +219,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>3.1.0.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
             <version>${springframework6.version}</version>

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Decoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Decoder.java
@@ -1,21 +1,22 @@
-package com.alibaba.fastjson2.support.spring6.http.codec;
+package com.alibaba.fastjson2.support.spring6.codec;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.support.config.FastJsonConfig;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.reactivestreams.Publisher;
 import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.AbstractDecoder;
 import org.springframework.core.codec.DecodingException;
 import org.springframework.core.codec.Hints;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.log.LogFormatUtils;
-import org.springframework.http.codec.json.AbstractJackson2Decoder;
+import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.util.MimeType;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -23,43 +24,45 @@ import java.io.InputStream;
 import java.util.Map;
 
 /**
- * Fastjson2 for Spring WebFlux.
+ * spring message codec decoder for Fastjson2.
  *
- * @author Xi.Liu
- * @see AbstractJackson2Decoder
- * @deprecated in favor of {@link com.alibaba.fastjson2.support.spring6.codec.Fastjson2Encoder} and {@link com.alibaba.fastjson2.support.spring6.codec.Fastjson2Decoder}
+ * @author 张治保
+ * @since 2025/8/6
  */
-@Deprecated
-public class Fastjson2Decoder
-        extends AbstractJackson2Decoder {
+public final class Fastjson2Decoder
+        extends AbstractDecoder<Object> {
     private final FastJsonConfig config;
 
-    public Fastjson2Decoder(ObjectMapper mapper, MimeType... mimeTypes) {
-        super(mapper, mimeTypes);
-        this.config = new FastJsonConfig();
+    /**
+     * default constructor
+     */
+    public Fastjson2Decoder() {
+        this(new FastJsonConfig(), MediaType.ALL);
     }
 
-    public Fastjson2Decoder(ObjectMapper mapper, FastJsonConfig config, MimeType... mimeTypes) {
-        super(mapper, mimeTypes);
+    /**
+     * Constructor with custom configs
+     *
+     * @param config    FastJsonConfig
+     * @param mimeTypes the mime types to support
+     */
+    public Fastjson2Decoder(FastJsonConfig config, MimeType... mimeTypes) {
+        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
         this.config = config;
     }
 
-    @NonNull
     @Override
-    public Flux<Object> decode(@NonNull Publisher<DataBuffer> input,
-                               @NonNull ResolvableType elementType,
-                               MimeType mimeType,
-                               Map<String, Object> hints) {
-        throw new UnsupportedOperationException("Does not support stream decoding yet");
+    @NonNull
+    public Flux<Object> decode(@NonNull Publisher<DataBuffer> inputStream, @NonNull ResolvableType elementType, @Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
+        return Flux.from(inputStream)
+                .mapNotNull(dataBuffer -> decode(dataBuffer, elementType, mimeType, hints));
     }
 
     @Override
-    public Object decode(@NonNull DataBuffer dataBuffer,
-                         @NonNull ResolvableType targetType,
-                         MimeType mimeType,
-                         Map<String, Object> hints) throws DecodingException {
+    @Nullable
+    public Object decode(@NonNull DataBuffer buffer, @NonNull ResolvableType targetType, MimeType mimeType, Map<String, Object> hints) throws DecodingException {
         try (ByteArrayOutputStream os = new ByteArrayOutputStream();
-                InputStream in = dataBuffer.asInputStream()) {
+                InputStream in = buffer.asInputStream()) {
             byte[] buf = new byte[1 << 16];
             for (; ; ) {
                 int len = in.read(buf);
@@ -82,8 +85,16 @@ public class Fastjson2Decoder
         } catch (IOException ex) {
             throw new DecodingException("I/O error while reading input message", ex);
         } finally {
-            DataBufferUtils.release(dataBuffer);
+            DataBufferUtils.release(buffer);
         }
+    }
+
+    @Override
+    @NonNull
+    public Mono<Object> decodeToMono(@NonNull Publisher<DataBuffer> inputStream, @NonNull ResolvableType elementType,
+                                     @Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
+        return DataBufferUtils.join(inputStream)
+                .flatMap(dataBuffer -> Mono.justOrEmpty(decode(dataBuffer, elementType, mimeType, hints)));
     }
 
     private void logValue(@Nullable Object value, @Nullable Map<String, Object> hints) {

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Encoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Encoder.java
@@ -1,0 +1,91 @@
+package com.alibaba.fastjson2.support.spring6.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import org.reactivestreams.Publisher;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.*;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MimeType;
+import reactor.core.publisher.Flux;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * spring message codec encoder for Fastjson2.
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+
+public final class Fastjson2Encoder
+        extends AbstractEncoder<Object> {
+    private final FastJsonConfig config;
+
+    /**
+     * default constructor
+     */
+    public Fastjson2Encoder() {
+        this(new FastJsonConfig(), MediaType.ALL);
+    }
+
+    /**
+     * Constructor with custom configs
+     *
+     * @param config    FastJsonConfig
+     * @param mimeTypes the mime types to support
+     */
+    public Fastjson2Encoder(FastJsonConfig config, MimeType... mimeTypes) {
+        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
+        this.config = config;
+    }
+
+    @Override
+    @NonNull
+    public Flux<DataBuffer> encode(@NonNull Publisher<?> inputStream, @NonNull DataBufferFactory bufferFactory, @NonNull ResolvableType elementType, MimeType mimeType, Map<String, Object> hints) {
+        return Flux.from(inputStream)
+                .map(val -> encodeValue(val, bufferFactory, elementType, mimeType, hints));
+    }
+
+    @Override
+    @NonNull
+    public DataBuffer encodeValue(@Nullable Object value, @NonNull DataBufferFactory bufferFactory, @NonNull ResolvableType valueType, MimeType mimeType, Map<String, Object> hints) {
+        byte[] bytes = null;
+        // Check if the value is a valid JSON string or byte array
+        if (value instanceof String str && JSON.isValidObject(str)) {
+            bytes = str.getBytes(config.getCharset());
+        } else if (value instanceof byte[] bts && JSON.isValid(bts)) {
+            bytes = bts;
+        }
+        // If bytes is not null, write it to a DataBuffer
+        if (bytes != null) {
+            int length = bytes.length;
+            DataBuffer buffer = bufferFactory.allocateBuffer(length)
+                    .write(bytes, 0, length);
+            Hints.touchDataBuffer(buffer, hints, logger);
+            return buffer;
+        }
+        //@see JSON.writeTo
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            JSON.writeTo(
+                    baos,
+                    value,
+                    config.getDateFormat(),
+                    config.getWriterFilters(),
+                    config.getWriterFeatures()
+            );
+            DataBuffer buffer = bufferFactory.allocateBuffer(baos.size());
+            baos.writeTo(buffer.asOutputStream());
+            Hints.touchDataBuffer(buffer, hints, logger);
+            return buffer;
+        } catch (IOException e) {
+            throw new EncodingException("JSON#writeTo cannot serialize '" + value + "' to 'OutputStream'", e);
+        }
+    }
+}

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Encoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Encoder.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.*;
 import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring6.codec.Fastjson2Decoder;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.core.ResolvableType;
@@ -27,7 +28,9 @@ import java.util.Map;
  *
  * @author Xi.Liu
  * @see AbstractJackson2Decoder
+ * @deprecated in favor of {@link com.alibaba.fastjson2.support.spring6.codec.Fastjson2Encoder} and {@link Fastjson2Decoder}
  */
+@Deprecated
 public class Fastjson2Encoder
         extends AbstractJackson2Encoder {
     private final FastJsonConfig config;

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Encoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/http/codec/Fastjson2Encoder.java
@@ -5,7 +5,6 @@ import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.*;
 import com.alibaba.fastjson2.support.config.FastJsonConfig;
-import com.alibaba.fastjson2.support.spring6.codec.Fastjson2Decoder;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.core.ResolvableType;
@@ -28,7 +27,7 @@ import java.util.Map;
  *
  * @author Xi.Liu
  * @see AbstractJackson2Decoder
- * @deprecated in favor of {@link com.alibaba.fastjson2.support.spring6.codec.Fastjson2Encoder} and {@link Fastjson2Decoder}
+ * @deprecated in favor of {@link com.alibaba.fastjson2.support.spring6.codec.Fastjson2Encoder} and {@link com.alibaba.fastjson2.support.spring6.codec.Fastjson2Decoder}
  */
 @Deprecated
 public class Fastjson2Encoder

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2CodecTest.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2CodecTest.java
@@ -1,0 +1,340 @@
+package com.alibaba.fastjson2.support.spring6.codec;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Fastjson2Encoder 和 Fastjson2Decoder 集成测试
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+public class Fastjson2CodecTest {
+    private Fastjson2Encoder encoder;
+    private Fastjson2Decoder decoder;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        encoder = new Fastjson2Encoder();
+        decoder = new Fastjson2Decoder();
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    @Test
+    void testEncodeThenDecodeSimpleObject() {
+        // 准备测试数据
+        TestVO original = new TestVO();
+        original.setId(123);
+        original.setName("test object");
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVO.class, decoded);
+        TestVO result = (TestVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+    }
+
+    @Test
+    void testEncodeThenDecodeComplexObject() {
+        // 准备复杂测试数据
+        ComplexVO original = new ComplexVO();
+        original.setId(1);
+        original.setName("complex test");
+        original.setTags(Arrays.asList("tag1", "tag2", "tag3"));
+        //Map.of("key1", "value1", "key2", "value2")
+        original.setMetadata(
+                new HashMap<String, String>() {
+                    {
+                        put("key1", "value1");
+                        put("key2", "value2");
+                    }
+                }
+        );
+        ResolvableType type = ResolvableType.forClass(ComplexVO.class);
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(ComplexVO.class, decoded);
+        ComplexVO result = (ComplexVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getTags(), result.getTags());
+        assertEquals(original.getMetadata(), result.getMetadata());
+    }
+
+    @Test
+    void testEncodeThenDecodeFlux() {
+        // 准备测试数据
+        TestVO vo1 = new TestVO();
+        vo1.setId(1);
+        vo1.setName("first");
+        TestVO vo2 = new TestVO();
+        vo2.setId(2);
+        vo2.setName("second");
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        // 编码 Flux
+        Flux<DataBuffer> encodedFlux = encoder.encode(Flux.just(vo1, vo2), bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码 Flux
+        Flux<Object> decodedFlux = decoder.decode(encodedFlux, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(decodedFlux)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO resultVO = (TestVO) result;
+                    return resultVO.getId() == 1 && "first".equals(resultVO.getName());
+                })
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO resultVO = (TestVO) result;
+                    return resultVO.getId() == 2 && "second".equals(resultVO.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testEncodeThenDecodeMono() {
+        // 准备测试数据
+        TestVO original = new TestVO();
+        original.setId(456);
+        original.setName("mono test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码为 Mono
+        Mono<Object> decodedMono = decoder.decodeToMono(Flux.just(encodedBuffer), type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(decodedMono)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO resultVO = (TestVO) result;
+                    return resultVO.getId() == 456 && "mono test".equals(resultVO.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testEncodeThenDecodeWithCustomConfig() {
+        // 创建自定义配置
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        Fastjson2Encoder customEncoder = new Fastjson2Encoder(config, MediaType.APPLICATION_JSON);
+        Fastjson2Decoder customDecoder = new Fastjson2Decoder(config, MediaType.APPLICATION_JSON);
+
+        // 准备测试数据
+        TestVOWithDate original = new TestVOWithDate();
+        original.setId(1);
+        original.setName("custom config test");
+        original.setDate("2023-01-01 12:00:00");
+
+        ResolvableType type = ResolvableType.forClass(TestVOWithDate.class);
+
+        // 编码
+        DataBuffer encodedBuffer = customEncoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = customDecoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVOWithDate.class, decoded);
+        TestVOWithDate result = (TestVOWithDate) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getDate(), result.getDate());
+    }
+
+    @Test
+    void testEncodeThenDecodePrimitiveTypes() {
+        // 测试整数
+        testEncodeThenDecodePrimitive(123, Integer.class);
+
+        // 测试字符串
+        testEncodeThenDecodePrimitive("hello world", String.class);
+
+        // 测试布尔值
+        testEncodeThenDecodePrimitive(true, Boolean.class);
+
+        // 测试浮点数
+        testEncodeThenDecodePrimitive(123.45, Double.class);
+    }
+
+    private <T> void testEncodeThenDecodePrimitive(T original, Class<T> clazz) {
+        ResolvableType type = ResolvableType.forClass(clazz);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertEquals(original, decoded);
+    }
+
+    @Test
+    void testEncodeThenDecodeNull() {
+        ResolvableType type = ResolvableType.forClass(Object.class);
+
+        // 编码 null
+        DataBuffer encodedBuffer = encoder.encodeValue(null, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNull(decoded);
+    }
+
+    @Test
+    void testEncodeThenDecodeWithHints() {
+        // 准备测试数据
+        TestVO original = new TestVO();
+        original.setId(789);
+        original.setName("hints test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        //Map.of("test", "value")
+        Map<String, Object> hints = new HashMap<String, Object>() {
+            {
+                put("test", "value");
+            }
+        };
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, hints);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, hints);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVO.class, decoded);
+        TestVO result = (TestVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+    }
+
+    @Test
+    void testEncodeThenDecodeLargeObject() {
+        // 准备大型测试数据
+        LargeVO original = new LargeVO();
+        original.setId(1);
+        original.setName("large test");
+        original.setDescription("This is a large object for testing purposes");
+        //"x".repeat(1000)
+        char[] chars = new char[1000];
+        Arrays.fill(chars, 'x');
+        original.setData(new String(chars)); // 1KB 的数据
+
+        ResolvableType type = ResolvableType.forClass(LargeVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(LargeVO.class, decoded);
+        LargeVO result = (LargeVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getDescription(), result.getDescription());
+        assertEquals(original.getData(), result.getData());
+    }
+
+    @Test
+    void testEncodeThenDecodeWithSpecialCharacters() {
+        // 准备包含特殊字符的测试数据
+        TestVO original = new TestVO();
+        original.setId(1);
+        original.setName("特殊字符测试: 中文, English, 123, !@#$%^&*()");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 编码
+        DataBuffer encodedBuffer = encoder.encodeValue(original, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 解码
+        Object decoded = decoder.decode(encodedBuffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(decoded);
+        assertInstanceOf(TestVO.class, decoded);
+        TestVO result = (TestVO) decoded;
+        assertEquals(original.getId(), result.getId());
+        assertEquals(original.getName(), result.getName());
+    }
+
+    // 测试用的 VO 类
+    @Setter
+    @Getter
+    private static class TestVO {
+        private int id;
+        private String name;
+    }
+
+    // 带日期的测试 VO 类
+    @Setter
+    @Getter
+    private static class TestVOWithDate {
+        private int id;
+        private String name;
+        private String date;
+    }
+
+    // 复杂对象测试类
+    @Setter
+    @Getter
+    private static class ComplexVO {
+        private int id;
+        private String name;
+        private List<String> tags;
+        private Map<String, String> metadata;
+    }
+
+    // 大型对象测试类
+    @Setter
+    @Getter
+    private static class LargeVO {
+        private int id;
+        private String name;
+        private String description;
+        private String data;
+    }
+}

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2DecoderTest.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2DecoderTest.java
@@ -1,0 +1,239 @@
+package com.alibaba.fastjson2.support.spring6.codec;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.codec.DecodingException;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Fastjson2Decoder 单元测试
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+public class Fastjson2DecoderTest {
+    private Fastjson2Decoder decoderAll;
+    private Fastjson2Decoder decoderJson;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        decoderAll = new Fastjson2Decoder();
+        decoderJson = new Fastjson2Decoder(new FastJsonConfig(), MediaType.APPLICATION_JSON);
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        Fastjson2Decoder defaultDecoder = new Fastjson2Decoder();
+        assertNotNull(defaultDecoder);
+        assertTrue(defaultDecoder.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testConstructorWithConfig() {
+        FastJsonConfig config = new FastJsonConfig();
+        Fastjson2Decoder customDecoder = new Fastjson2Decoder(config, MediaType.APPLICATION_JSON);
+        assertNotNull(customDecoder);
+        assertTrue(customDecoder.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testDecodeSimpleObject() {
+        // 准备测试数据
+        String json = "{\"id\":123,\"name\":\"test\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行解码
+        Object result = decoderAll.decode(buffer, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(result);
+        assertInstanceOf(TestVO.class, result);
+        TestVO vo = (TestVO) result;
+        assertEquals(123, vo.getId());
+        assertEquals("test", vo.getName());
+    }
+
+    @Test
+    void testDecodeToMono() {
+        // 准备测试数据
+        String json = "{\"id\":456,\"name\":\"mono test\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行解码
+        Mono<Object> mono = decoderAll.decodeToMono(Flux.just(buffer), type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(mono)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO vo = (TestVO) result;
+                    return vo.getId() == 456 && "mono test".equals(vo.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testDecodeFlux() {
+        // 准备测试数据
+        String json1 = "{\"id\":1,\"name\":\"first\"}";
+        String json2 = "{\"id\":2,\"name\":\"second\"}";
+
+        DataBuffer buffer1 = bufferFactory.wrap(json1.getBytes(StandardCharsets.UTF_8));
+        DataBuffer buffer2 = bufferFactory.wrap(json2.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行解码
+        Flux<Object> flux = decoderAll.decode(Flux.just(buffer1, buffer2), type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(flux)
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO vo = (TestVO) result;
+                    return vo.getId() == 1 && "first".equals(vo.getName());
+                })
+                .expectNextMatches(result -> {
+                    assertInstanceOf(TestVO.class, result);
+                    TestVO vo = (TestVO) result;
+                    return vo.getId() == 2 && "second".equals(vo.getName());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testDecodePrimitiveTypes() {
+        // 测试整数
+        DataBuffer intBuffer = bufferFactory.wrap("123".getBytes(StandardCharsets.UTF_8));
+        Object intResult = decoderAll.decode(intBuffer, ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON, null);
+        assertEquals(123, intResult);
+
+        // 测试字符串
+        DataBuffer stringBuffer = bufferFactory.wrap("\"hello world\"".getBytes(StandardCharsets.UTF_8));
+        Object stringResult = decoderAll.decode(stringBuffer, ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON, null);
+        assertEquals("hello world", stringResult);
+
+        // 测试布尔值
+        DataBuffer boolBuffer = bufferFactory.wrap("true".getBytes(StandardCharsets.UTF_8));
+        Object boolResult = decoderAll.decode(boolBuffer, ResolvableType.forClass(Boolean.class), MediaType.APPLICATION_JSON, null);
+        assertEquals(true, boolResult);
+    }
+
+    @Test
+    void testDecodeWithCustomConfig() {
+        // 创建自定义配置
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+        Fastjson2Decoder customDecoder = new Fastjson2Decoder(config, MediaType.APPLICATION_JSON);
+
+        // 测试带日期的对象
+        String json = "{\"id\":1,\"name\":\"test\",\"date\":\"2023-01-01 12:00:00\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVOWithDate.class);
+        Object result = customDecoder.decode(buffer, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        assertInstanceOf(TestVOWithDate.class, result);
+    }
+
+    @Test
+    void testDecodeInvalidJson() {
+        // 准备无效的 JSON 数据
+        String invalidJson = "{\"id\":123,\"name\":}";
+        DataBuffer buffer = bufferFactory.wrap(invalidJson.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 验证抛出异常
+        assertThrows(DecodingException.class, () -> {
+            decoderAll.decode(buffer, type, MediaType.APPLICATION_JSON, null);
+        });
+    }
+
+    @Test
+    void testDecodeEmptyBuffer() {
+        // 准备空数据
+        DataBuffer emptyBuffer = bufferFactory.wrap(new byte[0]);
+
+        ResolvableType type = ResolvableType.forClass(String.class);
+
+        // 验证空数据解码
+        Object result = decoderAll.decode(emptyBuffer, type, MediaType.APPLICATION_JSON, null);
+        assertNull(result);
+    }
+
+    @Test
+    void testCanDecode() {
+        // 测试支持的媒体类型
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
+
+        // 测试不支持的媒体类型
+        assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
+        assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+    }
+
+    @Test
+    void testDecodeWithHints() {
+        // 准备测试数据
+        String json = "{\"id\":789,\"name\":\"hints test\"}";
+        DataBuffer buffer = bufferFactory.wrap(json.getBytes(StandardCharsets.UTF_8));
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        Map<String, Object> hints = new HashMap<>() {{
+                put("test", "value");
+            }};
+
+        // 执行解码
+        Object result = decoderAll.decode(buffer, type, MediaType.APPLICATION_JSON, hints);
+
+        // 验证结果
+        assertNotNull(result);
+        assertInstanceOf(TestVO.class, result);
+        TestVO vo = (TestVO) result;
+        assertEquals(789, vo.getId());
+        assertEquals("hints test", vo.getName());
+    }
+
+    // 测试用的 VO 类
+    @Setter
+    @Getter
+    private static class TestVO {
+        private int id;
+        private String name;
+    }
+
+    // 带日期的测试 VO 类
+    @Getter
+    @Setter
+    private static class TestVOWithDate {
+        private int id;
+        private String name;
+        private String date;
+    }
+}

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2EncoderTest.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2EncoderTest.java
@@ -1,0 +1,329 @@
+package com.alibaba.fastjson2.support.spring6.codec;
+
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import lombok.Getter;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Fastjson2Encoder 单元测试
+ *
+ * @author 张治保
+ * @since 2025/8/6
+ */
+public class Fastjson2EncoderTest {
+    private Fastjson2Encoder encoderAll;
+    private Fastjson2Encoder encoderJson;
+    private DefaultDataBufferFactory bufferFactory;
+
+    @BeforeEach
+    void setUp() {
+        encoderAll = new Fastjson2Encoder();
+        encoderJson = new Fastjson2Encoder(new FastJsonConfig(), MediaType.APPLICATION_JSON);
+        bufferFactory = new DefaultDataBufferFactory();
+    }
+
+    @Test
+    void testDefaultConstructor() {
+        Fastjson2Encoder defaultEncoder = new Fastjson2Encoder();
+        assertNotNull(defaultEncoder);
+        assertTrue(defaultEncoder.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testConstructorWithConfig() {
+        FastJsonConfig config = new FastJsonConfig();
+        Fastjson2Encoder customEncoder = new Fastjson2Encoder(config, MediaType.APPLICATION_JSON);
+        assertNotNull(customEncoder);
+        assertTrue(customEncoder.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testEncodeSimpleObject() {
+        // 准备测试数据
+        TestVO vo = new TestVO();
+        vo.setId(123);
+        vo.setName("test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行编码
+        DataBuffer result = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":123"));
+        assertTrue(json.contains("\"name\":\"test\""));
+    }
+
+    @Test
+    void testEncodeFlux() {
+        // 准备测试数据
+        TestVO vo1 = new TestVO();
+        vo1.setId(1);
+        vo1.setName("first");
+
+        TestVO vo2 = new TestVO();
+        vo2.setId(2);
+        vo2.setName("second");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 执行编码
+        Flux<DataBuffer> flux = encoderAll.encode(Flux.just(vo1, vo2), bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        // 验证结果
+        StepVerifier.create(flux)
+                .expectNextMatches(buffer -> {
+                    String json = buffer.toString(StandardCharsets.UTF_8);
+                    return json.contains("\"id\":1") && json.contains("\"name\":\"first\"");
+                })
+                .expectNextMatches(buffer -> {
+                    String json = buffer.toString(StandardCharsets.UTF_8);
+                    return json.contains("\"id\":2") && json.contains("\"name\":\"second\"");
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void testEncodePrimitiveTypes() {
+        // 测试整数
+        ResolvableType intType = ResolvableType.forClass(Integer.class);
+        DataBuffer intBuffer = encoderAll.encodeValue(123, bufferFactory, intType, MediaType.APPLICATION_JSON, null);
+        assertEquals("123", intBuffer.toString(StandardCharsets.UTF_8));
+
+        // 测试字符串
+        ResolvableType stringType = ResolvableType.forClass(String.class);
+        DataBuffer stringBuffer = encoderAll.encodeValue("hello world", bufferFactory, stringType, MediaType.APPLICATION_JSON, null);
+        assertEquals("\"hello world\"", stringBuffer.toString(StandardCharsets.UTF_8));
+
+        // 测试布尔值
+        ResolvableType boolType = ResolvableType.forClass(Boolean.class);
+        DataBuffer boolBuffer = encoderAll.encodeValue(true, bufferFactory, boolType, MediaType.APPLICATION_JSON, null);
+        assertEquals("true", boolBuffer.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testEncodeWithCustomConfig() {
+        // 创建自定义配置
+        FastJsonConfig config = new FastJsonConfig();
+        config.setDateFormat("yyyy-MM-dd HH:mm:ss");
+        Fastjson2Encoder customEncoder = new Fastjson2Encoder(config, MediaType.APPLICATION_JSON);
+
+        // 测试带日期的对象
+        TestVOWithDate vo = new TestVOWithDate();
+        vo.setId(1);
+        vo.setName("test");
+        vo.setDate("2023-01-01 12:00:00");
+
+        ResolvableType type = ResolvableType.forClass(TestVOWithDate.class);
+        DataBuffer result = customEncoder.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":1"));
+        assertTrue(json.contains("\"name\":\"test\""));
+        assertTrue(json.contains("\"date\":\"2023-01-01 12:00:00\""));
+    }
+
+    @Test
+    void testEncodeValidJsonString() {
+        // 测试有效的 JSON 字符串
+        String validJson = "{\"id\":123,\"name\":\"test\"}";
+        ResolvableType type = ResolvableType.forClass(String.class);
+
+        DataBuffer result = encoderAll.encodeValue(validJson, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals(validJson, encoded);
+    }
+
+    @Test
+    void testEncodeValidJsonBytes() {
+        // 测试有效的 JSON 字节数组
+        String jsonString = "{\"id\":123,\"name\":\"test\"}";
+        byte[] jsonBytes = jsonString.getBytes(StandardCharsets.UTF_8);
+        ResolvableType type = ResolvableType.forClass(byte[].class);
+
+        DataBuffer result = encoderAll.encodeValue(jsonBytes, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals(jsonString, encoded);
+    }
+
+    @Test
+    void testEncodeInvalidJsonString() {
+        // 测试无效的 JSON 字符串（不是有效的 JSON 对象）
+        String invalidJson = "not a json object";
+        ResolvableType type = ResolvableType.forClass(String.class);
+
+        // 应该正常编码，因为不是有效的 JSON 对象
+        DataBuffer result = encoderAll.encodeValue(invalidJson, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals("\"not a json object\"", encoded);
+    }
+
+    @Test
+    void testEncodeNull() {
+        // 测试 null 值
+        ResolvableType type = ResolvableType.forClass(Object.class);
+
+        DataBuffer result = encoderAll.encodeValue(null, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String encoded = result.toString(StandardCharsets.UTF_8);
+        assertEquals("null", encoded);
+    }
+
+    @Test
+    void testEncodeComplexObject() {
+        // 测试复杂对象
+        ComplexVO complex = new ComplexVO();
+        complex.setId(1);
+        complex.setName("complex");
+        complex.setTags(Arrays.asList("tag1", "tag2"));
+        complex.setMetadata(
+                new HashMap<String, String>() {
+                    {
+                        put("key1", "value1");
+                        put("key2", "value2");
+                    }
+                }
+        );
+
+        ResolvableType type = ResolvableType.forClass(ComplexVO.class);
+
+        DataBuffer result = encoderAll.encodeValue(complex, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":1"));
+        assertTrue(json.contains("\"name\":\"complex\""));
+        assertTrue(json.contains("\"tag1\""));
+        assertTrue(json.contains("\"tag2\""));
+        assertTrue(json.contains("\"key1\":\"value1\""));
+        assertTrue(json.contains("\"key2\":\"value2\""));
+    }
+
+    @Test
+    void testCanEncode() {
+        // 测试支持的媒体类型
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
+
+        // 测试不支持的媒体类型
+        assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
+        assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+    }
+
+    @Test
+    void testEncodeWithHints() {
+        // 准备测试数据
+        TestVO vo = new TestVO();
+        vo.setId(789);
+        vo.setName("hints test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+        //Map.of("test", "value");
+        Map<String, Object> hints = new HashMap<String, Object>() {
+            {
+                put("test", "value");
+            }
+        };
+
+        // 执行编码
+        DataBuffer result = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, hints);
+
+        // 验证结果
+        assertNotNull(result);
+        String json = result.toString(StandardCharsets.UTF_8);
+        assertTrue(json.contains("\"id\":789"));
+        assertTrue(json.contains("\"name\":\"hints test\""));
+    }
+
+    @Test
+    void testEncodeWithDifferentMimeTypes() {
+        // 测试不同的 MIME 类型
+        TestVO vo = new TestVO();
+        vo.setId(1);
+        vo.setName("test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 测试 APPLICATION_JSON
+        DataBuffer jsonBuffer = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+        assertNotNull(jsonBuffer);
+
+        // 测试 ALL
+        DataBuffer allBuffer = encoderAll.encodeValue(vo, bufferFactory, type, MediaType.ALL, null);
+        assertNotNull(allBuffer);
+    }
+
+    @Test
+    void testEncodeExceptionHandling() {
+        // 测试编码异常处理
+        // 创建一个可能导致编码异常的对象（如果有的话）
+        // 这里我们测试一个正常情况，因为 Fastjson2 通常能处理大多数对象
+
+        TestVO vo = new TestVO();
+        vo.setId(1);
+        vo.setName("test");
+
+        ResolvableType type = ResolvableType.forClass(TestVO.class);
+
+        // 正常情况下不应该抛出异常
+        assertDoesNotThrow(() -> {
+            encoderAll.encodeValue(vo, bufferFactory, type, MediaType.APPLICATION_JSON, null);
+        });
+    }
+
+    // 测试用的 VO 类
+    @Setter
+    @Getter
+    private static class TestVO {
+        private int id;
+        private String name;
+    }
+
+    // 带日期的测试 VO 类
+    @Setter
+    @Getter
+    private static class TestVOWithDate {
+        private int id;
+        private String name;
+        private String date;
+    }
+
+    // 复杂对象测试类
+    @Setter
+    @Getter
+    private static class ComplexVO {
+        private int id;
+        private String name;
+        private List<String> tags;
+        private Map<String, String> metadata;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
The new codec classes are designed to work directly with Spring's reactive streams without depending on Jackson.
#3691 #1501
### Summary of your change 
I have marked the `com.alibaba.fastjson2.support.spring.http.codec.Fastjson2Decoder` and `com.alibaba.fastjson2.support.spring.http.codec.Fastjson2Encoder` as deprecated

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
