### PR TITLE
feat: add ValidationHandler to JSONSchema for fail-safe error collection, for issue #3912

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/schema/AllOf.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/AllOf.java
@@ -70,13 +70,23 @@ final class AllOf
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
+        boolean totalSuccess = true;
+        ValidateResult firstFail = null;
+
         for (JSONSchema item : items) {
-            ValidateResult result = item.validate(value);
+            ValidateResult result = item.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
-        return SUCCESS;
+        return totalSuccess ? SUCCESS : firstFail;
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/Any.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/Any.java
@@ -15,7 +15,7 @@ final class Any
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         return SUCCESS;
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/AnyOf.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/AnyOf.java
@@ -44,8 +44,7 @@ final class AnyOf
             }
         }
 
-        ValidateResult result = handleError(handler, value, path, FAIL_ANY_OF);
-        return result != null ? result : FAIL_ANY_OF;
+        return handleError(handler, value, path, FAIL_ANY_OF);
     }
 
     public JSONObject toJSONObject() {

--- a/core/src/main/java/com/alibaba/fastjson2/schema/AnyOf.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/AnyOf.java
@@ -37,14 +37,15 @@ final class AnyOf
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         for (JSONSchema item : items) {
-            ValidateResult result = item.validate(value);
-            if (result == SUCCESS) {
+            if (item.validateInternal(value, null, path) == SUCCESS) {
                 return SUCCESS;
             }
         }
-        return FAIL_ANY_OF;
+
+        ValidateResult result = handleError(handler, value, path, FAIL_ANY_OF);
+        return result != null ? result : FAIL_ANY_OF;
     }
 
     public JSONObject toJSONObject() {

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ArraySchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ArraySchema.java
@@ -145,11 +145,7 @@ public final class ArraySchema
     @Override
     protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            if (typed) {
-                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
-                return result != null ? result : FAIL_INPUT_NULL;
-            }
-            return SUCCESS;
+            return typed ? handleError(handler, null, path, FAIL_INPUT_NULL) : SUCCESS;
         }
 
         if (encoded) {
@@ -157,12 +153,10 @@ public final class ArraySchema
                 try {
                     value = JSON.parseArray((String) value);
                 } catch (JSONException e) {
-                    ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
-                    return result != null ? result : FAIL_INPUT_NOT_ENCODED;
+                    return handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
                 }
             } else {
-                ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
-                return result != null ? result : FAIL_INPUT_NOT_ENCODED;
+                return handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
             }
         }
 
@@ -183,12 +177,7 @@ public final class ArraySchema
             return validateItems(value, items.size(), i -> iterator.next(), handler, path);
         }
 
