### PR TITLE
fix: avoid StackOverflowError when serializing org.w3c.dom.Node, for issue #3960

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplXmlNode.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplXmlNode.java
@@ -1,0 +1,47 @@
+package com.alibaba.fastjson2.writer;
+
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONWriter;
+import org.w3c.dom.Node;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import java.io.StringWriter;
+import java.lang.reflect.Type;
+
+public class ObjectWriterImplXmlNode
+        implements ObjectWriter {
+    static final ObjectWriterImplXmlNode INSTANCE = new ObjectWriterImplXmlNode();
+
+    static final TransformerFactory TRANSFORMER_FACTORY;
+
+    static {
+        try {
+            TRANSFORMER_FACTORY = TransformerFactory.newInstance();
+        } catch (Exception e) {
+            throw new JSONException("init xml TransformerFactory error", e);
+        }
+    }
+
+    @Override
+    public void write(JSONWriter jsonWriter, Object object, Object fieldName, Type fieldType, long features) {
+        if (object == null) {
+            jsonWriter.writeNull();
+            return;
+        }
+
+        try {
+            Transformer transformer = TRANSFORMER_FACTORY.newTransformer();
+            DOMSource domSource = new DOMSource((Node) object);
+
+            StringWriter writer = new StringWriter();
+            transformer.transform(domSource, new StreamResult(writer));
+            jsonWriter.writeString(writer.toString());
+        } catch (Exception e) {
+            throw new JSONException("write xml node error", e);
+        }
+    }
+}

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -679,6 +679,10 @@ public class ObjectWriterProvider
             }
         }
 
+        if (org.w3c.dom.Node.class.isAssignableFrom(objectClass)) {
+            return ObjectWriterImplXmlNode.INSTANCE;
+        }
+
         switch (className) {
             case "com.google.common.collect.HashMultimap":
             case "com.google.common.collect.LinkedListMultimap":

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3960.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3960.java
@@ -1,0 +1,34 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3960 {
+    @Test
+    public void test() throws Exception {
+        String message = "<Container>" +
+                "<WeightMajor measurementSystem=\"English\" unit=\"lbs\">0</WeightMajor>" +
+                "</Container>";
+
+        // 使用 JDK 原生 API 解析，不依赖 JAXB
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(message)));
+
+        Element root = document.getDocumentElement();
+        Element weightMajor = (Element) root.getFirstChild();
+
+        String json1 = com.alibaba.fastjson.JSON.toJSONString(weightMajor);
+        String json2 = com.alibaba.fastjson2.JSON.toJSONString(weightMajor);
+        assertEquals(json1, json2);
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
参考了 1.x 的修复逻辑：https://github.com/alibaba/fastjson/commit/14f01b044de0cb14010094f828649c784b037599


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
