### PR TITLE
Attempt to provide a built-in WriteNonStringValueAsString serializer …

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAsString.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAsString.java
@@ -1,0 +1,219 @@
+package com.alibaba.fastjson2.writer;
+
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONWriter;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public abstract class ObjectWriterAsString implements ObjectWriter {
+    private ObjectWriterAsString() {
+    }
+
+    public static final ObjectWriterAsString OF_INTEGER = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Number) object).intValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_INT_VALUE = OF_INTEGER;
+
+    public static final ObjectWriterAsString OF_LONG = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Number) object).longValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_LONG_VALUE = OF_LONG;
+
+    public static final ObjectWriterAsString OF_FLOAT = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Number) object).floatValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_FLOAT_VALUE = OF_FLOAT;
+
+    public static final ObjectWriterAsString OF_DOUBLE = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Number) object).doubleValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_DOUBLE_VALUE = OF_DOUBLE;
+
+    public static final ObjectWriterAsString OF_SHORT = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Number) object).shortValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_SHORT_VALUE = OF_SHORT;
+
+    public static final ObjectWriterAsString OF_BYTE = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Number) object).byteValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_BYTE_VALUE = OF_BYTE;
+
+    public static final ObjectWriterAsString OF_CHARACTER = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(object.toString());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_CHAR_VALUE = OF_CHARACTER;
+
+    public static final ObjectWriterAsString OF_BOOLEAN = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString(((Boolean) object).booleanValue());
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+    public static final ObjectWriterAsString OF_BOOLEAN_VALUE = OF_BOOLEAN;
+
+    public static final ObjectWriterAsString OF_BIG_INTEGER = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeBigInt((BigInteger) object, JSONWriter.Feature.WriteNonStringValueAsString.mask);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_BIG_DECIMAL = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeDecimal((BigDecimal) object, JSONWriter.Feature.WriteNonStringValueAsString.mask, null);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_INT_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((int[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_LONG_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((long[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_FLOAT_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((float[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_DOUBLE_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((double[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_SHORT_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((short[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_BYTE_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((byte[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    public static final ObjectWriterAsString OF_BOOLEAN_ARRAY = new ObjectWriterAsString() {
+        @Override
+        public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+            if (object != null) {
+                jsonWriter.writeString((boolean[]) object);
+            } else {
+                jsonWriter.writeNull();
+            }
+        }
+    };
+
+    @Override
+    public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+        if (object == null) {
+            jsonWriter.writeNull();
+            return;
+        }
+
+        throw new JSONException("ObjectWriterAsString.write() should NOT be called directly: "
+                + object.getClass().getName());
+    }
+}

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
@@ -5,7 +5,7 @@ import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.codec.BeanInfo;
 import com.alibaba.fastjson2.codec.FieldInfo;
-import com.alibaba.fastjson2.filter.*;
+import com.alibaba.fastjson2.filter.Filter;
 import com.alibaba.fastjson2.function.*;
 import com.alibaba.fastjson2.modules.ObjectWriterModule;
 import com.alibaba.fastjson2.util.BeanUtils;
@@ -1944,6 +1944,11 @@ public class ObjectWriterCreator {
         } else if (Enum.class.isAssignableFrom(fieldClass)) {
             ObjectWriter objectWriter = provider.cache.get(fieldClass);
             if (!(objectWriter instanceof ObjectWriterImplEnum)) {
+                return objectWriter;
+            }
+        } else {
+            ObjectWriter objectWriter = provider.cache.get(fieldClass);
+            if (objectWriter != null && objectWriter instanceof ObjectWriterAsString) {
                 return objectWriter;
             }
         }


### PR DESCRIPTION
…for base types, for issue #3870

### What this PR does / why we need it?
是否可以提供如下功能：
对基础类型提供内置 NonStringValueAsString 序列化器；
方便用户全局注册。

尝试了一种实现方式（草稿，感觉不太好，无法避免装箱拆箱），跑了 BenchMark 程序和结果如下：
<details>
<summary>点击查看 benchmark 代码</summary>

```java
package com.alibaba.fastjson2.benchmark;

import com.alibaba.fastjson2.JSON;
import com.alibaba.fastjson2.JSONWriter;
import com.alibaba.fastjson2.writer.ObjectWriterAsString;
import com.alibaba.fastjson2.writer.ObjectWriterProvider;
import org.openjdk.jmh.annotations.*;
import org.openjdk.jmh.infra.Blackhole;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;

import java.math.BigDecimal;
import java.math.BigInteger;
import java.util.concurrent.TimeUnit;

@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Thread)
@Fork(3) 
@Warmup(iterations = 5, time = 5) 
@Measurement(iterations = 5, time = 5)
public class AsStringBenchmark {

    public static class PrimitiveBean {
        public int vInt;
        public long vLong;
        public float vFloat;
        public double vDouble;
        public short vShort;
        public byte vByte;
        public boolean vBoolean;
        public char vChar;
        public Integer vInteger;
        public Long vLongWrapper;
        public Float vFloatWrapper;
        public Double vDoubleWrapper;
        public Short vShortWrapper;
        public Byte vByteWrapper;
        public Boolean vBooleanWrapper;
        public Character vCharWrapper;
        public BigInteger vBigInteger;
        public BigDecimal vBigDecimal;
        public int[] vIntArray;
        public long[] vLongArray;
        public float[] vFloatArray;
        public double[] vDoubleArray;
        public short[] vShortArray;
        public byte[] vByteArray;
        public boolean[] vBooleanArray;

        public PrimitiveBean() {
            this.vInt = 10086;
            this.vLong = 1678888888888L;
            this.vFloat = 123.456f;
            this.vDouble = 3.1415926;
            this.vShort = (short) 123;
            this.vByte = (byte) 127;
            this.vBoolean = true;
            this.vChar = 'A';

            this.vInteger = 999;
            this.vLongWrapper = 54321L;
            this.vFloatWrapper = 67.89f;
            this.vDoubleWrapper = 0.9999;
            this.vShortWrapper = (short) 456;
            this.vByteWrapper = (byte) -1;
            this.vBooleanWrapper = Boolean.FALSE;
            this.vCharWrapper = 'Z';

            this.vBigInteger = new BigInteger("12345678901234567890");
            this.vBigDecimal = new BigDecimal("12345.67890123456789");

            this.vIntArray = new int[]{1, 2, 3, 4, 5};
            this.vLongArray = new long[]{100L, 200L, 300L, 400L, 500L};
            this.vFloatArray = new float[]{1.1f, 2.2f, 3.3f, 4.4f, 5.5f};
            this.vDoubleArray = new double[]{1.11, 2.22, 3.33, 4.44, 5.55};
            this.vShortArray = new short[]{10, 20, 30, 40, 50};
            this.vByteArray = new byte[]{0, 1, 2, 3, 4};
            this.vBooleanArray = new boolean[]{true, false, true, true, false};
        }
    }

    private PrimitiveBean bean;
    private JSONWriter.Context defaultContext;
    private JSONWriter.Context asStringContext;

    @Setup
    public void setup() {
        bean = new PrimitiveBean();

        ObjectWriterProvider customProvider0 = new ObjectWriterProvider();
        defaultContext = new JSONWriter.Context(customProvider0);
        defaultContext.config(JSONWriter.Feature.WriteNonStringValueAsString);


        ObjectWriterProvider customProvider = new ObjectWriterProvider();

        customProvider.register(int.class, ObjectWriterAsString.OF_INT_VALUE);
        customProvider.register(long.class, ObjectWriterAsString.OF_LONG_VALUE);
        customProvider.register(float.class, ObjectWriterAsString.OF_FLOAT_VALUE);
        customProvider.register(double.class, ObjectWriterAsString.OF_DOUBLE_VALUE);
        customProvider.register(short.class, ObjectWriterAsString.OF_SHORT_VALUE);
        customProvider.register(byte.class, ObjectWriterAsString.OF_BYTE_VALUE);
        customProvider.register(boolean.class, ObjectWriterAsString.OF_BOOLEAN_VALUE);
        customProvider.register(char.class, ObjectWriterAsString.OF_CHAR_VALUE);

        customProvider.register(Integer.class, ObjectWriterAsString.OF_INTEGER);
        customProvider.register(Long.class, ObjectWriterAsString.OF_LONG);
        customProvider.register(Float.class, ObjectWriterAsString.OF_FLOAT);
        customProvider.register(Double.class, ObjectWriterAsString.OF_DOUBLE);
        customProvider.register(Short.class, ObjectWriterAsString.OF_SHORT);
        customProvider.register(Byte.class, ObjectWriterAsString.OF_BYTE);
        customProvider.register(Boolean.class, ObjectWriterAsString.OF_BOOLEAN);
        customProvider.register(Character.class, ObjectWriterAsString.OF_CHARACTER);

        customProvider.register(BigInteger.class, ObjectWriterAsString.OF_BIG_INTEGER);
        customProvider.register(BigDecimal.class, ObjectWriterAsString.OF_BIG_DECIMAL);

        customProvider.register(int[].class, ObjectWriterAsString.OF_INT_ARRAY);
        customProvider.register(long[].class, ObjectWriterAsString.OF_LONG_ARRAY);
        customProvider.register(float[].class, ObjectWriterAsString.OF_FLOAT_ARRAY);
        customProvider.register(double[].class, ObjectWriterAsString.OF_DOUBLE_ARRAY);
        customProvider.register(short[].class, ObjectWriterAsString.OF_SHORT_ARRAY);
        customProvider.register(byte[].class, ObjectWriterAsString.OF_BYTE_ARRAY);
        customProvider.register(boolean[].class, ObjectWriterAsString.OF_BOOLEAN_ARRAY);

        asStringContext = new JSONWriter.Context(customProvider);
    }

    @Benchmark
    public void baseline_native_numbers(Blackhole bh) {
        bh.consume(JSON.toJSONString(bean, defaultContext));
    }

    @Benchmark
    public void target_as_string(Blackhole bh) {
        bh.consume(JSON.toJSONString(bean, asStringContext));
    }

    public static void main(String[] args) throws RunnerException {
        Options opt = new OptionsBuilder()
                .include(AsStringBenchmark.class.getSimpleName())
                .addProfiler("gc")
                .build();
        new Runner(opt).run();
    }
}
```
</details>


jdk21-asm（fastjson2.creator=asm）：
<img width="1231" height="392" alt="jdk21-asm" src="https://github.com/user-attachments/assets/5072b381-0b9c-4ed7-96f0-fa629e429809" />
jdk17-asm：
<img width="1223" height="391" alt="jdk17-asm" src="https://github.com/user-attachments/assets/2d066989-7b08-44cf-acf5-25d89005296a" />
jdk8-asm：
<img width="1224" height="385" alt="jdk8-asm" src="https://github.com/user-attachments/assets/ad644777-4868-4acd-b01b-e1601d2e42e6" />