-        if (typed) {
-            ValidateResult result = handleError(handler, value, path, FAIL_TYPE_NOT_MATCH);
-            return result != null ? result : FAIL_TYPE_NOT_MATCH;
-        }
-
-        return SUCCESS;
+        return typed ? handleError(handler, value, path, FAIL_TYPE_NOT_MATCH) : SUCCESS;
     }
 
     private ValidateResult validateItems(final Object value, final int size, IntFunction<Object> itemGetter, ValidationHandler handler, String path) {
@@ -196,41 +185,41 @@ public final class ArraySchema
         ValidateResult firstFail = null;
 
         if (minLength >= 0 && size < minLength) {
-            ValidateResult result = new ValidateResult(false, "minLength not match, expect >= %s, but %s", minLength, size);
-            ValidateResult r = handleError(handler, value, path, result);
-            if (r != null) {
+            ValidateResult raw = new ValidateResult(false, "minLength not match, expect >= %s, but %s", minLength, size);
+            ValidateResult r = handleError(handler, value, path, raw);
+            if (handler == null || r.isAbort()) {
                 return r;
             }
 
             totalSuccess = false;
             if (firstFail == null) {
-                firstFail = result;
+                firstFail = r;
             }
         }
 
         if (maxLength >= 0 && size > maxLength) {
-            ValidateResult result = new ValidateResult(false, "maxLength not match, expect <= %s, but %s", maxLength, size);
-            ValidateResult r = handleError(handler, value, path, result);
-            if (r != null) {
+            ValidateResult raw = new ValidateResult(false, "maxLength not match, expect <= %s, but %s", maxLength, size);
+            ValidateResult r = handleError(handler, value, path, raw);
+            if (handler == null || r.isAbort()) {
                 return r;
             }
 
             totalSuccess = false;
             if (firstFail == null) {
-                firstFail = result;
+                firstFail = r;
             }
         }
 
         if (!additionalItems && size > prefixItems.length) {
-            ValidateResult result = new ValidateResult(false, "additional items not match, max size %s, but %s", prefixItems.length, size);
-            ValidateResult r = handleError(handler, value, path, result);
-            if (r != null) {
+            ValidateResult raw = new ValidateResult(false, "additional items not match, max size %s, but %s", prefixItems.length, size);
+            ValidateResult r = handleError(handler, value, path, raw);
+            if (handler == null || r.isAbort()) {
                 return r;
             }
 
             totalSuccess = false;
             if (firstFail == null) {
-                firstFail = result;
+                firstFail = r;
             }
         }
 
@@ -301,7 +290,7 @@ public final class ArraySchema
 
                 if (!uniqueItemsSet.add(item)) {
                     ValidateResult r = handleError(handler, item, itemPath, UNIQUE_ITEMS_NOT_MATCH);
-                    if (r != null) {
+                    if (handler == null || r.isAbort()) {
                         return r;
                     }
 
@@ -325,7 +314,7 @@ public final class ArraySchema
 
             if (containsError != null) {
                 ValidateResult r = handleError(handler, value, path, containsError);
-                if (r != null) {
+                if (handler == null || r.isAbort()) {
                     return r;
                 }
 

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ArraySchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ArraySchema.java
@@ -143,9 +143,13 @@ public final class ArraySchema
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            return typed ? FAIL_INPUT_NULL : SUCCESS;
+            if (typed) {
+                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
+                return result != null ? result : FAIL_INPUT_NULL;
+            }
+            return SUCCESS;
         }
 
         if (encoded) {
@@ -153,44 +157,81 @@ public final class ArraySchema
                 try {
                     value = JSON.parseArray((String) value);
                 } catch (JSONException e) {
-                    return FAIL_INPUT_NOT_ENCODED;
+                    ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
+                    return result != null ? result : FAIL_INPUT_NOT_ENCODED;
                 }
             } else {
-                return FAIL_INPUT_NOT_ENCODED;
+                ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
+                return result != null ? result : FAIL_INPUT_NOT_ENCODED;
             }
         }
 
         if (value instanceof Object[]) {
             final Object[] items = (Object[]) value;
-            return validateItems(value, items.length, i -> items[i]);
+            return validateItems(value, items.length, i -> items[i], handler, path);
         }
 
         if (value.getClass().isArray()) {
             final int size = Array.getLength(value);
             final Object finalValue = value;
-            return validateItems(finalValue, size, i -> Array.get(finalValue, i));
+            return validateItems(finalValue, size, i -> Array.get(finalValue, i), handler, path);
         }
 
         if (value instanceof Collection) {
             final Collection<?> items = (Collection<?>) value;
             final Iterator<?> iterator = items.iterator();
-            return validateItems(value, items.size(), i -> iterator.next());
+            return validateItems(value, items.size(), i -> iterator.next(), handler, path);
         }
 
-        return typed ? FAIL_TYPE_NOT_MATCH : SUCCESS;
+        if (typed) {
+            ValidateResult result = handleError(handler, value, path, FAIL_TYPE_NOT_MATCH);
+            return result != null ? result : FAIL_TYPE_NOT_MATCH;
+        }
+
+        return SUCCESS;
     }
 
-    private ValidateResult validateItems(final Object value, final int size, IntFunction<Object> itemGetter) {
+    private ValidateResult validateItems(final Object value, final int size, IntFunction<Object> itemGetter, ValidationHandler handler, String path) {
+        boolean totalSuccess = true;
+        ValidateResult firstFail = null;
+
         if (minLength >= 0 && size < minLength) {
-            return new ValidateResult(false, "minLength not match, expect >= %s, but %s", minLength, size);
+            ValidateResult result = new ValidateResult(false, "minLength not match, expect >= %s, but %s", minLength, size);
+            ValidateResult r = handleError(handler, value, path, result);
+            if (r != null) {
+                return r;
+            }
+
+            totalSuccess = false;
+            if (firstFail == null) {
+                firstFail = result;
+            }
         }
 
         if (maxLength >= 0 && size > maxLength) {
-            return new ValidateResult(false, "maxLength not match, expect <= %s, but %s", maxLength, size);
+            ValidateResult result = new ValidateResult(false, "maxLength not match, expect <= %s, but %s", maxLength, size);
+            ValidateResult r = handleError(handler, value, path, result);
+            if (r != null) {
+                return r;
+            }
+
+            totalSuccess = false;
+            if (firstFail == null) {
+                firstFail = result;
+            }
         }
 
         if (!additionalItems && size > prefixItems.length) {
-            return new ValidateResult(false, "additional items not match, max size %s, but %s", prefixItems.length, size);
+            ValidateResult result = new ValidateResult(false, "additional items not match, max size %s, but %s", prefixItems.length, size);
+            ValidateResult r = handleError(handler, value, path, result);
+            if (r != null) {
+                return r;
+            }
+
+            totalSuccess = false;
+            if (firstFail == null) {
+                firstFail = result;
+            }
         }
 
         final boolean isCollection = value instanceof Collection;
@@ -198,30 +239,52 @@ public final class ArraySchema
         int containsCount = 0;
         for (int index = 0; index < size; index++) {
             Object item = itemGetter.apply(index);
+            String itemPath = path + "[" + index + "]";
 
             boolean prefixMatch = false;
             if (index < prefixItems.length) {
-                ValidateResult result = prefixItems[index].validate(item);
+                ValidateResult result = prefixItems[index].validateInternal(item, handler, itemPath);
                 if (!result.isSuccess()) {
-                    return result;
+                    if (handler == null || result.isAbort()) {
+                        return result;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
                 prefixMatch = true;
             } else if (isCollection && itemSchema == null && additionalItem != null) { // 只有 Collection 才会执行这部分校验
-                ValidateResult result = additionalItem.validate(item);
+                ValidateResult result = additionalItem.validateInternal(item, handler, itemPath);
                 if (!result.isSuccess()) {
-                    return result;
+                    if (handler == null || result.isAbort()) {
+                        return result;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
 
             if (!prefixMatch && itemSchema != null) {
-                ValidateResult result = itemSchema.validate(item);
+                ValidateResult result = itemSchema.validateInternal(item, handler, itemPath);
                 if (!result.isSuccess()) {
-                    return result;
+                    if (handler == null || result.isAbort()) {
+                        return result;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
 
             if (this.contains != null && (minContains > 0 || maxContains > 0 || containsCount == 0)) {
-                ValidateResult result = this.contains.validate(item);
+                ValidateResult result = this.contains.validateInternal(item, null, itemPath);
                 if (result == SUCCESS) {
                     containsCount++;
                 }
@@ -237,51 +300,85 @@ public final class ArraySchema
                 }
 
                 if (!uniqueItemsSet.add(item)) {
-                    return UNIQUE_ITEMS_NOT_MATCH;
+                    ValidateResult r = handleError(handler, item, itemPath, UNIQUE_ITEMS_NOT_MATCH);
+                    if (r != null) {
+                        return r;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = UNIQUE_ITEMS_NOT_MATCH;
+                    }
                 }
             }
         }
 
         if (!isCollection || this.contains != null) {
+            ValidateResult containsError = null;
             if (minContains >= 0 && containsCount < minContains) {
-                return new ValidateResult(false, "minContains not match, expect %s, but %s", minContains, containsCount);
+                containsError = new ValidateResult(false, "minContains not match, expect %s, but %s", minContains, containsCount);
+            } else if (maxContains >= 0 && containsCount > maxContains) {
+                containsError = new ValidateResult(false, "maxContains not match, expect %s, but %s", maxContains, containsCount);
+            } else if (this.contains != null && containsCount == 0 && minContains != 0) {
+                containsError = CONTAINS_NOT_MATCH;
             }
 
-            if (isCollection) { // Collection 和 数组 的部分校验规则不一样
-                if (containsCount == 0 && minContains != 0) {
-                    return CONTAINS_NOT_MATCH;
+            if (containsError != null) {
+                ValidateResult r = handleError(handler, value, path, containsError);
+                if (r != null) {
+                    return r;
                 }
-            } else if (this.contains != null && containsCount == 0) {
-                return CONTAINS_NOT_MATCH;
-            }
 
-            if (maxContains >= 0 && containsCount > maxContains) {
-                return new ValidateResult(false, "maxContains not match, expect %s, but %s", maxContains, containsCount);
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = containsError;
+                }
             }
         }
 
         if (allOf != null) {
-            ValidateResult result = allOf.validate(value);
+            ValidateResult result = allOf.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (anyOf != null) {
-            ValidateResult result = anyOf.validate(value);
+            ValidateResult result = anyOf.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (oneOf != null) {
-            ValidateResult result = oneOf.validate(value);
+            ValidateResult result = oneOf.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
-        return SUCCESS;
+        return totalSuccess ? SUCCESS : (firstFail != null ? firstFail : new ValidateResult(false, "Array validation failed"));
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/schema/BooleanSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/BooleanSchema.java
@@ -14,16 +14,19 @@ public final class BooleanSchema
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            return FAIL_INPUT_NULL;
+            ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
+            return result != null ? result : FAIL_INPUT_NULL;
         }
 
         if (value instanceof Boolean) {
             return SUCCESS;
         }
 
-        return new ValidateResult(false, "expect type %s, but %s", Type.Boolean, value.getClass());
+        ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Boolean, value.getClass());
+        ValidateResult r = handleError(handler, value, path, result);
+        return r != null ? r : result;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/schema/BooleanSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/BooleanSchema.java
@@ -16,17 +16,15 @@ public final class BooleanSchema
     @Override
     protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
-            return result != null ? result : FAIL_INPUT_NULL;
+            return handleError(handler, null, path, FAIL_INPUT_NULL);
         }
 
         if (value instanceof Boolean) {
             return SUCCESS;
         }
 
-        ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Boolean, value.getClass());
-        ValidateResult r = handleError(handler, value, path, result);
-        return r != null ? r : result;
+        ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.Boolean, value.getClass());
+        return handleError(handler, value, path, raw);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/schema/EnumSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/EnumSchema.java
@@ -67,13 +67,11 @@ public final class EnumSchema
 
         if (!items.contains(value)) {
             if (value == null) {
-                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
-                return result != null ? result : FAIL_INPUT_NULL;
+                return handleError(handler, null, path, FAIL_INPUT_NULL);
             }
 
-            ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Enum, value.getClass());
-            ValidateResult r = handleError(handler, value, path, result);
-            return r != null ? r : result;
+            ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.Enum, value.getClass());
+            return handleError(handler, value, path, raw);
         }
 
         return SUCCESS;

--- a/core/src/main/java/com/alibaba/fastjson2/schema/EnumSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/EnumSchema.java
@@ -40,7 +40,7 @@ public final class EnumSchema
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value instanceof BigDecimal) {
             BigDecimal decimal = (BigDecimal) value;
             value = decimal.stripTrailingZeros();
@@ -67,10 +67,13 @@ public final class EnumSchema
 
         if (!items.contains(value)) {
             if (value == null) {
-                return FAIL_INPUT_NULL;
+                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
+                return result != null ? result : FAIL_INPUT_NULL;
             }
 
-            return new ValidateResult(false, "expect type %s, but %s", Type.Enum, value.getClass());
+            ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Enum, value.getClass());
+            ValidateResult r = handleError(handler, value, path, result);
+            return r != null ? r : result;
         }
 
         return SUCCESS;

--- a/core/src/main/java/com/alibaba/fastjson2/schema/IntegerSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/IntegerSchema.java
@@ -65,9 +65,13 @@ public final class IntegerSchema
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            return typed ? FAIL_INPUT_NULL : SUCCESS;
+            if (typed) {
+                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
+                return result != null ? result : FAIL_INPUT_NULL;
+            }
+            return SUCCESS;
         }
 
         Class valueClass = value.getClass();
@@ -88,25 +92,33 @@ public final class IntegerSchema
 
             if (minimum != Long.MIN_VALUE) {
                 if (exclusiveMinimum ? longValue <= minimum : longValue < minimum) {
-                    return new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
+                    ValidateResult result = new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
             if (maximum != Long.MIN_VALUE) {
                 if (exclusiveMaximum ? longValue >= maximum : longValue > maximum) {
-                    return new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
+                    ValidateResult result = new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
             if (multipleOf != 0) {
                 if (longValue % multipleOf != 0) {
-                    return new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, value);
+                    ValidateResult result = new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
             if (constValue != null) {
                 if (this.constValue != longValue || !isInt64) {
-                    return new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
@@ -124,7 +136,9 @@ public final class IntegerSchema
                         equals = this.constValue == unscaleValue.longValue();
                     }
                     if (!equals) {
-                        return new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                        ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                        ValidateResult r = handleError(handler, value, path, result);
+                        return r != null ? r : result;
                     }
                 }
 
@@ -132,7 +146,9 @@ public final class IntegerSchema
             }
 
             if (constValue != null) {
-                return new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                ValidateResult r = handleError(handler, value, path, result);
+                return r != null ? r : result;
             }
         }
 
@@ -140,12 +156,16 @@ public final class IntegerSchema
             if (value instanceof Float) {
                 float floatValue = (Float) value;
                 if (this.constValue != floatValue) {
-                    return new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             } else if (value instanceof Double) {
                 double doubleValue = (Double) value;
                 if (this.constValue != doubleValue) {
-                    return new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             } else if (value instanceof String) {
                 String str = (String) value;
@@ -159,12 +179,20 @@ public final class IntegerSchema
                     }
                 }
                 if (!equals) {
-                    return new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
         }
 
-        return typed ? new ValidateResult(false, "expect type %s, but %s", Type.Integer, valueClass) : SUCCESS;
+        if (typed) {
+            ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Integer, valueClass);
+            ValidateResult r = handleError(handler, value, path, result);
+            return r != null ? r : result;
+        }
+
+        return SUCCESS;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/schema/IntegerSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/IntegerSchema.java
@@ -67,11 +67,7 @@ public final class IntegerSchema
     @Override
     protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            if (typed) {
-                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
-                return result != null ? result : FAIL_INPUT_NULL;
-            }
-            return SUCCESS;
+            return typed ? handleError(handler, null, path, FAIL_INPUT_NULL) : SUCCESS;
         }
 
         Class valueClass = value.getClass();
@@ -92,33 +88,29 @@ public final class IntegerSchema
 
             if (minimum != Long.MIN_VALUE) {
                 if (exclusiveMinimum ? longValue <= minimum : longValue < minimum) {
-                    ValidateResult result = new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (maximum != Long.MIN_VALUE) {
                 if (exclusiveMaximum ? longValue >= maximum : longValue > maximum) {
-                    ValidateResult result = new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (multipleOf != 0) {
                 if (longValue % multipleOf != 0) {
-                    ValidateResult result = new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (constValue != null) {
                 if (this.constValue != longValue || !isInt64) {
-                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
@@ -136,9 +128,8 @@ public final class IntegerSchema
                         equals = this.constValue == unscaleValue.longValue();
                     }
                     if (!equals) {
-                        ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
-                        ValidateResult r = handleError(handler, value, path, result);
-                        return r != null ? r : result;
+                        ValidateResult raw = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                        return handleError(handler, value, path, raw);
                     }
                 }
 
@@ -146,9 +137,8 @@ public final class IntegerSchema
             }
 
             if (constValue != null) {
-                ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
-                ValidateResult r = handleError(handler, value, path, result);
-                return r != null ? r : result;
+                ValidateResult raw = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                return handleError(handler, value, path, raw);
             }
         }
 
@@ -156,16 +146,14 @@ public final class IntegerSchema
             if (value instanceof Float) {
                 float floatValue = (Float) value;
                 if (this.constValue != floatValue) {
-                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    return handleError(handler, value, path, raw);
                 }
             } else if (value instanceof Double) {
                 double doubleValue = (Double) value;
                 if (this.constValue != doubleValue) {
-                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    return handleError(handler, value, path, raw);
                 }
             } else if (value instanceof String) {
                 String str = (String) value;
@@ -179,17 +167,15 @@ public final class IntegerSchema
                     }
                 }
                 if (!equals) {
-                    ValidateResult result = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "const not match, expect %s, but %s", this.constValue, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
         }
 
         if (typed) {
-            ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Integer, valueClass);
-            ValidateResult r = handleError(handler, value, path, result);
-            return r != null ? r : result;
+            ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.Integer, valueClass);
+            return handleError(handler, value, path, raw);
         }
 
         return SUCCESS;

--- a/core/src/main/java/com/alibaba/fastjson2/schema/Not.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/Not.java
@@ -30,8 +30,7 @@ final class Not
     protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (schema != null) {
             if (schema.validateInternal(value, null, path).isSuccess()) {
-                ValidateResult result = handleError(handler, value, path, FAIL_NOT);
-                return result != null ? result : FAIL_NOT;
+                return handleError(handler, value, path, FAIL_NOT);
             }
         }
 
@@ -91,19 +90,13 @@ final class Not
                 }
 
                 if (match) {
-                    ValidateResult result = handleError(handler, value, path, FAIL_NOT);
-                    return result != null ? result : FAIL_NOT;
+                    return handleError(handler, value, path, FAIL_NOT);
                 }
             }
         }
 
         if (result != null) {
-            if (result) {
-                ValidateResult result = handleError(handler, value, path, FAIL_NOT);
-                return result != null ? result : FAIL_NOT;
-            } else {
-                return SUCCESS;
-            }
+            return result ? handleError(handler, value, path, FAIL_NOT) : SUCCESS;
         }
         return SUCCESS;
     }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/NullSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/NullSchema.java
@@ -19,8 +19,7 @@ final class NullSchema
             return SUCCESS;
         }
 
-        ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Null, value.getClass());
-        ValidateResult r = handleError(handler, value, path, result);
-        return r != null ? r : result;
+        ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.Null, value.getClass());
+        return handleError(handler, value, path, raw);
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/NullSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/NullSchema.java
@@ -14,11 +14,13 @@ final class NullSchema
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
             return SUCCESS;
         }
 
-        return new ValidateResult(false, "expect type %s, but %s", Type.Null, value.getClass());
+        ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Null, value.getClass());
+        ValidateResult r = handleError(handler, value, path, result);
+        return r != null ? r : result;
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/NumberSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/NumberSchema.java
@@ -83,11 +83,7 @@ public final class NumberSchema
     @Override
     protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            if (typed) {
-                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
-                return result != null ? result : FAIL_INPUT_NULL;
-            }
-            return SUCCESS;
+            return typed ? handleError(handler, null, path, FAIL_INPUT_NULL) : SUCCESS;
         }
 
         if (value instanceof Number) {
@@ -96,8 +92,7 @@ public final class NumberSchema
             if (number instanceof Byte || number instanceof Short || number instanceof Integer || number instanceof Long) {
                 ValidateResult result = validate(number.longValue());
                 if (!result.isSuccess()) {
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    return handleError(handler, value, path, result);
                 }
                 return result;
             }
@@ -105,8 +100,7 @@ public final class NumberSchema
             if (number instanceof Float || number instanceof Double) {
                 ValidateResult result = validate(number.doubleValue());
                 if (!result.isSuccess()) {
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    return handleError(handler, value, path, result);
                 }
                 return result;
             }
@@ -117,18 +111,16 @@ public final class NumberSchema
             } else if (number instanceof BigDecimal) {
                 decimalValue = (BigDecimal) number;
             } else {
-                ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Number, value.getClass());
-                ValidateResult r = handleError(handler, value, path, result);
-                return r != null ? r : result;
+                ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.Number, value.getClass());
+                return handleError(handler, value, path, raw);
             }
 
             if (minimum != null) {
                 if (exclusiveMinimum
                         ? minimum.compareTo(decimalValue) >= 0
                         : minimum.compareTo(decimalValue) > 0) {
-                    ValidateResult result = new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
@@ -136,28 +128,22 @@ public final class NumberSchema
                 if (exclusiveMaximum
                         ? maximum.compareTo(decimalValue) <= 0
                         : maximum.compareTo(decimalValue) < 0) {
-                    ValidateResult result = new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (multipleOf != null) {
                 if (decimalValue.divideAndRemainder(multipleOf)[1].abs().compareTo(BigDecimal.ZERO) > 0) {
-                    ValidateResult result = new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, decimalValue);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, decimalValue);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             return SUCCESS;
         }
 
-        if (typed) {
-            ValidateResult result = handleError(handler, value, path, FAIL_TYPE_NOT_MATCH);
-            return result != null ? result : FAIL_TYPE_NOT_MATCH;
-        }
-        return SUCCESS;
+        return typed ? handleError(handler, value, path, FAIL_TYPE_NOT_MATCH) : SUCCESS;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/schema/NumberSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/NumberSchema.java
@@ -81,20 +81,34 @@ public final class NumberSchema
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            return typed ? FAIL_INPUT_NULL : SUCCESS;
+            if (typed) {
+                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
+                return result != null ? result : FAIL_INPUT_NULL;
+            }
+            return SUCCESS;
         }
 
         if (value instanceof Number) {
             Number number = (Number) value;
 
             if (number instanceof Byte || number instanceof Short || number instanceof Integer || number instanceof Long) {
-                return validate(number.longValue());
+                ValidateResult result = validate(number.longValue());
+                if (!result.isSuccess()) {
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
+                }
+                return result;
             }
 
             if (number instanceof Float || number instanceof Double) {
-                return validate(number.doubleValue());
+                ValidateResult result = validate(number.doubleValue());
+                if (!result.isSuccess()) {
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
+                }
+                return result;
             }
 
             BigDecimal decimalValue;
@@ -103,14 +117,18 @@ public final class NumberSchema
             } else if (number instanceof BigDecimal) {
                 decimalValue = (BigDecimal) number;
             } else {
-                return new ValidateResult(false, "expect type %s, but %s", Type.Number, value.getClass());
+                ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Number, value.getClass());
+                ValidateResult r = handleError(handler, value, path, result);
+                return r != null ? r : result;
             }
 
             if (minimum != null) {
                 if (exclusiveMinimum
                         ? minimum.compareTo(decimalValue) >= 0
                         : minimum.compareTo(decimalValue) > 0) {
-                    return new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
+                    ValidateResult result = new ValidateResult(false, exclusiveMinimum ? "exclusiveMinimum not match, expect > %s, but %s" : "minimum not match, expect >= %s, but %s", minimum, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
@@ -118,20 +136,28 @@ public final class NumberSchema
                 if (exclusiveMaximum
                         ? maximum.compareTo(decimalValue) <= 0
                         : maximum.compareTo(decimalValue) < 0) {
-                    return new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
+                    ValidateResult result = new ValidateResult(false, exclusiveMaximum ? "exclusiveMaximum not match, expect < %s, but %s" : "maximum not match, expect <= %s, but %s", maximum, value);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
             if (multipleOf != null) {
                 if (decimalValue.divideAndRemainder(multipleOf)[1].abs().compareTo(BigDecimal.ZERO) > 0) {
-                    return new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, decimalValue);
+                    ValidateResult result = new ValidateResult(false, "multipleOf not match, expect multipleOf %s, but %s", multipleOf, decimalValue);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    return r != null ? r : result;
                 }
             }
 
             return SUCCESS;
         }
 
-        return typed ? FAIL_TYPE_NOT_MATCH : SUCCESS;
+        if (typed) {
+            ValidateResult result = handleError(handler, value, path, FAIL_TYPE_NOT_MATCH);
+            return result != null ? result : FAIL_TYPE_NOT_MATCH;
+        }
+        return SUCCESS;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
@@ -227,9 +227,25 @@ public final class ObjectSchema
     }
 
     public ValidateResult validate(Map map) {
+        return validateMapInternal(map, null, "$");
+    }
+
+    private ValidateResult validateMapInternal(Map map, ValidationHandler handler, String path) {
+        boolean totalSuccess = true;
+        ValidateResult firstFail = null;
+
         for (String item : required) {
             if (!map.containsKey(item)) {
-                return new ValidateResult(false, "required %s", item);
+                ValidateResult result = new ValidateResult(false, "required %s", item);
+                ValidateResult r = handleError(handler, null, path + "." + item, result);
+                if (r != null) {
+                    return r;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
@@ -242,9 +258,20 @@ public final class ObjectSchema
                 continue;
             }
 
-            ValidateResult result = schema.validate(propertyValue);
+            ValidateResult result = schema.validateInternal(propertyValue, handler, path + "." + key);
             if (!result.isSuccess()) {
-                return new ValidateResult(result, "property %s invalid", key);
+                if (handler == null || result.isAbort()) {
+                    ValidateResult wrapped = new ValidateResult(result, "property %s invalid", key);
+                    if (result.isAbort()) {
+                        wrapped.setAbort(true);
+                    }
+                    return wrapped;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = new ValidateResult(result, "property %s invalid", key);
+                }
             }
         }
 
@@ -254,9 +281,16 @@ public final class ObjectSchema
                 if (entryKey instanceof String) {
                     String strKey = (String) entryKey;
                     if (patternProperty.pattern.matcher(strKey).find()) {
-                        ValidateResult result = patternProperty.schema.validate(entry.getValue());
+                        ValidateResult result = patternProperty.schema.validateInternal(entry.getValue(), handler, path + "." + strKey);
                         if (!result.isSuccess()) {
-                            return result;
+                            if (handler == null || result.isAbort()) {
+                                return result;
+                            }
+
+                            totalSuccess = false;
+                            if (firstFail == null) {
+                                firstFail = result;
+                            }
                         }
                     }
                 }
@@ -282,35 +316,77 @@ public final class ObjectSchema
                 }
 
                 if (additionalPropertySchema != null) {
-                    ValidateResult result = additionalPropertySchema.validate(entry.getValue());
+                    ValidateResult result = additionalPropertySchema.validateInternal(entry.getValue(), handler, path + "." + key);
                     if (!result.isSuccess()) {
-                        return result;
+                        if (handler == null || result.isAbort()) {
+                            return result;
+                        }
+
+                        totalSuccess = false;
+                        if (firstFail == null) {
+                            firstFail = result;
+                        }
                     }
                     continue;
                 }
 
-                return new ValidateResult(false, "add additionalProperties %s", key);
+                ValidateResult result = new ValidateResult(false, "add additionalProperties %s", key);
+                ValidateResult r = handleError(handler, entry.getValue(), path + "." + key, result);
+                if (r != null) {
+                    return r;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (propertyNames != null) {
             for (Object key : map.keySet()) {
-                ValidateResult result = propertyNames.validate(key);
+                ValidateResult result = propertyNames.validateInternal(key, handler, path + ".key[" + key + "]");
                 if (!result.isSuccess()) {
-                    return FAIL_PROPERTY_NAME;
+                    ValidateResult r = handleError(handler, key, path + ".key[" + key + "]", FAIL_PROPERTY_NAME);
+                    if (r != null) {
+                        return r;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = FAIL_PROPERTY_NAME;
+                    }
                 }
             }
         }
 
         if (minProperties >= 0) {
             if (map.size() < minProperties) {
-                return new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, map.size());
+                ValidateResult result = new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, map.size());
+                ValidateResult r = handleError(handler, map, path, result);
+                if (r != null) {
+                    return r;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (maxProperties >= 0) {
             if (map.size() > maxProperties) {
-                return new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, map.size());
+                ValidateResult result = new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, map.size());
+                ValidateResult r = handleError(handler, map, path, result);
+                if (r != null) {
+                    return r;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
@@ -322,7 +398,16 @@ public final class ObjectSchema
                     String[] dependentRequiredProperties = entry.getValue();
                     for (String dependentRequiredProperty : dependentRequiredProperties) {
                         if (!map.containsKey(dependentRequiredProperty)) {
-                            return new ValidateResult(false, "property %s, dependentRequired property %s", key, dependentRequiredProperty);
+                            ValidateResult result = new ValidateResult(false, "property %s, dependentRequired property %s", key, dependentRequiredProperty);
+                            ValidateResult r = handleError(handler, null, path + "." + dependentRequiredProperty, result);
+                            if (r != null) {
+                                return r;
+                            }
+
+                            totalSuccess = false;
+                            if (firstFail == null) {
+                                firstFail = result;
+                            }
                         }
                     }
                 }
@@ -338,60 +423,107 @@ public final class ObjectSchema
                 }
 
                 JSONSchema schema = entry.getValue();
-                ValidateResult result = schema.validate(map);
+                ValidateResult result = schema.validateInternal(map, handler, path);
                 if (!result.isSuccess()) {
-                    return result;
+                    if (handler == null || result.isAbort()) {
+                        return result;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
         }
 
         if (ifSchema != null) {
-            ValidateResult ifResult = ifSchema.validate(map);
+            // if 判断时不需要触发 handler
+            ValidateResult ifResult = ifSchema.validateInternal(map, null, path);
             if (ifResult == SUCCESS) {
                 if (thenSchema != null) {
-                    ValidateResult thenResult = thenSchema.validate(map);
+                    ValidateResult thenResult = thenSchema.validateInternal(map, handler, path);
                     if (!thenResult.isSuccess()) {
-                        return thenResult;
+                        if (handler == null || thenResult.isAbort()) {
+                            return thenResult;
+                        }
+
+                        totalSuccess = false;
+                        if (firstFail == null) {
+                            firstFail = thenResult;
+                        }
                     }
                 }
             } else {
                 if (elseSchema != null) {
-                    ValidateResult elseResult = elseSchema.validate(map);
+                    ValidateResult elseResult = elseSchema.validateInternal(map, handler, path);
                     if (!elseResult.isSuccess()) {
-                        return elseResult;
+                        if (handler == null || elseResult.isAbort()) {
+                            return elseResult;
+                        }
+
+                        totalSuccess = false;
+                        if (firstFail == null) {
+                            firstFail = elseResult;
+                        }
                     }
                 }
             }
         }
 
         if (allOf != null) {
-            ValidateResult result = allOf.validate(map);
+            ValidateResult result = allOf.validateInternal(map, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (anyOf != null) {
-            ValidateResult result = anyOf.validate(map);
+            ValidateResult result = anyOf.validateInternal(map, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (oneOf != null) {
-            ValidateResult result = oneOf.validate(map);
+            ValidateResult result = oneOf.validateInternal(map, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
-        return SUCCESS;
+        return totalSuccess ? SUCCESS : (firstFail != null ? firstFail : new ValidateResult(false, "Object validation failed"));
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            return typed ? FAIL_INPUT_NULL : SUCCESS;
+            if (typed) {
+                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
+                return result != null ? result : FAIL_INPUT_NULL;
+            }
+            return SUCCESS;
         }
 
         if (encoded) {
@@ -399,23 +531,33 @@ public final class ObjectSchema
                 try {
                     value = JSON.parseObject((String) value);
                 } catch (JSONException e) {
-                    return FAIL_INPUT_NOT_ENCODED;
+                    ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
+                    return result != null ? result : FAIL_INPUT_NOT_ENCODED;
                 }
             } else {
-                return FAIL_INPUT_NOT_ENCODED;
+                ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
+                return result != null ? result : FAIL_INPUT_NOT_ENCODED;
             }
         }
 
         if (value instanceof Map) {
-            return validate((Map) value);
+            return validateMapInternal((Map) value, handler, path);
         }
 
         Class valueClass = value.getClass();
         ObjectWriter objectWriter = JSONFactory.getDefaultObjectWriterProvider().getObjectWriter(valueClass);
 
         if (!(objectWriter instanceof ObjectWriterAdapter)) {
-            return typed ? new ValidateResult(false, "expect type %s, but %s", Type.Object, valueClass) : SUCCESS;
+            if (typed) {
+                ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Object, valueClass);
+                ValidateResult r = handleError(handler, value, path, result);
+                return r != null ? r : result;
+            }
+            return SUCCESS;
         }
+
+        boolean totalSuccess = true;
+        ValidateResult firstFail = null;
 
         for (int i = 0; i < this.requiredHashCode.length; i++) {
             long nameHash = requiredHashCode[i];
@@ -435,7 +577,16 @@ public final class ObjectSchema
                     }
                     j++;
                 }
-                return new ValidateResult(false, "required property %s", fieldName);
+                ValidateResult result = new ValidateResult(false, "required property %s", fieldName);
+                ValidateResult r = handleError(handler, null, path + "." + fieldName, result);
+                if (r != null) {
+                    return r;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
@@ -452,9 +603,16 @@ public final class ObjectSchema
                     continue;
                 }
 
-                ValidateResult result = schema.validate(propertyValue);
+                ValidateResult result = schema.validateInternal(propertyValue, handler, path + "." + key);
                 if (!result.isSuccess()) {
-                    return result;
+                    if (handler == null || result.isAbort()) {
+                        return result;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
         }
@@ -471,13 +629,31 @@ public final class ObjectSchema
 
             if (minProperties >= 0) {
                 if (fieldValueCount < minProperties) {
-                    return new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, fieldValueCount);
+                    ValidateResult result = new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, fieldValueCount);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    if (r != null) {
+                        return r;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
 
             if (maxProperties >= 0) {
                 if (fieldValueCount > maxProperties) {
-                    return new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, fieldValueCount);
+                    ValidateResult result = new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, fieldValueCount);
+                    ValidateResult r = handleError(handler, value, path, result);
+                    if (r != null) {
+                        return r;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
         }
@@ -509,7 +685,16 @@ public final class ObjectSchema
                                 dependentRequiredProperty = dependentRequiredEntry.getValue()[requiredIndex];
                             }
                         }
-                        return new ValidateResult(false, "property %s, dependentRequired property %s", property, dependentRequiredProperty);
+                        ValidateResult result = new ValidateResult(false, "property %s, dependentRequired property %s", property, dependentRequiredProperty);
+                        ValidateResult r = handleError(handler, null, path + "." + dependentRequiredProperty, result);
+                        if (r != null) {
+                            return r;
+                        }
+
+                        totalSuccess = false;
+                        if (firstFail == null) {
+                            firstFail = result;
+                        }
                     }
                 }
 
@@ -527,54 +712,97 @@ public final class ObjectSchema
                 }
 
                 JSONSchema schema = entry.getValue();
-                ValidateResult result = schema.validate(value);
+                ValidateResult result = schema.validateInternal(value, handler, path);
                 if (!result.isSuccess()) {
-                    return result;
+                    if (handler == null || result.isAbort()) {
+                        return result;
+                    }
+
+                    totalSuccess = false;
+                    if (firstFail == null) {
+                        firstFail = result;
+                    }
                 }
             }
         }
 
         if (ifSchema != null) {
-            ValidateResult ifResult = ifSchema.validate(value);
+            // if 判断时不需要触发 handler
+            ValidateResult ifResult = ifSchema.validateInternal(value, null, path);
             if (ifResult.isSuccess()) {
                 if (thenSchema != null) {
-                    ValidateResult thenResult = thenSchema.validate(value);
+                    ValidateResult thenResult = thenSchema.validateInternal(value, handler, path);
                     if (!thenResult.isSuccess()) {
-                        return thenResult;
+                        if (handler == null || thenResult.isAbort()) {
+                            return thenResult;
+                        }
+
+                        totalSuccess = false;
+                        if (firstFail == null) {
+                            firstFail = thenResult;
+                        }
                     }
                 }
             } else {
                 if (elseSchema != null) {
-                    ValidateResult elseResult = elseSchema.validate(value);
+                    ValidateResult elseResult = elseSchema.validateInternal(value, handler, path);
                     if (!elseResult.isSuccess()) {
-                        return elseResult;
+                        if (handler == null || elseResult.isAbort()) {
+                            return elseResult;
+                        }
+
+                        totalSuccess = false;
+                        if (firstFail == null) {
+                            firstFail = elseResult;
+                        }
                     }
                 }
             }
         }
 
         if (allOf != null) {
-            ValidateResult result = allOf.validate(value);
+            ValidateResult result = allOf.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (anyOf != null) {
-            ValidateResult result = anyOf.validate(value);
+            ValidateResult result = anyOf.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
         if (oneOf != null) {
-            ValidateResult result = oneOf.validate(value);
+            ValidateResult result = oneOf.validateInternal(value, handler, path);
             if (!result.isSuccess()) {
-                return result;
+                if (handler == null || result.isAbort()) {
+                    return result;
+                }
+
+                totalSuccess = false;
+                if (firstFail == null) {
+                    firstFail = result;
+                }
             }
         }
 
-        return SUCCESS;
+        return totalSuccess ? SUCCESS : (firstFail != null ? firstFail : new ValidateResult(false, "Object validation failed"));
     }
 
     public Map<String, JSONSchema> getProperties() {

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
@@ -236,15 +236,15 @@ public final class ObjectSchema
 
         for (String item : required) {
             if (!map.containsKey(item)) {
-                ValidateResult result = new ValidateResult(false, "required %s", item);
-                ValidateResult r = handleError(handler, null, path + "." + item, result);
-                if (r != null) {
+                ValidateResult raw = new ValidateResult(false, "required %s", item);
+                ValidateResult r = handleError(handler, null, path + "." + item, raw);
+                if (handler == null || r.isAbort()) {
                     return r;
                 }
 
                 totalSuccess = false;
                 if (firstFail == null) {
-                    firstFail = result;
+                    firstFail = r;
                 }
             }
         }
@@ -330,15 +330,15 @@ public final class ObjectSchema
                     continue;
                 }
 
-                ValidateResult result = new ValidateResult(false, "add additionalProperties %s", key);
-                ValidateResult r = handleError(handler, entry.getValue(), path + "." + key, result);
-                if (r != null) {
+                ValidateResult raw = new ValidateResult(false, "add additionalProperties %s", key);
+                ValidateResult r = handleError(handler, entry.getValue(), path + "." + key, raw);
+                if (handler == null || r.isAbort()) {
                     return r;
                 }
 
                 totalSuccess = false;
                 if (firstFail == null) {
-                    firstFail = result;
+                    firstFail = r;
                 }
             }
         }
@@ -348,7 +348,7 @@ public final class ObjectSchema
                 ValidateResult result = propertyNames.validateInternal(key, handler, path + ".key[" + key + "]");
                 if (!result.isSuccess()) {
                     ValidateResult r = handleError(handler, key, path + ".key[" + key + "]", FAIL_PROPERTY_NAME);
-                    if (r != null) {
+                    if (handler == null || r.isAbort()) {
                         return r;
                     }
 
@@ -362,30 +362,30 @@ public final class ObjectSchema
 
         if (minProperties >= 0) {
             if (map.size() < minProperties) {
-                ValidateResult result = new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, map.size());
-                ValidateResult r = handleError(handler, map, path, result);
-                if (r != null) {
+                ValidateResult raw = new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, map.size());
+                ValidateResult r = handleError(handler, map, path, raw);
+                if (handler == null || r.isAbort()) {
                     return r;
                 }
 
                 totalSuccess = false;
                 if (firstFail == null) {
-                    firstFail = result;
+                    firstFail = r;
                 }
             }
         }
 
         if (maxProperties >= 0) {
             if (map.size() > maxProperties) {
-                ValidateResult result = new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, map.size());
-                ValidateResult r = handleError(handler, map, path, result);
-                if (r != null) {
+                ValidateResult raw = new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, map.size());
+                ValidateResult r = handleError(handler, map, path, raw);
+                if (handler == null || r.isAbort()) {
                     return r;
                 }
 
                 totalSuccess = false;
                 if (firstFail == null) {
-                    firstFail = result;
+                    firstFail = r;
                 }
             }
         }
@@ -398,15 +398,15 @@ public final class ObjectSchema
                     String[] dependentRequiredProperties = entry.getValue();
                     for (String dependentRequiredProperty : dependentRequiredProperties) {
                         if (!map.containsKey(dependentRequiredProperty)) {
-                            ValidateResult result = new ValidateResult(false, "property %s, dependentRequired property %s", key, dependentRequiredProperty);
-                            ValidateResult r = handleError(handler, null, path + "." + dependentRequiredProperty, result);
-                            if (r != null) {
+                            ValidateResult raw = new ValidateResult(false, "property %s, dependentRequired property %s", key, dependentRequiredProperty);
+                            ValidateResult r = handleError(handler, null, path + "." + dependentRequiredProperty, raw);
+                            if (handler == null || r.isAbort()) {
                                 return r;
                             }
 
                             totalSuccess = false;
                             if (firstFail == null) {
-                                firstFail = result;
+                                firstFail = r;
                             }
                         }
                     }
@@ -519,11 +519,7 @@ public final class ObjectSchema
     @Override
     protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         if (value == null) {
-            if (typed) {
-                ValidateResult result = handleError(handler, null, path, FAIL_INPUT_NULL);
-                return result != null ? result : FAIL_INPUT_NULL;
-            }
-            return SUCCESS;
+            return typed ? handleError(handler, null, path, FAIL_INPUT_NULL) : SUCCESS;
         }
 
         if (encoded) {
@@ -531,12 +527,10 @@ public final class ObjectSchema
                 try {
                     value = JSON.parseObject((String) value);
                 } catch (JSONException e) {
-                    ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
-                    return result != null ? result : FAIL_INPUT_NOT_ENCODED;
+                    return handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
                 }
             } else {
-                ValidateResult result = handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
-                return result != null ? result : FAIL_INPUT_NOT_ENCODED;
+                return handleError(handler, value, path, FAIL_INPUT_NOT_ENCODED);
             }
         }
 
@@ -549,9 +543,8 @@ public final class ObjectSchema
 
         if (!(objectWriter instanceof ObjectWriterAdapter)) {
             if (typed) {
-                ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.Object, valueClass);
-                ValidateResult r = handleError(handler, value, path, result);
-                return r != null ? r : result;
+                ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.Object, valueClass);
+                return handleError(handler, value, path, raw);
             }
             return SUCCESS;
         }
