### PR TITLE
fix: WebFlux uses the same codec 

### DIFF
--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Decoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Decoder.java
@@ -37,7 +37,7 @@ public final class Fastjson2Decoder
      * default constructor
      */
     public Fastjson2Decoder() {
-        this(new FastJsonConfig(), MediaType.ALL);
+        this(new FastJsonConfig(), MediaType.APPLICATION_JSON, new MediaType("application", "*+json"));
     }
 
     /**
@@ -47,7 +47,9 @@ public final class Fastjson2Decoder
      * @param mimeTypes the mime types to support
      */
     public Fastjson2Decoder(FastJsonConfig config, MimeType... mimeTypes) {
-        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
+        super(mimeTypes == null || mimeTypes.length == 0
+                ? new MimeType[]{MediaType.APPLICATION_JSON, new MediaType("application", "*+json")}
+                : mimeTypes);
         this.config = config;
     }
 

--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/codec/Fastjson2Encoder.java
@@ -34,7 +34,7 @@ public final class Fastjson2Encoder
      * default constructor
      */
     public Fastjson2Encoder() {
-        this(new FastJsonConfig(), MediaType.ALL);
+        this(new FastJsonConfig(), MediaType.APPLICATION_JSON, new MediaType("application", "*+json"));
     }
 
     /**
@@ -44,7 +44,9 @@ public final class Fastjson2Encoder
      * @param mimeTypes the mime types to support
      */
     public Fastjson2Encoder(FastJsonConfig config, MimeType... mimeTypes) {
-        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
+        super(mimeTypes == null || mimeTypes.length == 0
+                ? new MimeType[]{MediaType.APPLICATION_JSON, new MediaType("application", "*+json")}
+                : mimeTypes);
         this.config = config;
     }
 

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/GenericFastJsonRedisSerializerTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/GenericFastJsonRedisSerializerTest.java
@@ -68,18 +68,18 @@ public class GenericFastJsonRedisSerializerTest {
         assertEquals(baseResult2.getCode(), "1000");
         assertEquals(baseResult2.getData().size(), 3);
 
-        String json = "{\n" +
-                "\"@type\": \"com.alibaba.fastjson2.spring.GenericFastJsonRedisSerializerTest$BaseResult\",\n" +
-                "\"code\": \"1000\",\n" +
-                "\"data\": [\n" +
-                "\"按手动控制按钮\",\n" +
-                "\"不停机\",\n" +
-                "\"不转动\",\n" +
-                "\"传动轴振动大\",\n" +
-                "\"第一推进器\",\n" +
-                "\"电机不运行\",\n" +
-                "],\n" +
-                "\"msg\": \"success\"\n" +
+        String json = "{" +
+                "\"@type\": \"com.alibaba.fastjson2.spring.GenericFastJsonRedisSerializerTest$BaseResult\"," +
+                "\"code\": \"1000\"," +
+                "\"data\": [" +
+                "\"button1\"," +
+                "\"button2\"," +
+                "\"button3\"," +
+                "\"button4\"," +
+                "\"button5\"," +
+                "\"button6\"" +
+                "]," +
+                "\"msg\": \"success\"" +
                 "}";
 
         BaseResult<List<String>> baseResult3 = (BaseResult<List<String>>) genericFastJsonRedisSerializer.deserialize(json.getBytes());

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2DecoderTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2DecoderTest.java
@@ -188,12 +188,14 @@ public class Fastjson2DecoderTest {
     @Test
     void testCanDecode() {
         // 测试支持的媒体类型
-        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
-        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), new MediaType("application", "vnd.api+json")));
         assertTrue(decoderAll.canDecode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
         assertTrue(decoderAll.canDecode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
 
         // 测试不支持的媒体类型
+        assertFalse(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
         assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
         assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
         assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2EncoderTest.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/codec/Fastjson2EncoderTest.java
@@ -229,12 +229,14 @@ public class Fastjson2EncoderTest {
     @Test
     void testCanEncode() {
         // 测试支持的媒体类型
-        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
-        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), new MediaType("application", "vnd.api+json")));
         assertTrue(encoderAll.canEncode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
         assertTrue(encoderAll.canEncode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
 
         // 测试不支持的媒体类型
+        assertFalse(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
         assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
         assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
         assertFalse(encoderJson.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Decoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Decoder.java
@@ -31,40 +31,48 @@ import java.util.Map;
  */
 public final class Fastjson2Decoder
         extends AbstractDecoder<Object> {
+    private static final int BUFFER_SIZE = 65536;
+
     private final FastJsonConfig config;
 
-    /**
-     * default constructor
-     */
     public Fastjson2Decoder() {
-        this(new FastJsonConfig(), MediaType.ALL);
+        this(new FastJsonConfig(),
+                MediaType.APPLICATION_JSON,
+             new MediaType("application", "*+json"));
     }
 
-    /**
-     * Constructor with custom configs
-     *
-     * @param config    FastJsonConfig
-     * @param mimeTypes the mime types to support
-     */
-    public Fastjson2Decoder(FastJsonConfig config, MimeType... mimeTypes) {
-        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
+    public Fastjson2Decoder(final FastJsonConfig config,
+                            final MimeType... mimeTypes) {
+        super(mimeTypes == null || mimeTypes.length == 0
+                ? new MimeType[]{
+                    MediaType.APPLICATION_JSON,
+                    new MediaType("application", "*+json")}
+                : mimeTypes);
         this.config = config;
     }
 
     @Override
     @NonNull
-    public Flux<Object> decode(@NonNull Publisher<DataBuffer> inputStream, @NonNull ResolvableType elementType, @Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
+    public Flux<Object> decode(@NonNull final Publisher<DataBuffer> inputStream,
+                               @NonNull final ResolvableType elementType,
+                               @Nullable final MimeType mimeType,
+                               @Nullable final Map<String, Object> hints) {
         return Flux.from(inputStream)
-                .mapNotNull(dataBuffer -> decode(dataBuffer, elementType, mimeType, hints));
+                .mapNotNull(dataBuffer ->
+                    decode(dataBuffer, elementType, mimeType, hints));
     }
 
     @Override
     @Nullable
-    public Object decode(@NonNull DataBuffer buffer, @NonNull ResolvableType targetType, MimeType mimeType, Map<String, Object> hints) throws DecodingException {
+    public Object decode(@NonNull final DataBuffer buffer,
+                         @NonNull final ResolvableType targetType,
+                         final MimeType mimeType,
+                         final Map<String, Object> hints)
+            throws DecodingException {
         try (ByteArrayOutputStream os = new ByteArrayOutputStream();
                 InputStream in = buffer.asInputStream()) {
-            byte[] buf = new byte[1 << 16];
-            for (; ; ) {
+            byte[] buf = new byte[BUFFER_SIZE];
+            for (;;) {
                 int len = in.read(buf);
                 if (len == -1) {
                     break;
@@ -81,9 +89,11 @@ public final class Fastjson2Decoder
             logValue(value, hints);
             return value;
         } catch (JSONException ex) {
-            throw new DecodingException("JSON parse error: " + ex.getMessage(), ex);
+            throw new DecodingException("JSON parse error: " + ex.getMessage(),
+                    ex);
         } catch (IOException ex) {
-            throw new DecodingException("I/O error while reading input message", ex);
+            throw new DecodingException(
+                    "I/O error while reading input message", ex);
         } finally {
             DataBufferUtils.release(buffer);
         }
@@ -91,17 +101,24 @@ public final class Fastjson2Decoder
 
     @Override
     @NonNull
-    public Mono<Object> decodeToMono(@NonNull Publisher<DataBuffer> inputStream, @NonNull ResolvableType elementType,
-                                     @Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
+    public Mono<Object> decodeToMono(
+            @NonNull final Publisher<DataBuffer> inputStream,
+            @NonNull final ResolvableType elementType,
+            @Nullable final MimeType mimeType,
+            @Nullable final Map<String, Object> hints) {
         return DataBufferUtils.join(inputStream)
-                .flatMap(dataBuffer -> Mono.justOrEmpty(decode(dataBuffer, elementType, mimeType, hints)));
+                .flatMap(dataBuffer -> Mono.justOrEmpty(
+                    decode(dataBuffer, elementType, mimeType, hints)));
     }
 
-    private void logValue(@Nullable Object value, @Nullable Map<String, Object> hints) {
+    private void logValue(@Nullable final Object value,
+                          @Nullable final Map<String, Object> hints) {
         if (!Hints.isLoggingSuppressed(hints)) {
             LogFormatUtils.traceDebug(logger, traceOn -> {
-                String formatted = LogFormatUtils.formatValue(value, !traceOn);
-                return Hints.getLogPrefix(hints) + "Decoded [" + formatted + "]";
+                String formatted = LogFormatUtils.formatValue(value,
+                        !traceOn);
+                return Hints.getLogPrefix(hints) + "Decoded [" + formatted
+                        + "]";
             });
         }
     }

--- a/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Encoder.java
+++ b/extension-spring6/src/main/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2Encoder.java
@@ -32,7 +32,7 @@ public final class Fastjson2Encoder
      * default constructor
      */
     public Fastjson2Encoder() {
-        this(new FastJsonConfig(), MediaType.ALL);
+        this(new FastJsonConfig(), MediaType.APPLICATION_JSON, new MediaType("application", "*+json"));
     }
 
     /**
@@ -42,7 +42,9 @@ public final class Fastjson2Encoder
      * @param mimeTypes the mime types to support
      */
     public Fastjson2Encoder(FastJsonConfig config, MimeType... mimeTypes) {
-        super(mimeTypes == null || mimeTypes.length == 0 ? new MimeType[]{MediaType.ALL} : mimeTypes);
+        super(mimeTypes == null || mimeTypes.length == 0
+                ? new MimeType[]{MediaType.APPLICATION_JSON, new MediaType("application", "*+json")}
+                : mimeTypes);
         this.config = config;
     }
 

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/GenericFastJsonRedisSerializerTest.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/GenericFastJsonRedisSerializerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.serializer.SerializationException;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
@@ -82,7 +83,7 @@ public class GenericFastJsonRedisSerializerTest {
                 "\"msg\": \"success\"\n" +
                 "}";
 
-        BaseResult<List<String>> baseResult3 = (BaseResult<List<String>>) genericFastJsonRedisSerializer.deserialize(json.getBytes());
+        BaseResult<List<String>> baseResult3 = (BaseResult<List<String>>) genericFastJsonRedisSerializer.deserialize(json.getBytes(StandardCharsets.UTF_8));
         assertEquals(baseResult3.getCode(), "1000");
         assertEquals(baseResult3.getData().size(), 6);
     }

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2DecoderTest.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2DecoderTest.java
@@ -186,16 +186,57 @@ public class Fastjson2DecoderTest {
 
     @Test
     void testCanDecode() {
-        // 测试支持的媒体类型
-        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
-        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        // 测试默认解码器应该支持的JSON相关媒体类型
         assertTrue(decoderAll.canDecode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
         assertTrue(decoderAll.canDecode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
 
-        // 测试不支持的媒体类型
+        // 测试支持JSON相关的其他类型
+        MediaType jsonVariant = new MediaType("application", "hal+json");
+        assertTrue(decoderAll.canDecode(ResolvableType.forClass(TestVO.class), jsonVariant));
+
+        //默认解码器不应该支持非JSON媒体类型
+        assertFalse(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        assertFalse(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.MULTIPART_FORM_DATA));
+        assertFalse(decoderAll.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_OCTET_STREAM));
+
+        // 测试指定JSON类型的解码器行为
+        assertTrue(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
         assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
         assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.TEXT_HTML));
         assertFalse(decoderJson.canDecode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+    }
+
+    @Test
+    void FileUploadMediaTypeHandling() {
+        // 创建默认解码器
+        Fastjson2Decoder fixedDecoder = new Fastjson2Decoder();
+
+        //JSON解码器不应该声称能处理文件上传相关的媒体类型
+        assertFalse(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), MediaType.MULTIPART_FORM_DATA),
+                "error");
+
+        assertFalse(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), MediaType.APPLICATION_OCTET_STREAM),
+                "error");
+
+        assertFalse(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), MediaType.MULTIPART_MIXED),
+                "error");
+
+        assertFalse(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), MediaType.MULTIPART_RELATED),
+                "error");
+        assertTrue(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), MediaType.APPLICATION_JSON),
+                "error");
+
+        assertTrue(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), new MediaType("application", "hal+json")),
+                "error");
+
+        assertTrue(fixedDecoder.canDecode(ResolvableType.forClass(Object.class), new MediaType("application", "vnd.api+json")),
+                "error");
+
+        Fastjson2Decoder legacyDecoder = new Fastjson2Decoder(new FastJsonConfig(), MediaType.ALL);
+        assertTrue(legacyDecoder.canDecode(ResolvableType.forClass(Object.class), MediaType.MULTIPART_FORM_DATA),
+                "right");
     }
 
     @Test

--- a/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2EncoderTest.java
+++ b/extension-spring6/src/test/java/com/alibaba/fastjson2/support/spring6/codec/Fastjson2EncoderTest.java
@@ -227,9 +227,9 @@ public class Fastjson2EncoderTest {
 
     @Test
     void testCanEncode() {
-        // 测试支持的媒体类型
-        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
-        assertTrue(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+        // 测试不支持的媒体类型
+        assertFalse(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+        assertFalse(encoderAll.canEncode(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
         assertTrue(encoderAll.canEncode(ResolvableType.forClass(TestVO.class), MediaType.APPLICATION_JSON));
         assertTrue(encoderAll.canEncode(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
 


### PR DESCRIPTION
### What this PR does / why we need it?
GenericFastJsonRedisSerializerTest does not specify encoding, sometimes it may go wrong
Spring WebFlux uses the same codec for all data, so it is definitely not the same codec for processing files and json data, which will definitely cause problems.


### Summary of your change
use utf-8
Please use Fastjson2Decoder only when you encounter a request with Content-Type of application/json. Otherwise, use another encoder to solve the problem.


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
