### PR TITLE
Fixed issue 3883. Add according unit test.

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -5236,6 +5236,9 @@ class JSONReaderUTF8
 
         if (ch == '.') {
             valueType = JSON_TYPE_DEC;
+            if (offset == end) {
+                throw new JSONException(info("illegal input"));
+            }
             ch = bytes[offset++];
             while (ch >= '0' && ch <= '9') {
                 valid = true;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3800/Issue3883.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3800/Issue3883.java
@@ -1,0 +1,14 @@
+package com.alibaba.fastjson2.issues_3800;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class Issue3883 {
+    @Test
+    public void jsonReaderUTF8ArrayOOBTest() {
+        assertThrows(JSONException.class, () -> JSON.parse(new String("\0.")));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
This PR handles case which is described in issue: [https://github.com/alibaba/fastjson2/issues/3883](https://github.com/alibaba/fastjson2/issues/3883)


### Summary of your change

* Add array bounds check, throw JSONException if found bad statement.
* Add according unit test in ./core/src/test/java/com/alibaba/fastjson2/issues_3800/Issue3883.java
* Made sure tests are passing and test coverage is added if needed. (`./mvnw test -Dtest="Issue3825#jsonReaderUTF8ArrayOOBTest" -pl core` returns OK)