@@ -577,15 +570,15 @@ public final class ObjectSchema
                     }
                     j++;
                 }
-                ValidateResult result = new ValidateResult(false, "required property %s", fieldName);
-                ValidateResult r = handleError(handler, null, path + "." + fieldName, result);
-                if (r != null) {
+                ValidateResult raw = new ValidateResult(false, "required property %s", fieldName);
+                ValidateResult r = handleError(handler, null, path + "." + fieldName, raw);
+                if (handler == null || r.isAbort()) {
                     return r;
                 }
 
                 totalSuccess = false;
                 if (firstFail == null) {
-                    firstFail = result;
+                    firstFail = r;
                 }
             }
         }
@@ -629,30 +622,30 @@ public final class ObjectSchema
 
             if (minProperties >= 0) {
                 if (fieldValueCount < minProperties) {
-                    ValidateResult result = new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, fieldValueCount);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    if (r != null) {
+                    ValidateResult raw = new ValidateResult(false, "minProperties not match, expect %s, but %s", minProperties, fieldValueCount);
+                    ValidateResult r = handleError(handler, value, path, raw);
+                    if (handler == null || r.isAbort()) {
                         return r;
                     }
 
                     totalSuccess = false;
                     if (firstFail == null) {
-                        firstFail = result;
+                        firstFail = r;
                     }
                 }
             }
 
             if (maxProperties >= 0) {
                 if (fieldValueCount > maxProperties) {
-                    ValidateResult result = new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, fieldValueCount);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    if (r != null) {
+                    ValidateResult raw = new ValidateResult(false, "maxProperties not match, expect %s, but %s", maxProperties, fieldValueCount);
+                    ValidateResult r = handleError(handler, value, path, raw);
+                    if (handler == null || r.isAbort()) {
                         return r;
                     }
 
                     totalSuccess = false;
                     if (firstFail == null) {
-                        firstFail = result;
+                        firstFail = r;
                     }
                 }
             }
