### PR TITLE
Exclude some fields in proguard rule

### DIFF
--- a/core/src/main/resources/META-INF/proguard/fastjson2.pro
+++ b/core/src/main/resources/META-INF/proguard/fastjson2.pro
@@ -24,3 +24,18 @@
 # Keep any (anonymous) classes extending TypeReference
 -keep, allowobfuscation class com.alibaba.fastjson2.TypeReference
 -keep, allowobfuscation class * extends com.alibaba.fastjson2.TypeReference
+
+# Don't rename/shrink the following class fields, as they are accessed by internal reflection tool *AtomicReferenceFieldUpdater*
+# They should always be described by "volatile" modifier, if not, please report an issue
+-keepclassmembers class com.alibaba.fastjson2.JSONFactory$CacheItem {
+  volatile <fields>;
+}
+-keepclassmembers class com.alibaba.fastjson2.util.TypeUtils$Cache {
+  volatile <fields>;
+}
+-keepclassmembers class com.alibaba.fastjson2.writer.FieldWriter {
+  volatile com.alibaba.fastjson2.writer.ObjectWriter initObjectWriter;
+}
+-keepclassmembers class com.alibaba.fastjson2.writer.FieldWriterObject {
+  volatile java.lang.Class initValueClass;
+}


### PR DESCRIPTION
### What this PR does / why we need it?
部分字段由java.util.concurrent.atomic.AtomicReferenceFieldUpdater以反射形式访问，这类字段容易被Proguard重命名或直接删除 导致java.lang.ExceptionInInitializerError (Caused by: java.lang.RuntimeException: java.lang.NoSuchFieldException: chars)，现有的配置文件没有解决这一点。
此PR在现有配置文件中补充排除规则以解决上述问题。


### Summary of your change
在fastjson2.pro中添加了相关字段的排除项


#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
