### PR TITLE
refactor(extension): 重构 FastJsonHttpMessageConverter 以提高性能

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -1699,7 +1699,6 @@ public interface JSON {
      * @return {@link T} or {@code null}
      * @throws JSONException If a parsing error occurs
      */
-    @SuppressWarnings("unchecked")
     static <T> T parseObject(
             byte[] bytes,
             Type type,
@@ -1718,6 +1717,26 @@ public interface JSON {
                 features
         );
         context.setDateFormat(format);
+
+        return parseObject(bytes, type, context);
+    }
+
+    /**
+     * Parses the json string as {@link T}. Returns
+     * {@code null} if received {@link String} is {@code null} or empty.
+     *
+     * @param bytes the specified UTF8 text to be parsed
+     * @param type the specified actual type
+     * @param context the specified custom context
+     * @return {@link T} or {@code null}
+     * @throws JSONException If a parsing error occurs
+     * @throws NullPointerException If received context is null
+     */
+    @SuppressWarnings("unchecked")
+    static <T> T parseObject(byte[] bytes, Type type, JSONReader.Context context) {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
 
         boolean fieldBased = (context.features & JSONReader.Feature.FieldBased.mask) != 0;
         ObjectReader<T> objectReader = context.provider.getObjectReader(type, fieldBased);

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -150,10 +150,10 @@ public class FastJsonHttpMessageConverter
     }
 
     // see jdk.internal.util.ArraysSupport.SOFT_MAX_ARRAY_LENGTH
-    public static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+    private static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 
     // see jdk.internal.util.ArraysSupport.newLength( )
-    public static int newLength(int oldLength, int minGrowth, int prefGrowth) {
+    private static int newLength(int oldLength, int minGrowth, int prefGrowth) {
         // preconditions not checked because of inlining
         // assert oldLength >= 0
         // assert minGrowth > 0

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -21,6 +21,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 /**
  * Fastjson for Spring MVC Converter.
@@ -93,24 +94,96 @@ public class FastJsonHttpMessageConverter
         return readType(getType(clazz, null), inputMessage);
     }
 
-    private Object readType(Type type, HttpInputMessage inputMessage) {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-            InputStream in = inputMessage.getBody();
+    /** Default initialization capacity when content-length is not specified */
+    public static int REQUEST_BODY_DEFAULT_INITIAL_CAPACITY = 1024;
 
-            byte[] buf = new byte[1024 * 64];
-            for (; ; ) {
-                int len = in.read(buf);
-                if (len == -1) {
-                    break;
-                }
+    public static void setRequestBodyDefaultInitialCapacity(int initialCapacity) {
+        if (initialCapacity < 128 || initialCapacity > 1024 * 1024) {
+            throw new IllegalArgumentException("invalid initialCapacity: " + initialCapacity);
+        }
+        REQUEST_BODY_DEFAULT_INITIAL_CAPACITY = initialCapacity;
+    }
 
-                if (len > 0) {
-                    baos.write(buf, 0, len);
+    /**
+     * @param contentLength The content length of the request message. If -1 is passed, it means unknown.
+     */
+    protected static int calcInitialCapacity(long contentLength) {
+        return contentLength == -1 || contentLength > Integer.MAX_VALUE
+                ? REQUEST_BODY_DEFAULT_INITIAL_CAPACITY
+                // The maximum limit is 1MB to prevent fake request headers
+                : (int) Math.min(contentLength, 1024 * 1024);
+    }
+
+    /**
+     * @param in the specified input stream
+     * @param contentLength -1 means unknown
+     */
+    protected static byte[] fastRead(final InputStream in, final long contentLength) throws IOException {
+        final int expectSize = calcInitialCapacity(contentLength);
+        byte[] body = new byte[expectSize];
+
+        int offset = in.read(body, 0, body.length);
+        if (offset == -1) {
+            body = new byte[0];
+        } else if (contentLength == -1 || offset != contentLength) {
+            final byte[] buf = new byte[1024];
+            int len = in.read(buf);
+            while (len != -1) { // Refer to the implementation of ByteArrayOutputStream
+                final int minRequired = offset + len;
+                final int oldLength = body.length;
+                if (minRequired > oldLength) {
+                    int newLength = newLength(oldLength, minRequired - oldLength, oldLength);
+                    byte[] newBody = Arrays.copyOf(body, newLength);
+                    System.arraycopy(buf, 0, newBody, offset, len);
+                    body = newBody;
+                } else {
+                    System.arraycopy(buf, 0, body, offset, len);
                 }
+                offset = minRequired;
+                len = in.read(buf);
             }
-            byte[] bytes = baos.toByteArray();
+            if (offset != body.length) {
+                body = Arrays.copyOf(body, offset);
+            }
+        }
+        return body;
+    }
 
-            return JSON.parseObject(bytes, type, config.getDateFormat(), config.getReaderFilters(), config.getReaderFeatures());
+    // see jdk.internal.util.ArraysSupport.SOFT_MAX_ARRAY_LENGTH
+    public static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+
+    // see jdk.internal.util.ArraysSupport.newLength( )
+    public static int newLength(int oldLength, int minGrowth, int prefGrowth) {
+        // preconditions not checked because of inlining
+        // assert oldLength >= 0
+        // assert minGrowth > 0
+
+        int prefLength = oldLength + Math.max(minGrowth, prefGrowth); // might overflow
+        if (0 < prefLength && prefLength <= SOFT_MAX_ARRAY_LENGTH) {
+            return prefLength;
+        } else {
+            // put code cold in a separate method
+            return hugeLength(oldLength, minGrowth);
+        }
+    }
+
+    // see jdk.internal.util.ArraysSupport.hugeLength( )
+    private static int hugeLength(int oldLength, int minGrowth) {
+        int minLength = oldLength + minGrowth;
+        if (minLength < 0) { // overflow
+            throw new OutOfMemoryError("Required array length " + oldLength + " + " + minGrowth + " is too large");
+        } else if (minLength <= SOFT_MAX_ARRAY_LENGTH) {
+            return SOFT_MAX_ARRAY_LENGTH;
+        } else {
+            return minLength;
+        }
+    }
+
+    protected Object readType(Type type, HttpInputMessage inputMessage) {
+        final long contentLength = inputMessage.getHeaders().getContentLength(); // -1 表示未知
+        try {
+            final byte[] body = fastRead(inputMessage.getBody(), contentLength);
+            return JSON.parseObject(body, type, config.readerContext());
         } catch (JSONException ex) {
             throw new HttpMessageNotReadableException("JSON parse error: " + ex.getMessage(), ex, inputMessage);
         } catch (IOException ex) {
@@ -138,10 +211,7 @@ public class FastJsonHttpMessageConverter
                 }
 
                 contentLength = JSON.writeTo(
-                        baos, object,
-                        config.getDateFormat(),
-                        config.getWriterFilters(),
-                        config.getWriterFeatures()
+                        baos, object, config.writerContext()
                 );
             }
 

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -95,13 +95,13 @@ public class FastJsonHttpMessageConverter
     }
 
     /** Default initialization capacity when content-length is not specified */
-    public static int REQUEST_BODY_DEFAULT_INITIAL_CAPACITY = 1024;
+    private static int REQUEST_BODY_INITIAL_CAPACITY = 1024;
 
-    public static void setRequestBodyDefaultInitialCapacity(int initialCapacity) {
+    public static void setRequestBodyInitialCapacity(int initialCapacity) {
         if (initialCapacity < 128 || initialCapacity > 1024 * 1024) {
             throw new IllegalArgumentException("invalid initialCapacity: " + initialCapacity);
         }
-        REQUEST_BODY_DEFAULT_INITIAL_CAPACITY = initialCapacity;
+        REQUEST_BODY_INITIAL_CAPACITY = initialCapacity;
     }
 
     /**
@@ -109,7 +109,7 @@ public class FastJsonHttpMessageConverter
      */
     protected static int calcInitialCapacity(long contentLength) {
         return contentLength == -1 || contentLength > Integer.MAX_VALUE
-                ? REQUEST_BODY_DEFAULT_INITIAL_CAPACITY
+                ? REQUEST_BODY_INITIAL_CAPACITY
                 // The maximum limit is 1MB to prevent fake request headers
                 : (int) Math.min(contentLength, 1024 * 1024);
     }

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -95,7 +95,7 @@ public class FastJsonHttpMessageConverter
     }
 
     /** Default initialization capacity when content-length is not specified */
-    private static int REQUEST_BODY_INITIAL_CAPACITY = 1024;
+    private static int REQUEST_BODY_INITIAL_CAPACITY = 8192;
 
     public static void setRequestBodyInitialCapacity(int initialCapacity) {
         if (initialCapacity < 128 || initialCapacity > 1024 * 1024) {

--- a/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
@@ -293,5 +293,4 @@ public class FastJsonConfig {
         }
         return context;
     }
-
 }


### PR DESCRIPTION
### What this PR does / why we need it?

之前的 `com.alibaba.fastjson2.support.spring.http.converter.FastJsonHttpMessageConverter` 存在以下可进行性能优化的关键点：

1. 使用 `ByteArrayOutputStream` 存储请求数据，默认初始化容量为 32，不太合理，需要循环多次扩容才能达到目标容量。最后`ByteArrayOutputStream.toByteArray()` 时又会额外进行一次数据复制。
2. 用于循环读取 字节数组 的 临时 `buf` 默认容量为 `1024 * 64`（ 即 64KB ），我们分析了自己系统、以及淘宝、京东、腾讯等主流应用的部分JSON请求报文，几乎都没遇到过这么大的数据报文，所以，这个 `buf` 容量其实在绝大多数情况下都是比较浪费的。
3. JSON 请求的数据一般都放在 HTTP 的请求主体中，请求方法也几乎都是 POST 和 PUT。根据 [RFC 7230](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2) 规范，**除了**附带`Transfer-Encoding` 请求头以进行分块传输的请求，都应该（**SHOULD**）附带 `Content-Length` 请求头，这意味着几乎所有的 JSON 请求都会附带 `Content-Length` 请求头，我们通过上述分析以及多个浏览器 + HttpClient 实测也都验证了这一点。因此利用 `Content-Length` 请求头，在绝大多数情况下，都可以避免请求字节数组的容量扩容开销。
4. `new` 一个 `JSONReader.Context` 或 `JSONWriter.Context` 的开销不大，不过对于每天请求千万级别以上的系统来说，每次请求都需要分别构造一个，如果能够缓存下来，也能够节省一点性能——蚊子肉也算是肉~。

### Summary of your change

- 新增 `fastRead()` 方法，用于高效读取请求字节数据（借鉴了 JDK `ByteArrayOutputStream` 底层实现）；
- 优化内存分配，避免不必要的数组扩容和拷贝；
- 新增 `JSONReader.Context` 和 `JSONWriter.Context` 缓存避免重复构造 Context 的性能开销；
- 增加对大数组长度的处理逻辑，防止内存溢出；
- 预留自定义请求数据初始化容量的方法 `setRequestBodyDefaultInitialCapacity()`，方便根据项目实际情况自定义合理的初始化容量；
- 结合实际情况，预防过大的 `Content-Length` 请求头伪造。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
