### PR TITLE
fix issue3936

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3936.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3936.java
@@ -3,16 +3,18 @@ package com.alibaba.fastjson2.issues_3900;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONReader;
-import com.alibaba.fastjson2.JSONTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class Issue3936 {
+    public static class JsonTest {
+    }
+
     @Test
     public void testBaseCase() {
         String jsonStr = "{\"list\":[{\"name1\":\"ccc\"},{\"name2\":{3:[{\"id\":123}]}}]}";
-        JSON.parseObject(jsonStr, JSONTest.class, JSONReader.Feature.AllowUnQuotedFieldNames);
+        JSON.parseObject(jsonStr, JsonTest.class, JSONReader.Feature.AllowUnQuotedFieldNames);
     }
 
     @Test


### PR DESCRIPTION
### What this PR does / why we need it?
[issue3936](https://github.com/alibaba/fastjson2/issues/3936)，修复后，fastjson2 在启用 JSONReader.Feature.AllowUnQuotedFieldNames 特性时，能够正确解析含数字字段名的JSON，如 {"name2":{3:[{"id":123}]}} ，不会再出现死循环问题

在 JSONReaderUTF8.java 的 readFieldNameHashCodeUnquote 方法中，fastjson2 对字段名采用了 两种不同的哈希计算策略 ：

- 短字段名（≤8字符） ：直接将 ASCII 码组合成一个 long 类型的哈希值（ nameValue ）
- 长字段名（>8字符） ：使用标准的 Fnv 哈希算法计算

当解析数字字段名（如 3 ）时：

- 3 是短字段名（仅1个字符）
- '3' 的 ASCII 码为 51 ，因此 nameValue = 51
- 由于 nameValue != 0 ，代码直接返回 51 作为哈希值

数字字段名使用的 ASCII 组合哈希（如 51 ）与 Fnv 哈希算法生成的值不匹配，导致无法正确识别和处理字段，最终进入无限循环尝试解析同一个字段，对了，死循环的逻辑在com.alibaba.fastjson2.reader.ObjectReaderBean#processExtra(com.alibaba.fastjson2.JSONReader, java.lang.Object, long)，
jsonReader.skipValue()会执行异常，一直重复处理 :{3:

### Summary of your change
在 JSONReaderUTF8.java 的 readFieldNameHashCodeUnquote 方法中，仅非数字短字段名使用ASCII哈希优化，数字字段名强制使用Fnv哈希算法


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