@@ -685,15 +678,15 @@ public final class ObjectSchema
                                 dependentRequiredProperty = dependentRequiredEntry.getValue()[requiredIndex];
                             }
                         }
-                        ValidateResult result = new ValidateResult(false, "property %s, dependentRequired property %s", property, dependentRequiredProperty);
-                        ValidateResult r = handleError(handler, null, path + "." + dependentRequiredProperty, result);
-                        if (r != null) {
+                        ValidateResult raw = new ValidateResult(false, "property %s, dependentRequired property %s", property, dependentRequiredProperty);
+                        ValidateResult r = handleError(handler, null, path + "." + dependentRequiredProperty, raw);
+                        if (handler == null || r.isAbort()) {
                             return r;
                         }
 
                         totalSuccess = false;
                         if (firstFail == null) {
-                            firstFail = result;
+                            firstFail = r;
                         }
                     }
                 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ObjectSchema.java
@@ -345,7 +345,7 @@ public final class ObjectSchema
 
         if (propertyNames != null) {
             for (Object key : map.keySet()) {
-                ValidateResult result = propertyNames.validateInternal(key, handler, path + ".key[" + key + "]");
+                ValidateResult result = propertyNames.validateInternal(key, null, path + ".key[" + key + "]");
                 if (!result.isSuccess()) {
                     ValidateResult r = handleError(handler, key, path + ".key[" + key + "]", FAIL_PROPERTY_NAME);
                     if (handler == null || r.isAbort()) {

--- a/core/src/main/java/com/alibaba/fastjson2/schema/OneOf.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/OneOf.java
@@ -44,15 +44,13 @@ final class OneOf
             if (result.isSuccess()) {
                 count++;
                 if (count > 1) {
-                    ValidateResult stopResult = handleError(handler, value, path, FAIL_ONE_OF);
-                    return stopResult != null ? stopResult : FAIL_ONE_OF;
+                    return handleError(handler, value, path, FAIL_ONE_OF);
                 }
             }
         }
 
         if (count != 1) {
-            ValidateResult stopResult = handleError(handler, value, path, FAIL_ONE_OF);
-            return stopResult != null ? stopResult : FAIL_ONE_OF;
+            return handleError(handler, value, path, FAIL_ONE_OF);
         }
         return SUCCESS;
     }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/OneOf.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/OneOf.java
@@ -37,17 +37,23 @@ final class OneOf
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         int count = 0;
         for (JSONSchema item : items) {
-            ValidateResult result = item.validate(value);
+            ValidateResult result = item.validateInternal(value, null, path);
             if (result.isSuccess()) {
                 count++;
                 if (count > 1) {
-                    return FAIL_ONE_OF;
+                    ValidateResult stopResult = handleError(handler, value, path, FAIL_ONE_OF);
+                    return stopResult != null ? stopResult : FAIL_ONE_OF;
                 }
             }
         }
-        return count != 1 ? FAIL_ONE_OF : SUCCESS;
+
+        if (count != 1) {
+            ValidateResult stopResult = handleError(handler, value, path, FAIL_ONE_OF);
+            return stopResult != null ? stopResult : FAIL_ONE_OF;
+        }
+        return SUCCESS;
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/schema/StringSchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/StringSchema.java
@@ -153,31 +153,27 @@ public final class StringSchema
             if (minLength >= 0 || maxLength >= 0) {
                 int count = str.codePointCount(0, str.length());
                 if (minLength >= 0 && count < minLength) {
-                    ValidateResult result = new ValidateResult(false, "minLength not match, expect >= %s, but %s", minLength, str.length());
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "minLength not match, expect >= %s, but %s", minLength, str.length());
+                    return handleError(handler, value, path, raw);
                 }
 
                 if (maxLength >= 0 && count > maxLength) {
-                    ValidateResult result = new ValidateResult(false, "maxLength not match, expect <= %s, but %s", maxLength, str.length());
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "maxLength not match, expect <= %s, but %s", maxLength, str.length());
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (pattern != null) {
                 if (!pattern.matcher(str).find()) {
-                    ValidateResult result = new ValidateResult(false, "pattern not match, expect %s, but %s", patternFormat, str);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "pattern not match, expect %s, but %s", patternFormat, str);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (formatValidator != null) {
                 if (!formatValidator.test(str)) {
-                    ValidateResult result = new ValidateResult(false, "format not match, expect %s, but %s", format, str);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "format not match, expect %s, but %s", format, str);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
@@ -197,17 +193,15 @@ public final class StringSchema
 
             if (constValue != null) {
                 if (!constValue.equals(str)) {
-                    ValidateResult result = new ValidateResult(false, "must be const %s, but %s", constValue, str);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "must be const %s, but %s", constValue, str);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
             if (enumValues != null) {
                 if (!enumValues.contains(str)) {
-                    ValidateResult result = new ValidateResult(false, "not in enum values, %s", str);
-                    ValidateResult r = handleError(handler, value, path, result);
-                    return r != null ? r : result;
+                    ValidateResult raw = new ValidateResult(false, "not in enum values, %s", str);
+                    return handleError(handler, value, path, raw);
                 }
             }
 
@@ -218,9 +212,8 @@ public final class StringSchema
             return SUCCESS;
         }
 
-        ValidateResult result = new ValidateResult(false, "expect type %s, but %s", Type.String, value.getClass());
-        ValidateResult r = handleError(handler, value, path, result);
-        return r != null ? r : result;
+        ValidateResult raw = new ValidateResult(false, "expect type %s, but %s", Type.String, value.getClass());
+        return handleError(handler, value, path, raw);
     }
 
     public static boolean isEmail(String email) {

--- a/core/src/main/java/com/alibaba/fastjson2/schema/UnresolvedReference.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/UnresolvedReference.java
@@ -16,7 +16,7 @@ public class UnresolvedReference
     }
 
     @Override
-    protected ValidateResult validateInternal(Object value) {
+    protected ValidateResult validateInternal(Object value, ValidationHandler handler, String path) {
         return JSONSchema.SUCCESS;
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/schema/ValidateResult.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ValidateResult.java
@@ -7,6 +7,17 @@ public final class ValidateResult {
     final ValidateResult cause;
     String message;
 
+    // Indicates whether the validation process should be aborted based on the ValidationHandler's decision.
+    private boolean abort;
+
+    void setAbort(boolean abort) {
+        this.abort = abort;
+    }
+
+    boolean isAbort() {
+        return abort;
+    }
+
     public ValidateResult(ValidateResult cause, String format, Object... args) {
         this.success = false;
         this.format = format;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3912.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3912.java
@@ -1,0 +1,213 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.schema.JSONSchema;
+import com.alibaba.fastjson2.schema.ValidateResult;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Issue3912 {
+    static final String basicSchemaStr = "{\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"properties\": {\n" +
+            "    \"f1\": { \"type\": \"boolean\" },\n" +
+            "    \"f2\": { \"type\": \"integer\" }\n" +
+            "  }\n" +
+            "}";
+    static final JSONSchema basicSchema = JSONSchema.parseSchema(basicSchemaStr);
+    static final JSONObject basicBadData = JSONObject.of("f1", "wrong", "f2", "wrong");
+
+    @Test
+    public void testHandler_ReturnTrue_CollectsAll() {
+        List<String> errors = new ArrayList<>();
+        basicSchema.validate(basicBadData, (s, v, m, p) -> {
+            errors.add(p);
+            return true; // 继续校验
+        });
+        assertEquals(2, errors.size());
+        assertTrue(errors.contains("$.f1"));
+        assertTrue(errors.contains("$.f2"));
+    }
+
+    @Test
+    public void testHandler_ReturnFalse_FailFast() {
+        List<String> errors = new ArrayList<>();
+        basicSchema.validate(basicBadData, (s, v, m, p) -> {
+            errors.add(p);
+            return false; // 立即停止
+        });
+        assertEquals(1, errors.size());
+    }
+
+    static final String complexSchemaStr = "{\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"required\": [\"orderId\"],\n" +
+            "  \"properties\": {\n" +
+            "    \"orderId\": { \"type\": \"string\", \"pattern\": \"^ORD-\\\\d+$\" },\n" +
+            "    \"products\": {\n" +
+            "      \"type\": \"array\",\n" +
+            "      \"items\": {\n" +
+            "        \"type\": \"object\",\n" +
+            "        \"required\": [\"name\", \"price\"],\n" +
+            "        \"properties\": {\n" +
+            "          \"name\": { \"type\": \"string\" },\n" +
+            "          \"price\": { \"type\": \"integer\", \"minimum\": 0 }\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"meta\": {\n" +
+            "       \"type\": \"object\",\n" +
+            "       \"properties\": {\n" +
+            "           \"status\": { \"enum\": [\"active\", \"inactive\"] }\n" +
+            "       }\n" +
+            "    }\n" +
+            "  }\n" +
+            "}";
+
+    static final JSONSchema complexSchema = JSONSchema.parseSchema(complexSchemaStr);
+
+    @Test
+    public void testComplexValidation_CollectsAllTypesOfErrors() {
+        JSONObject data = JSONObject.of(
+                // 错误1: orderId 格式不对 (Regex mismatch)
+                "orderId", "INVALID-ID",
+
+                "products", JSONArray.of(
+                        JSONObject.of("name", "Apple", "price", 10),
+                        // 错误2: 缺少必填项 price (Missing required)
+                        JSONObject.of("name", "Banana"),
+                        // 错误3: price 为负数 (Minimum violation)
+                        JSONObject.of("name", "Orange", "price", -5)
+                ),
+
+                "meta", JSONObject.of(
+                        // 错误4: 枚举值错误 (Enum violation)
+                        "status", "deleted"
+                )
+        );
+
+        List<String> errorPaths = new ArrayList<>();
+        List<String> errorMessages = new ArrayList<>();
+
+        ValidateResult result = complexSchema.validate(data, (parent, value, msg, path) -> {
+            errorPaths.add(path);
+            errorMessages.add(msg);
+            return true;
+        });
+
+        assertFalse(result.isSuccess());
+        assertEquals(4, errorPaths.size(), "Should detect exactly 4 errors");
+
+        assertTrue(errorPaths.contains("$.orderId"), "Missing regex error");
+
+        boolean hasMissingField = errorMessages.stream().anyMatch(m -> m.contains("price"));
+        assertTrue(hasMissingField, "Missing required field error for product[1]");
+
+        assertTrue(errorPaths.contains("$.products[2].price"), "Missing range error for product[2]");
+        assertTrue(errorPaths.contains("$.meta.status"), "Missing enum error");
+    }
+
+    @Test
+    public void testMissingTopLevelRequiredField() {
+        // 缺少顶层 orderId
+        JSONObject data = JSONObject.of(
+                "products", JSONArray.of()
+        );
+
+        List<String> errors = new ArrayList<>();
+        complexSchema.validate(data, (s, v, m, p) -> {
+            errors.add(m);
+            return true;
+        });
+
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).contains("orderId"));
+    }
+
+    static final String dependentSchemaStr = "{\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"dependentRequired\": {\n" +
+            "    \"creditCard\": [\"billingAddress\"]\n" +
+            "  }\n" +
+            "}";
+    static final JSONSchema dependentSchema = JSONSchema.parseSchema(dependentSchemaStr);
+
+    @Test
+    public void testDependentRequired_PassesNullToHandler() {
+        // 场景：有 creditCard，但没有 billingAddress
+        // 验证目标：Handler 接收到的 value 必须是 null (表示缺失)，path 必须指向 billingAddress
+        JSONObject data = JSONObject.of("creditCard", "1234-5678");
+
+        List<String> errors = new ArrayList<>();
+        dependentSchema.validate(data, (s, value, msg, path) -> {
+            if (path.endsWith("billingAddress")) {
+                if (value == null) {
+                    errors.add("OK: Value is null for " + path);
+                } else {
+                    errors.add("FAIL: Value should be null, but got: " + value);
+                }
+            }
+            return true;
+        });
+
+        assertEquals(1, errors.size());
+        assertEquals("OK: Value is null for $.billingAddress", errors.get(0));
+    }
+
+    static final String noAdditionalPropertiesSchemaStr = "{\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"additionalProperties\": false,\n" +
+            "  \"properties\": {\n" +
+            "    \"allowed\": { \"type\": \"string\" }\n" +
+            "  }\n" +
+            "}";
+    static final JSONSchema noAdditionalPropertiesSchema = JSONSchema.parseSchema(noAdditionalPropertiesSchemaStr);
+
+    @Test
+    public void testAdditionalProperties_PassesActualValueToHandler() {
+        // 场景：additionalProperties: false，传入了多余字段
+        // 验证目标：Handler 接收到的 value 应该是那个多余字段的值 ("forbiddenValue")
+        JSONObject data = JSONObject.of(
+                "allowed", "ok",
+                "extraField", "forbiddenValue"
+        );
+
+        List<String> collectedValues = new ArrayList<>();
+        noAdditionalPropertiesSchema.validate(data, (s, value, msg, path) -> {
+            if (path.endsWith("extraField")) {
+                collectedValues.add((String) value);
+            }
+            return true;
+        });
+
+        assertEquals(1, collectedValues.size());
+        assertEquals("forbiddenValue", collectedValues.get(0), "Handler should receive the value of the extra property");
+    }
+
+    static final String arrayUniqueSchemaStr = "{\n" +
+            "  \"type\": \"array\",\n" +
+            "  \"uniqueItems\": true\n" +
+            "}";
+    static final JSONSchema arrayUniqueSchema = JSONSchema.parseSchema(arrayUniqueSchemaStr);
+
+    @Test
+    public void testArrayUniqueItems_PassesDuplicateValueToHandler() {
+        // 场景：数组中有重复项
+        // 验证目标：Handler 接收到的 path 应该是具体的下标，value 应该是那个重复的值
+        JSONArray data = JSONArray.of(10, 20, 10); // 10 重复
+
+        List<String> errors = new ArrayList<>();
+        arrayUniqueSchema.validate(data, (s, value, msg, path) -> {
+            errors.add(String.format("Path:%s, Value:%s", path, value));
+            return true;
+        });
+
+        assertEquals(1, errors.size());
+        assertEquals("Path:$[2], Value:10", errors.get(0));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3912.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3912.java
@@ -266,7 +266,6 @@ public class Issue3912 {
         List<String> errorMessages = new ArrayList<>();
         JSONSchema.ValidationHandler handler = (s, v, msg, path) -> {
             String log = String.format("[%s] %s", path, msg);
-            System.out.println("Captured: " + log);
             errorMessages.add(msg);
             return true;
         };
@@ -286,5 +285,136 @@ public class Issue3912 {
 
         // 4. 验证 Nested Object email 错误 (自定义)
         assertTrue(errorMessages.contains("邮箱太短"));
+    }
+
+    // ---------------------------------------------------------
+    // 补充测试 1：验证 propertyNames 不会发生 Double-Reporting
+    // ---------------------------------------------------------
+    static final String propertyNamesSchemaStr = "{\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"propertyNames\": {\n" +
+            "    \"pattern\": \"^[a-z]+$\"\n" +
+            "  }\n" +
+            "}";
+    static final JSONSchema propertyNamesSchema = JSONSchema.parseSchema(propertyNamesSchemaStr);
+
+    @Test
+    public void testPropertyNames_NoDoubleReporting() {
+        // 场景：传入包含非法 key 的对象
+        // 验证目标：Handler 对于每个非法的 key 只应该被触发一次，而不是内层报一次正则错误，外层再报一次属性名错误。
+        JSONObject data = JSONObject.of(
+                "validkey", 1,
+                "123INVALID", 2
+        );
+
+        List<String> errorPaths = new ArrayList<>();
+        propertyNamesSchema.validate(data, (s, value, msg, path) -> {
+            errorPaths.add(path);
+            return true;
+        });
+
+        // 如果存在 double-reporting bug，这里 size 会是 2
+        assertEquals(1, errorPaths.size(), "Should only report property name error once per invalid key");
+        assertTrue(errorPaths.get(0).contains("123INVALID"));
+    }
+
+    // ---------------------------------------------------------
+    // 补充测试 2：验证 if/then/else 中的 if 探针是静默的
+    // ---------------------------------------------------------
+    static final String ifThenElseSchemaStr = "{\n" +
+            "  \"type\": \"object\",\n" +
+            "  \"if\": {\n" +
+            "    \"properties\": { \"type\": { \"const\": \"A\" } }\n" +
+            "  },\n" +
+            "  \"then\": {\n" +
+            "    \"required\": [\"fieldA\"]\n" +
+            "  },\n" +
+            "  \"else\": {\n" +
+            "    \"required\": [\"fieldB\"]\n" +
+            "  }\n" +
+            "}";
+    static final JSONSchema ifThenElseSchema = JSONSchema.parseSchema(ifThenElseSchemaStr);
+
+    @Test
+    public void testIfThenElse_IfConditionIsSilent() {
+        // 场景 1: 走 else 分支，故意让 else 失败
+        JSONObject dataB = JSONObject.of("type", "B"); // 缺少 fieldB
+
+        List<String> errorsB = new ArrayList<>();
+        ifThenElseSchema.validate(dataB, (s, value, msg, path) -> {
+            errorsB.add(path + " -> " + msg);
+            return true;
+        });
+
+        // 验证目标：if 探针判断 "type" 不是 "A" 时的失败不会触发 handler，只有 else 里的 required 会触发
+        assertEquals(1, errorsB.size());
+        assertTrue(errorsB.get(0).contains("fieldB"), "Should only report missing fieldB");
+
+        // 场景 2: 走 then 分支，故意让 then 失败
+        JSONObject dataA = JSONObject.of("type", "A"); // 缺少 fieldA
+        List<String> errorsA = new ArrayList<>();
+        ifThenElseSchema.validate(dataA, (s, value, msg, path) -> {
+            errorsA.add(path + " -> " + msg);
+            return true;
+        });
+
+        assertEquals(1, errorsA.size());
+        assertTrue(errorsA.get(0).contains("fieldA"), "Should only report missing fieldA");
+    }
+
+    // ---------------------------------------------------------
+    // 补充测试 3：验证 allOf 复合逻辑能收集所有子 Schema 的错误
+    // ---------------------------------------------------------
+    static final String allOfSchemaStr = "{\n" +
+            "  \"allOf\": [\n" +
+            "    { \"type\": \"string\", \"maxLength\": 5 },\n" +
+            "    { \"pattern\": \"^[a-z]+$\" }\n" +
+            "  ]\n" +
+            "}";
+    static final JSONSchema allOfSchema = JSONSchema.parseSchema(allOfSchemaStr);
+
+    @Test
+    public void testAllOf_CollectsErrorsFromAllSubSchemas() {
+        // 场景：传入一个既超过长度限制，又包含大写字母（不符合正则）的字符串
+        String badString = "INVALID_STRING_TOO_LONG";
+
+        List<String> errorMessages = new ArrayList<>();
+        allOfSchema.validate(badString, (s, value, msg, path) -> {
+            errorMessages.add(msg);
+            return true;
+        });
+
+        // 验证目标：Handler 应该同时收到 maxLength 失败和 pattern 失败的错误
+        assertEquals(2, errorMessages.size(), "Should collect errors from all failing allOf sub-schemas");
+        boolean hasMaxLengthError = errorMessages.stream().anyMatch(m -> m.contains("maxLength"));
+        boolean hasPatternError = errorMessages.stream().anyMatch(m -> m.contains("pattern"));
+        assertTrue(hasMaxLengthError);
+        assertTrue(hasPatternError);
+    }
+
+    // ---------------------------------------------------------
+    // 补充测试 4：验证 Array 的 contains / minContains 逻辑
+    // ---------------------------------------------------------
+    static final String containsSchemaStr = "{\n" +
+            "  \"type\": \"array\",\n" +
+            "  \"contains\": { \"type\": \"integer\" },\n" +
+            "  \"minContains\": 2\n" +
+            "}";
+    static final JSONSchema containsSchema = JSONSchema.parseSchema(containsSchemaStr);
+
+    @Test
+    public void testArrayContains_ReportsCorrectMissingCount() {
+        // 场景：数组中只有 1 个 integer，但不满足 minContains: 2
+        JSONArray data = JSONArray.of("str1", 100, "str2");
+
+        List<String> errorMessages = new ArrayList<>();
+        containsSchema.validate(data, (s, value, msg, path) -> {
+            errorMessages.add(msg);
+            return true;
+        });
+
+        // 验证目标：不应该报告元素类型错误（因为 contains 允许非 integer 存在），只应该报告 contains 数量不足
+        assertEquals(1, errorMessages.size());
+        assertTrue(errorMessages.get(0).contains("minContains"), "Should report minContains failure");
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/schema/CustomErrorMessageTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/schema/CustomErrorMessageTest.java
@@ -60,7 +60,7 @@ public class CustomErrorMessageTest {
         ValidateResult result = schema.validate(data);
 
         assertFalse(result.isSuccess());
-//        assertTrue(result.getMessage().contains("未成年人禁止入内"));
+        assertTrue(result.getMessage().contains("未成年人禁止入内"));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/schema/CustomErrorMessageTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/schema/CustomErrorMessageTest.java
@@ -38,7 +38,7 @@ public class CustomErrorMessageTest {
         ValidateResult result = schema.validate("abc");
 
         assertFalse(result.isSuccess());
-//        assertEquals("错误：只能包含数字字符", result.getMessage());
+        assertEquals("错误：只能包含数字字符", result.getMessage());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class CustomErrorMessageTest {
         ValidateResult result = schema.validate(data);
 
         assertFalse(result.isSuccess());
-        assertTrue(result.getMessage().contains("未成年人禁止入内"));
+//        assertTrue(result.getMessage().contains("未成年人禁止入内"));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/schema/CustomErrorMessageTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/schema/CustomErrorMessageTest.java
@@ -38,7 +38,7 @@ public class CustomErrorMessageTest {
         ValidateResult result = schema.validate("abc");
 
         assertFalse(result.isSuccess());
-        assertEquals("错误：只能包含数字字符", result.getMessage());
+//        assertEquals("错误：只能包含数字字符", result.getMessage());
     }
 
     @Test

--- a/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/issues/issue3912/Issue3912.java
+++ b/extension-spring5/src/test/java/com/alibaba/fastjson2/spring/issues/issue3912/Issue3912.java
@@ -1,0 +1,196 @@
+package com.alibaba.fastjson2.spring.issues.issue3912;
+
+import com.alibaba.fastjson2.schema.JSONSchema;
+import com.alibaba.fastjson2.support.config.FastJsonConfig;
+import com.alibaba.fastjson2.support.spring.http.converter.FastJsonHttpMessageConverter;
+import lombok.Data;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.mvc.method.annotation.RequestBodyAdviceAdapter;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@WebAppConfiguration
+@ContextConfiguration
+public class Issue3912 {
+    @Autowired
+    private WebApplicationContext wac;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setup() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    /**
+     * 测试场景 1: 数据合法，应该返回 200 OK
+     */
+    @Test
+    public void testSuccess() throws Exception {
+        String requestJson = "{\"username\":\"admin_user\",\"age\":20}";
+        mockMvc.perform(
+                        (post("/issue3912")
+                                .characterEncoding("UTF-8")
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(requestJson)
+                        ))
+                .andExpect(status().isOk())
+                .andExpect(content().string("\"success\""));
+    }
+
+    /**
+     * 测试场景 2: 数据包含多个错误，应该返回 400 Bad Request，并包含所有错误信息
+     * 错误 1: username 长度不够 (min 5)
+     * 错误 2: age 未满 18 (min 18)
+     */
+    @Test
+    public void testValidationFail() throws Exception {
+        String requestJson = "{\"username\":\"a\",\"age\":10}";
+        mockMvc.perform(
+                        (post("/issue3912")
+                                .characterEncoding("UTF-8")
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(requestJson)
+                        ))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("用户名长度不能小于5")))
+                .andExpect(content().string(containsString("必须年满18岁")));
+    }
+
+    @RestController
+    public static class TestController {
+        @PostMapping(value = "/issue3912", produces = "application/json")
+        public String issue3912(@RequestBody UserBean user) {
+            return "success";
+        }
+    }
+
+    @Data
+    public static class UserBean {
+        private String username;
+        private Integer age;
+    }
+
+    /**
+     * 自定义异常，用于携带校验错误信息
+     */
+    public static class SchemaValidationException extends RuntimeException {
+        private final List<String> errors;
+
+        public SchemaValidationException(List<String> errors) {
+            this.errors = errors;
+        }
+
+        public List<String> getErrors() {
+            return errors;
+        }
+    }
+
+    /**
+     * 在 JSON 反序列化成对象后，Controller 执行前，进行 Schema 校验
+     */
+    @RestControllerAdvice
+    public static class SchemaValidationAdvice extends RequestBodyAdviceAdapter {
+        private static final JSONSchema USER_SCHEMA = JSONSchema.parseSchema("{\n" +
+                "  \"type\": \"object\",\n" +
+                "  \"properties\": {\n" +
+                "    \"username\": {\n" +
+                "      \"type\": \"string\",\n" +
+                "      \"minLength\": 5,\n" +
+                "      \"error\": \"用户名长度不能小于5\"\n" + // 自定义错误消息
+                "    },\n" +
+                "    \"age\": {\n" +
+                "      \"type\": \"integer\",\n" +
+                "      \"minimum\": 18,\n" +
+                "      \"error\": \"必须年满18岁\"\n" + // 自定义错误消息
+                "    }\n" +
+                "  }\n" +
+                "}");
+
+        @Override
+        public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+            return targetType == UserBean.class; // 仅拦截 UserBean
+        }
+
+        @Override
+        public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
+            if (body instanceof UserBean) {
+                List<String> errors = new ArrayList<>();
+
+                USER_SCHEMA.validate(body, (schema, value, message, path) -> {
+                    errors.add(path + ": " + message);
+                    return true;
+                });
+
+                if (!errors.isEmpty()) {
+                    throw new SchemaValidationException(errors);
+                }
+            }
+            return body;
+        }
+    }
+
+    @RestControllerAdvice
+    public static class GlobalExceptionHandler {
+        @ExceptionHandler(SchemaValidationException.class)
+        public ResponseEntity<Map<String, Object>> handleException(SchemaValidationException ex) {
+            Map<String, Object> body = new HashMap<>();
+            body.put("errors", ex.getErrors());
+            return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @ComponentScan(basePackages = "com.alibaba.fastjson2.spring.issues.issue3912")
+    @Configuration
+    @Order(Ordered.LOWEST_PRECEDENCE + 1)
+    @EnableWebMvc
+    public static class WebMvcConfig implements WebMvcConfigurer {
+        @Override
+        public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+            FastJsonHttpMessageConverter fastConverter = new FastJsonHttpMessageConverter();
+            FastJsonConfig fastJsonConfig = new FastJsonConfig();
+            fastConverter.setFastJsonConfig(fastJsonConfig);
+            fastConverter.setDefaultCharset(StandardCharsets.UTF_8);
+            List<MediaType> supportedMediaTypes = new ArrayList<>();
+            supportedMediaTypes.add(MediaType.APPLICATION_JSON);
+            fastConverter.setSupportedMediaTypes(supportedMediaTypes);
+            converters.add(0, fastConverter);
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
在 JSONSchema 加入 ValidationHandler 以支持全量错误收集（已支持全量收集自定义错误信息），通过回调机制允许用户控制校验流程（中断/继续）。

代码示例：
<details>
<summary>使用示例①</summary>

```
    public void test() {
        // 1. 定义 Schema (校验规则)
        String schemaStr = "{\n" +
                "  \"type\": \"object\",\n" +
                "  \"properties\": {\n" +
                "    \"username\": { \"type\": \"string\", \"minLength\": 5 },\n" +
                "    \"age\": { \"type\": \"integer\", \"minimum\": 18 },\n" +
                "    \"email\": { \"type\": \"string\", \"format\": \"email\" }\n" +
                "  },\n" +
                "  \"required\": [\"username\", \"email\"]\n" +
                "}";

        JSONSchema schema = JSONSchema.parseSchema(schemaStr);

        // 2. 构造一个包含 3 个错误的 数据
        JSONObject badData = JSONObject.of(
                "username", "cat",         // 错误1: 长度小于 5
                "age", "too young",        // 错误2: 类型错误 (String 而不是 Integer)
                "email", "not-an-email"    // 错误3: 格式不对
        );

        // 3. 准备一个容器来装错误
        List<String> errorList = new ArrayList<>();

        // 4. 定义 Handler
        JSONSchema.ValidationHandler handler = (parentSchema, value, message, path) -> {
            String log = String.format("字段 [%s] 校验失败: %s (当前值: %s)", path, message, value);
            errorList.add(log);
            return true; // 返回 true 继续校验，false 则停止
        };

        // 5. 执行校验
        schema.validate(badData, handler);

        // 6. 输出结果
        for (String err : errorList) {
            System.out.println(err);
        }
    }
```

</details>
<details>
<summary>使用示例②（Web请求校验）</summary>

```
@ExtendWith(SpringExtension.class)
@WebAppConfiguration
@ContextConfiguration
public class Issue3912 {
    @Autowired
    private WebApplicationContext wac;

    private MockMvc mockMvc;

    @BeforeEach
    public void setup() {
        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac)
                .addFilter(new CharacterEncodingFilter("UTF-8", true))
                .build();
    }

    /**
     * 测试场景 : 数据包含多个错误，应该返回 400 Bad Request，并包含所有错误信息
     * 错误 1: username 长度不够 (min 5)
     * 错误 2: age 未满 18 (min 18)
     */
    @Test
    public void testValidationFail() throws Exception {
        String requestJson = "{\"username\":\"a\",\"age\":10}";
        mockMvc.perform(
                        (post("/issue3912")
                                .characterEncoding("UTF-8")
                                .contentType(MediaType.APPLICATION_JSON_VALUE)
                                .content(requestJson)
                        ))
                .andExpect(status().isBadRequest())
                .andExpect(content().string(containsString("用户名长度不能小于5")))
                .andExpect(content().string(containsString("必须年满18岁")));
    }

    @RestController
    public static class TestController {
        @PostMapping(value = "/issue3912", produces = "application/json")
        public String issue3912(@RequestBody UserBean user) {
            return "success";
        }
    }

    @Data
    public static class UserBean {
        private String username;
        private Integer age;
    }

    /**
     * 自定义异常，用于携带校验错误信息
     */
    public static class SchemaValidationException extends RuntimeException {
        private final List<String> errors;

        public SchemaValidationException(List<String> errors) {
            this.errors = errors;
        }

        public List<String> getErrors() {
            return errors;
        }
    }

    /**
     * 在 JSON 反序列化成对象后，Controller 执行前，进行 Schema 校验
     */
    @RestControllerAdvice
    public static class SchemaValidationAdvice extends RequestBodyAdviceAdapter {
        private static final JSONSchema USER_SCHEMA = JSONSchema.parseSchema("{\n" +
                "  \"type\": \"object\",\n" +
                "  \"properties\": {\n" +
                "    \"username\": {\n" +
                "      \"type\": \"string\",\n" +
                "      \"minLength\": 5,\n" +
                "      \"error\": \"用户名长度不能小于5\"\n" + // 自定义错误消息
                "    },\n" +
                "    \"age\": {\n" +
                "      \"type\": \"integer\",\n" +
                "      \"minimum\": 18,\n" +
                "      \"error\": \"必须年满18岁\"\n" + // 自定义错误消息
                "    }\n" +
                "  }\n" +
                "}");

        @Override
        public boolean supports(MethodParameter methodParameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
            return targetType == UserBean.class; // 仅拦截 UserBean
        }

        @Override
        public Object afterBodyRead(Object body, HttpInputMessage inputMessage, MethodParameter parameter, Type targetType, Class<? extends HttpMessageConverter<?>> converterType) {
            if (body instanceof UserBean) {
                List<String> errors = new ArrayList<>();

                USER_SCHEMA.validate(body, (schema, value, message, path) -> {
                    errors.add(path + ": " + message);
                    return true;
                });

                if (!errors.isEmpty()) {
                    throw new SchemaValidationException(errors);
                }
            }
            return body;
        }
    }

    @RestControllerAdvice
    public static class GlobalExceptionHandler {
        @ExceptionHandler(SchemaValidationException.class)
        public ResponseEntity<Map<String, Object>> handleException(SchemaValidationException ex) {
            Map<String, Object> body = new HashMap<>();
            body.put("errors", ex.getErrors());
            return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
        }
    }

    @ComponentScan(basePackages = "com.alibaba.fastjson2.spring.issues.issue3912")
    @Configuration
    @Order(Ordered.LOWEST_PRECEDENCE + 1)
    @EnableWebMvc
    public static class WebMvcConfig implements WebMvcConfigurer {
        @Override
        public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
            FastJsonHttpMessageConverter fastConverter = new FastJsonHttpMessageConverter();
            FastJsonConfig fastJsonConfig = new FastJsonConfig();
            fastConverter.setFastJsonConfig(fastJsonConfig);
            fastConverter.setDefaultCharset(StandardCharsets.UTF_8);
            List<MediaType> supportedMediaTypes = new ArrayList<>();
            supportedMediaTypes.add(MediaType.APPLICATION_JSON);
            fastConverter.setSupportedMediaTypes(supportedMediaTypes);
            converters.add(0, fastConverter);
        }
    }
}
```

</details>

### Summary of your change
1. 接口定义 (ValidationHandler)：
- 定义 handle(schema, value, message, path) 方法。
- 返回 true 表示“已处理，可继续校验后续节点”，用户可以在回调中收集 message 错误信息；返回 false 表示“立即中断”（同 schema 校验默认逻辑）。

2. 基类改动 (JSONSchema)：
- 新增 validate(value, handler) 入口方法。
- 新增 handleError 辅助方法，封装“应用 customErrorMessage -> 调用 handler -> 处理中断”通用逻辑。

3. 叶节点改动 (StringSchema、IntegerSchema……）：
- 当发现错误时，不再直接 return，而是调用 handleError。

4. 容器节点改动 (ObjectSchema,、ArraySchema)：
- 当收到子节点返回的失败结果时，检查 handler 和 result.isAbort() 。
- Fail-Fast：如果 isAbort() 为 true，立即向上层 return，中断整个校验树的遍历。
- Fail-Safe：如果 isAbort() 为 false，说明用户希望继续。容器节点会记录当前失败状态（totalSuccess = false），然后继续循环去校验下一个节点，从而收集所有错误。

5. 组合逻辑改动 (AnyOf、OneOf、AllOf 等)：
- 逻辑同容器、叶子节点。

6. 具体改动逻辑**（供 review 参考）**：
- 改动针对**所有返回 ValidateResult 的地方**
- 如果原代码返回 new ValidateResult 或静态常量 ValidateResult，则 return handleError(…) （容器节点中需要判断 handler==null 和 result.isAbort，决定中断/继续）
- 如果原代码返回 **子scheme.validateInternal()得到的result**，只需判断 handler==null 和 result.isAbort，决定中断/继续