### PR TITLE
fix context features loss in JSON.toJSON method, for issue #3944

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -4012,8 +4012,23 @@ public interface JSON {
         if (object == null) {
             return null;
         }
-        if (object instanceof JSONObject || object instanceof JSONArray) {
-            return object;
+
+        if (object instanceof JSONObject) {
+            if (features == null || features.length == 0) {
+                return object;
+            }
+            JSONObject jsonObject = (JSONObject) object;
+            jsonObject.setContextFeatures(features);
+            return jsonObject;
+        }
+
+        if (object instanceof JSONArray) {
+            if (features == null || features.length == 0) {
+                return object;
+            }
+            JSONArray jsonArray = (JSONArray) object;
+            jsonArray.setContextFeatures(features);
+            return jsonArray;
         }
 
         JSONWriter.Context writeContext = features == null ?
@@ -4024,7 +4039,14 @@ public interface JSON {
                 && !writeContext.isEnabled(JSONWriter.Feature.ReferenceDetection)
                 && (objectWriter.getFeatures() & JSONWriter.Feature.WriteClassName.mask) == 0) {
             ObjectWriterAdapter objectWriterAdapter = (ObjectWriterAdapter) objectWriter;
-            return objectWriterAdapter.toJSONObject(object, writeContext.features);
+
+            JSONObject jsonObject = objectWriterAdapter.toJSONObject(object, writeContext.features);
+
+            long mask = writeContext.getFeatures();
+            if (mask != 0) {
+                jsonObject.setContextFeatures(mask);
+            }
+            return jsonObject;
         }
 
         String str;
@@ -4035,7 +4057,18 @@ public interface JSON {
             throw new JSONException("toJSONString error", ex);
         }
 
-        return parse(str);
+        Object result = parse(str);
+
+        long mask = writeContext.getFeatures();
+        if (mask != 0) {
+            if (result instanceof JSONObject) {
+                ((JSONObject) result).setContextFeatures(mask);
+            } else if (result instanceof JSONArray) {
+                ((JSONArray) result).setContextFeatures(mask);
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -26,6 +26,24 @@ public class JSONArray
         extends ArrayList<Object> {
     private static final long serialVersionUID = 1L;
 
+    protected long contextFeatures;
+
+    public void setContextFeatures(JSONWriter.Feature... features) {
+        long combinedFeatures = this.contextFeatures;
+        for (JSONWriter.Feature feature : features) {
+            combinedFeatures |= feature.mask;
+        }
+        this.contextFeatures = combinedFeatures;
+    }
+
+    public void setContextFeatures(long features) {
+        this.contextFeatures = features;
+    }
+
+    public long getContextFeatures() {
+        return contextFeatures;
+    }
+
     static ObjectWriter<JSONArray> arrayWriter;
 
     /**
@@ -1049,7 +1067,9 @@ public class JSONArray
      */
     @Override
     public String toString() {
-        try (JSONWriter writer = JSONWriter.of()) {
+        JSONWriter.Context context = JSONFactory.createWriteContext();
+        context.features |= this.contextFeatures;
+        try (JSONWriter writer = JSONWriter.of(context)) {
             writer.setRootObject(this);
             writer.write(this);
             return writer.toString();
@@ -1064,7 +1084,9 @@ public class JSONArray
      */
     @SuppressWarnings("unchecked")
     public String toString(JSONWriter.Feature... features) {
-        try (JSONWriter writer = JSONWriter.of(features)) {
+        JSONWriter.Context context = features == null ?
+                JSONFactory.createWriteContext() : JSONFactory.createWriteContext(features);
+        try (JSONWriter writer = JSONWriter.of(context)) {
             if ((writer.context.features & NONE_DIRECT_FEATURES) == 0) {
                 writer.write(this);
             } else {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -35,6 +35,24 @@ public class JSONObject
         implements InvocationHandler {
     private static final long serialVersionUID = 1L;
 
+    protected long contextFeatures;
+
+    public void setContextFeatures(JSONWriter.Feature... features) {
+        long combinedFeatures = this.contextFeatures;
+        for (JSONWriter.Feature feature : features) {
+            combinedFeatures |= feature.mask;
+        }
+        this.contextFeatures = combinedFeatures;
+    }
+
+    public void setContextFeatures(long features) {
+        this.contextFeatures = features;
+    }
+
+    public long getContextFeatures() {
+        return contextFeatures;
+    }
+
     static ObjectReader<JSONArray> arrayReader;
     static final long NONE_DIRECT_FEATURES = ReferenceDetection.mask
             | PrettyFormat.mask
@@ -1150,7 +1168,9 @@ public class JSONObject
      */
     @Override
     public String toString() {
-        try (JSONWriter writer = JSONWriter.of()) {
+        JSONWriter.Context context = JSONFactory.createWriteContext();
+        context.features |= this.contextFeatures;
+        try (JSONWriter writer = JSONWriter.of(context)) {
             writer.setRootObject(this);
             writer.write(this);
             return writer.toString();
@@ -1164,7 +1184,9 @@ public class JSONObject
      * @return JSON {@link String}
      */
     public String toString(JSONWriter.Feature... features) {
-        try (JSONWriter writer = JSONWriter.of(features)) {
+        JSONWriter.Context context = features == null ?
+                JSONFactory.createWriteContext() : JSONFactory.createWriteContext(features);
+        try (JSONWriter writer = JSONWriter.of(context)) {
             writer.setRootObject(this);
             writer.write(this);
             return writer.toString();

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3944.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3944.java
@@ -1,0 +1,92 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue3944 {
+    @Test
+    public void test_issue3944() {
+        class A {
+            A a;
+            String b;
+            public String getB() {
+                return b;
+            }
+            public A getA() {
+                return a;
+            }
+        }
+        A a = new A();
+        a.a = a;
+        a.b = "test";
+        assertEquals("{\"a\":{\"$ref\":\"..\"},\"b\":\"test\"}", JSON.toJSON(a, JSONWriter.Feature.ReferenceDetection).toString());
+    }
+
+    @Test
+    public void test_JSONObject() {
+        JSONObject obj = new JSONObject();
+        obj.put("a", 1);
+        obj.put("b", "2");
+        System.out.println();
+        assertEquals("{\"a\":\"1\",\"b\":\"2\"}", JSON.toJSON(obj, JSONWriter.Feature.WriteNonStringValueAsString).toString());
+    }
+
+    @Test
+    public void test_JSONArray() {
+        JSONArray a = new JSONArray();
+        a.add(1);
+        a.add("2");
+        assertEquals("[\"1\",\"2\"]", JSON.toJSON(a, JSONWriter.Feature.WriteNonStringValueAsString).toString());
+    }
+
+    @Test
+    public void test_toJSON_OptimizationPath_WithContext() {
+        class Bean {
+            public int id = 101;
+            public String name = "optimization";
+        }
+        Bean bean = new Bean();
+
+        JSONObject jsonObject = (JSONObject) JSON.toJSON(bean, JSONWriter.Feature.PrettyFormat);
+        assertTrue(jsonObject.toString().contains("\n"));
+        assertTrue(jsonObject.toString().contains("id"));
+    }
+
+    @Test
+    public void test_toJSON_FallbackPath_JSONObject_Circular() {
+        class CyclicBean {
+            public int id = 1;
+            public CyclicBean self;
+        }
+        CyclicBean bean = new CyclicBean();
+        bean.self = bean;
+
+        JSONObject jsonObject = (JSONObject) JSON.toJSON(bean, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(jsonObject.toString().contains("$ref"));
+    }
+
+    @Test
+    public void test_toJSON_FallbackPath_JSONArray_WriteType() {
+        class Item {
+            public int val = 999;
+        }
+        List<Item> list = new ArrayList<>();
+        list.add(new Item());
+
+        JSONArray jsonArray = (JSONArray) JSON.toJSON(list,
+                JSONWriter.Feature.WriteClassName,
+                JSONWriter.Feature.PrettyFormat);
+
+        assertTrue(jsonArray.toString().contains("\n"));
+        assertTrue(jsonArray.toString().contains("@type"));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
修复 JSONObject/JSONArray 在 toString 时，未考虑上下文特性的问题（为两个类型增加了 contextFeatures 字段）


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
