### PR TITLE
fix: Handle custom ObjectReaders lacking createInstance in JSONObject…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1292,7 +1292,12 @@ public class JSONObject
 
         ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
         ObjectReader<T> objectReader = provider.getObjectReader(clazz, fieldBased);
-        return objectReader.createInstance(this, featuresValue);
+
+        try {
+            return objectReader.createInstance(this, featuresValue);
+        } catch (UnsupportedOperationException e) {
+            return JSON.parseObject(this.toJSONString(), clazz, features);
+        }
     }
 
     public void copyTo(Object object, JSONReader.Feature... features) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -1292,12 +1292,7 @@ public class JSONObject
 
         ObjectReaderProvider provider = JSONFactory.getDefaultObjectReaderProvider();
         ObjectReader<T> objectReader = provider.getObjectReader(clazz, fieldBased);
-
-        try {
-            return objectReader.createInstance(this, featuresValue);
-        } catch (UnsupportedOperationException e) {
-            return JSON.parseObject(this.toJSONString(), clazz, features);
-        }
+        return objectReader.createInstance(this, featuresValue);
     }
 
     public void copyTo(Object object, JSONReader.Feature... features) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3901.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3901.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.reader.ObjectReader;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3901 {
+    @Test
+    public void test() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("name", "James");
+
+        JSON.register(User.class, new UserReader());
+        User user = jsonObject.to(User.class);
+        assertEquals("ZhangSan", user.getName());
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class User {
+        private String name;
+    }
+
+    public class UserReader implements ObjectReader {
+        @Override
+        public Object readObject(JSONReader jsonReader, Type fieldType, Object fieldName, long features) {
+            jsonReader.readObject();
+            return new User("ZhangSan");
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3901.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3901.java
@@ -1,41 +1,146 @@
 package com.alibaba.fastjson2.issues_3900;
 
-import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONObject;
-import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.reader.ObjectReader;
+import com.alibaba.fastjson2.util.TypeUtils;
 import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
 
 public class Issue3901 {
-    @Test
-    public void test() {
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.put("name", "James");
-
+    @BeforeEach
+    public void setup() {
         JSON.register(User.class, new UserReader());
-        User user = jsonObject.to(User.class);
-        assertEquals("ZhangSan", user.getName());
     }
 
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class User {
-        private String name;
+    @AfterEach
+    public void tearDown() {
+        JSON.register(User.class, (ObjectReader) null);
     }
 
-    public class UserReader implements ObjectReader {
+    @Test
+    public void testJSONObjectTo() {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put("id", 1001);
+        jsonObject.put("name", "fastjson");
+
+        User user = jsonObject.to(User.class); // 底层调用 createInstance(Map)
+
+        Assertions.assertEquals(1001, user.id);
+        Assertions.assertEquals("FASTJSON", user.name);
+    }
+
+    @Test
+    public void testJSONObjectGetObject() {
+        JSONObject root = new JSONObject();
+        JSONObject userJson = new JSONObject();
+        userJson.put("id", 1002);
+        userJson.put("name", "fastjson");
+        root.put("userInfo", userJson);
+
+        User user = root.getObject("userInfo", User.class); // 底层调用 createInstance(Map)
+
+        Assertions.assertEquals(1002, user.id);
+        Assertions.assertEquals("FASTJSON", user.name);
+    }
+
+    @Test
+    public void testJSONArrayTo() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(1003);
+        jsonArray.add("array_test");
+
+        User user = jsonArray.to(User.class); // 底层调用 createInstance(Collection)
+
+        Assertions.assertEquals(1003, user.id);
+        Assertions.assertEquals("ARRAY_TEST", user.name);
+    }
+
+    public static class UserReader implements ObjectReader<User> {
+        /**
+         * 用户如果注册了自定义反序列化器，调用以下方法前，需要重写 createInstance(Map map, long features)：
+         *
+         * JSONObject：
+         * getObject(String key, Class<T> type, ...)
+         * getObject(String key, Type type, ...)
+         * to(Class<T> clazz, ...)
+         * to(Type type, ...)
+         * to(TypeReference<T> ...)
+         * toJavaObject(...)
+         *
+         * JSONArray：
+         * getObject(int index, Class<T> type, ...)
+         * getObject(int index, Type type, ...)
+         * toArray(Class<T> itemClass, ...)
+         * toJavaList(...)
+         * toList(Class<T> itemClass, ...)
+         */
         @Override
-        public Object readObject(JSONReader jsonReader, Type fieldType, Object fieldName, long features) {
-            jsonReader.readObject();
-            return new User("ZhangSan");
+        public User createInstance(Map map, long features) {
+            if (map == null) {
+                return null;
+            }
+            User user = new User();
+
+            Object id = map.get("id");
+            Object name = map.get("name");
+
+            user.id = TypeUtils.toIntValue(id);
+            String nameStr = TypeUtils.cast(name, String.class);
+            user.name = nameStr != null ? nameStr.toUpperCase() : null;
+            return user;
         }
+
+        /**
+         * 用户如果注册了自定义反序列化器，调用以下方法前，需要重写 createInstance(Collection collection, long features)：
+         *
+         * JSONObject：
+         * getObject(String key, Class<T> type, ...)
+         * getObject(String key, Type type, ...)
+         *
+         * JSONArray：
+         * getObject(int index, Class<T> type, ...)
+         * getObject(int index, Type type, ...)
+         * to(Class<T> type)
+         * to(Type type)
+         * toJavaObject(...) (Deprecated)
+         */
+        @Override
+        public User createInstance(Collection collection, long features) {
+            if (collection == null || collection.isEmpty()) {
+                return null;
+            }
+            User user = new User();
+            Iterator<?> iterator = collection.iterator();
+
+            if (iterator.hasNext()) {
+                user.id = TypeUtils.toIntValue(iterator.next());
+            }
+            if (iterator.hasNext()) {
+                String nameStr = TypeUtils.cast(iterator.next(), String.class);
+                user.name = nameStr != null ? nameStr.toUpperCase() : null;
+            }
+            return user;
+        }
+
+        @Override
+        public User readObject(JSONReader jsonReader, Type fieldType, Object fieldName, long features) {
+            return new User();
+        }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class User {
+        public int id;
+        public String name;
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3901.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3901.java
@@ -1,6 +1,9 @@
 package com.alibaba.fastjson2.issues_3900;
 
-import com.alibaba.fastjson2.*;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.reader.ObjectReader;
 import com.alibaba.fastjson2.util.TypeUtils;
 import lombok.AllArgsConstructor;
@@ -13,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 public class Issue3901 {
@@ -119,8 +123,25 @@ public class Issue3901 {
                 return null;
             }
             User user = new User();
-            Iterator<?> iterator = collection.iterator();
 
+            // 高性能路径
+            if (collection instanceof List) {
+                List<?> list = (List<?>) collection;
+                int size = list.size();
+
+                if (size > 0) {
+                    user.id = TypeUtils.toIntValue(list.get(0));
+                }
+
+                if (size > 1) {
+                    String nameStr = TypeUtils.cast(list.get(1), String.class);
+                    user.name = nameStr != null ? nameStr.toUpperCase() : null;
+                }
+
+                return user;
+            }
+
+            Iterator<?> iterator = collection.iterator();
             if (iterator.hasNext()) {
                 user.id = TypeUtils.toIntValue(iterator.next());
             }


### PR DESCRIPTION
….to, for issue #3901

对没有实现 createInstance 方法的类型使用 JSON.parseObject(this.toJSONString(), clazz, features)，但这里会增加一次序列化的开销，目前没有想到更好的修复方案
