### PR TITLE
feat: support dumping ASM generated bytecode for debugging, for issue…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -709,6 +709,9 @@ public class ObjectReaderCreatorASM
         }
 
         byte[] code = cw.toByteArray();
+
+        ASMUtils.debugDump(objectClass, context.classNameFull, code);
+
         try {
             Class<?> readerClass = classLoader.defineClassPublic(context.classNameFull, code, 0, code.length);
 

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -586,6 +586,8 @@ public class ObjectWriterCreatorASM
 
         byte[] code = cw.toByteArray();
 
+        ASMUtils.debugDump(objectClass, classNameFull, code);
+
         Class<?> deserClass = classLoader.defineClassPublic(classNameFull, code, 0, code.length);
 
         try {


### PR DESCRIPTION
… #3878

### What this PR does / why we need it?

为了方便调试 ASM 动态生成的序列化/反序列化类，建议新增字节码输出功能。

使用方法：
通过 JVM 启动参数 **-Dfastjson2.asm.debug** 控制：
- 指定类名：-Dfastjson2.asm.debug=User（支持模糊匹配；大小写敏感）
- 指定类名列表：-Dfastjson2.asm.debug=User,Student
- 全量输出：-Dfastjson2.asm.debug=true 或 *

**注意，使用该参数，程序中需要有序列化/反序列化操作，否则不会输出相关字节码。**

输出路径：
- 使用 IDE 工具，默认生成在项目根目录的 fastjson2_asm_dump 文件夹下，并自动按 reader 和 writer 分类；
- 命令行执行，输出在当前目录的 fastjson2_asm_dump 文件夹下。