### PR TITLE
fix DirectByteBuffer java.nio.ByteBuffer#array UnsupportedOperationEx…

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/write/ByteBufferTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/write/ByteBufferTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.ByteBuffer;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ByteBufferTest {
     @Test
@@ -36,6 +37,34 @@ public class ByteBufferTest {
         byte[] jsonbBytes = JSONB.toBytes(buffer, JSONWriter.Feature.WriteClassName);
         System.out.println(JSONB.toJSONString(jsonbBytes));
         ByteBuffer buffer1 = (ByteBuffer) JSONB.parseObject(jsonbBytes, Object.class, JSONReader.Feature.SupportAutoType);
+        assertArrayEquals(bytes, buffer1.array());
+    }
+
+    @Test
+    public void testDirectByteBuffer() {
+        // Test DirectByteBuffer serialization (allocateDirect creates a DirectByteBuffer)
+        byte[] bytes = new byte[]{1, 2, 3};
+        ByteBuffer directBuffer = ByteBuffer.allocateDirect(3);
+        directBuffer.put(bytes);
+        directBuffer.flip();
+
+        String str = JSON.toJSONString(directBuffer);
+        assertEquals("[1,2,3]", str);
+
+        ByteBuffer buffer1 = JSON.parseObject(str, ByteBuffer.class);
+        assertArrayEquals(bytes, buffer1.array());
+    }
+
+    @Test
+    public void testReadOnlyByteBuffer() {
+        // Test read-only ByteBuffer serialization
+        byte[] bytes = new byte[]{1, 2, 3};
+        ByteBuffer buffer = ByteBuffer.wrap(bytes).asReadOnlyBuffer();
+
+        String str = JSON.toJSONString(buffer);
+        assertEquals("[1,2,3]", str);
+
+        ByteBuffer buffer1 = JSON.parseObject(str, ByteBuffer.class);
         assertArrayEquals(bytes, buffer1.array());
     }
 }


### PR DESCRIPTION
修复对 DirectByteBuffer 等的支持。

```
java.lang.UnsupportedOperationException: null
        at java.base/java.nio.ByteBuffer.array(ByteBuffer.java:1049)
        at com.alibaba.arthas.deps.com.alibaba.fastjson2.writer.ObjectWriterBaseModule.lambda$getObjectWriter$0(ObjectWriterBaseModule.java:1142)
        at com.alibaba.arthas.deps.com.alibaba.fastjson2.writer.ObjectWriterImplInt8ValueArray.write(ObjectWriterImplInt8ValueArray.java:58)
        at com.alibaba.arthas.deps.com.alibaba.fastjson2.writer.FieldWriterObject.writeInternal(FieldWriterObject.java:377)
        at com.alibaba.arthas.deps.com.alibaba.fastjson2.writer.FieldWriterObject.write(FieldWriterObject.java:248)
        at com.alibaba.arthas.deps.com.alibaba.fastjson2.writer.ObjectWriter3.write(ObjectWriter3.java:75)
        at com.alibaba.arthas.deps.com.alibaba.fastjson2.writer.OWG_34_3_Cleaner.write(Unknown Source)
```