### PR TITLE
fix issue3939

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -4395,11 +4395,13 @@ public abstract class JSONReader
             }
             case JSON_TYPE_DEC: {
                 BigDecimal decimal = null;
+                boolean needsExponent = false;
 
                 if (mag0 == 0 && mag1 == 0) {
                     if (mag2 == 0 && mag3 >= 0) {
                         int unscaledVal = negative ? -mag3 : mag3;
                         decimal = BigDecimal.valueOf(unscaledVal, scale);
+                        needsExponent = true;
                     } else {
                         long v3 = mag3 & 0XFFFFFFFFL;
                         long v2 = mag2 & 0XFFFFFFFFL;
@@ -4408,6 +4410,7 @@ public abstract class JSONReader
                             long v23 = (v2 << 32) + v3;
                             long unscaledVal = negative ? -v23 : v23;
                             decimal = BigDecimal.valueOf(unscaledVal, scale);
+                            needsExponent = true;
                         }
                     }
                 }
@@ -4434,7 +4437,7 @@ public abstract class JSONReader
                         return Double.parseDouble(
                                 decimalStr + "E" + exponent);
                     }
-                    if (mag0 == 0 && mag1 == 0) {
+                    if (needsExponent) {
                         return decimal.signum() == 0 ? BigDecimal.ZERO : new BigDecimal(decimalStr + "E" + exponent);
                     }
                     return decimal.signum() == 0 ? BigDecimal.ZERO : decimal;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3939.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3939.java
@@ -32,6 +32,17 @@ public class Issue3939 {
         assertEquals(obj.get("a"), a.a);
     }
 
+    @Test
+    public void test_3() {
+        String json = "{\"a\":9223372036854776000e-10}";
+        A a = JSON.parseObject(json, A.class);
+        JSONObject obj = JSON.parseObject(json, JSONReader.Feature.UseBigDecimalForDoubles);
+
+        BigDecimal expected = new BigDecimal("9223372036854776000e-10");
+        assertEquals(expected, a.a);
+        assertEquals(obj.get("a"), a.a);
+    }
+
     public static class A {
         public BigDecimal a;
     }


### PR DESCRIPTION
### What this PR does / why we need it?
修复 [issue3939](https://github.com/alibaba/fastjson2/issues/3939)

test_1 会走到 JSON_TYPE_BIG_DEC 分支的 BigInteger 方法处理，由于没有对应科学计数法的处理，所以会抛出异常

test_2 会走到 JSON_TYPE_DEC 分支的大数路径，由于大数路径重复处理了指数，所以发生异常
- 小数路径 ：当 mag0 == 0 && mag1 == 0 时，使用 BigDecimal.valueOf(unscaledVal, scale) 创建 BigDecimal， 未应用指数
- 大数路径 ：当 decimal == null 时（即不是小数路径），创建 BigInteger 并使用 new BigDecimal(bigInt, scale - exponent) 创建 BigDecimal， 已应用指数

### Summary of your change
com.alibaba.fastjson2.JSONReader#getNumber 中的 JSON_TYPE_BIG_DEC 分支和 JSON_TYPE_DEC 分支


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
