### PR TITLE
fix bug for issue #3724

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -884,7 +884,16 @@ public class ObjectReaderBaseModule
             }
 
             BeanUtils.declaredFields(objectClass, field -> {
-                if (field.getName().equals(fieldName)) {
+                if (field.getType() == boolean.class || field.getType() == Boolean.class) {
+                    if (field.getName().startsWith("is")) {
+                        name = field.getName().substring(2);
+                        if (!name.isEmpty()) {
+                            name = Character.toLowerCase(name.charAt(0)) + name.substring(1);
+                        }
+                    }
+                }
+
+                if (field.getName().equals(fieldName) || name.equals(fieldName)) {
                     int modifiers = field.getModifiers();
                     if ((!Modifier.isPublic(modifiers)) && !Modifier.isStatic(modifiers)) {
                         getFieldInfo(fieldInfo, objectClass, field);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -884,6 +884,7 @@ public class ObjectReaderBaseModule
             }
 
             BeanUtils.declaredFields(objectClass, field -> {
+                String name = "";
                 if (field.getType() == boolean.class || field.getType() == Boolean.class) {
                     if (field.getName().startsWith("is")) {
                         name = field.getName().substring(2);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3700/Issue3724.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3700/Issue3724.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson2.issues_3700;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.annotation.JSONField;
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3724 {
+    @Test
+    public void test() {
+        String str = "{\"isSuccess\":true,\"isSuccess2\":true}";
+        BooleanDTO booleanDTO = JSON.parseObject(str, BooleanDTO.class);
+        assertEquals(str, JSON.toJSONString(booleanDTO));
+    }
+
+    @Data
+    public class BooleanDTO {
+        @JSONField(name = "isSuccess")
+        private boolean isSuccess;
+        @JSONField(name = "isSuccess2")
+        private boolean isSuccess2;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
该 issue 的问题是，对于 "is" 开头的 boolean 属性，反序列化时 @JSONField(name = "xxx") 定义在 setter 上可以生效，定义在 Field 上就不生效。表现不一致，个人感觉应该是 bug。查源码发现，在对 setter 进行 getFieldInfo 时，因为 setter 提取属性名和 filed 属性名不一致，导致未能进入下面的逻辑（未处理 Field 上的 @JSONField）。但不清楚这样改是否合适。


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
