### PR TITLE
fix: no longer treats fluent methods as setters from record

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -470,6 +470,7 @@ public abstract class BeanUtils {
             return;
         }
 
+        boolean record = isRecord(objectClass);
         Method[] methods = methodCache.get(objectClass);
         if (methods == null) {
             methods = getMethods(objectClass);
@@ -587,7 +588,8 @@ public abstract class BeanUtils {
             }
 
             final int methodNameLength = methodName.length();
-            boolean nameMatch = methodNameLength > 3 && (methodName.startsWith("set") || returnType == objectClass);
+            boolean nameMatch = methodNameLength > 3
+                    && (methodName.startsWith("set") || (!record && returnType == objectClass));
             if (!nameMatch) {
                 if (mixin != null) {
                     Method mixinMethod = getMethod(mixin, method);

--- a/test-jdk17/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3985.java
+++ b/test-jdk17/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3985.java
@@ -1,0 +1,31 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue3985 {
+    public record Money(Long value) {
+        public Money divide(Money divisor) {
+            if (divisor == null || divisor.value == 0) {
+                throw new ArithmeticException("The divisor must not be null or zero.");
+            }
+            return this;
+        }
+    }
+
+    @Test
+    public void testRecordJsonbSetterMatch() {
+        JSONObject object = new JSONObject();
+        object.put("value", 100L);
+        object.put("divide", null);
+        byte[] bytes = JSONB.toBytes(object, JSONWriter.Feature.WriteNulls);
+
+        Money money = assertDoesNotThrow(() -> JSONB.parseObject(bytes, Money.class));
+        assertEquals(100L, money.value());
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?
 Record 的 divide(Money) 返回自身，原逻辑把“返回类型=类自身”当作 fluent setter，导致 JSONB 解析时把 divide 当字段写入入
 口并触发调用，从而抛出异常。Record 本质上是不可变载体，初始化应以构造器为主
我们应该对 Record 禁用 fluent setter
就是检测的时候跳过他

### Summary of your change



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
