### PR TITLE
improved BigDecimal parsing performance

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -4379,18 +4379,12 @@ final class JSONReaderUTF16
         }
 
         valueType = JSON_TYPE_INT;
-        boolean overflow = false;
+        int digitCount = 0; // Total digit count for overflow detection
         long longValue = 0;
         while (ch >= '0' && ch <= '9') {
             valid = true;
-            if (!overflow) {
-                long r = longValue * 10;
-                if ((longValue | 10) >>> 31 == 0L || (r / 10 == longValue)) {
-                    longValue = r + (ch - '0');
-                } else {
-                    overflow = true;
-                }
-            }
+            longValue = (longValue << 3) + (longValue << 1) + (ch & 0xf);
+            digitCount++;
 
             if (offset == end) {
                 ch = EOI;
@@ -4400,10 +4394,6 @@ final class JSONReaderUTF16
             ch = chars[offset++];
         }
 
-        if (longValue < 0) {
-            overflow = true;
-        }
-
         this.scale = 0;
         if (ch == '.') {
             valueType = JSON_TYPE_DEC;
@@ -4411,14 +4401,8 @@ final class JSONReaderUTF16
             while (ch >= '0' && ch <= '9') {
                 valid = true;
                 this.scale++;
-                if (!overflow) {
-                    long r = longValue * 10;
-                    if ((longValue | 10) >>> 31 == 0L || (r / 10 == longValue)) {
-                        longValue = r + (ch - '0');
-                    } else {
-                        overflow = true;
-                    }
-                }
+                longValue = (longValue << 3) + (longValue << 1) + (ch & 0xf);
+                digitCount++;
 
                 if (offset == end) {
                     ch = EOI;
@@ -4428,6 +4412,9 @@ final class JSONReaderUTF16
                 ch = chars[offset++];
             }
         }
+
+        // Check overflow: more than 18 digits, or 19 digits with negative value (sign bit set)
+        boolean overflow = digitCount > 18 && (digitCount > 19 || longValue < 0);
 
         int expValue = 0;
         if (ch == 'e' || ch == 'E') {
@@ -4520,8 +4507,12 @@ final class JSONReaderUTF16
             }
         }
         if (!value) {
-            if (expValue == 0 && !overflow && longValue != 0) {
-                decimal = BigDecimal.valueOf(negative ? -longValue : longValue, scale);
+            if (!overflow && longValue != 0) {
+                // Combine scale and exponent: scale - expValue
+                // For 1.5E3: scale=1, exp=3 => combined=-2 => 1500
+                // For 1.5E-3: scale=1, exp=-3 => combined=4 => 0.0015
+                int combinedScale = scale - expValue;
+                decimal = BigDecimal.valueOf(negative ? -longValue : longValue, combinedScale);
                 value = true;
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -6822,18 +6822,12 @@ class JSONReaderUTF8
         }
 
         valueType = JSON_TYPE_INT;
-        boolean overflow = false;
+        int digitCount = 0; // Total digit count for overflow detection
         long longValue = 0;
         while (ch >= '0' && ch <= '9') {
             valid = true;
-            if (!overflow) {
-                long r = longValue * 10;
-                if ((longValue | 10) >>> 31 == 0L || (r / 10 == longValue)) {
-                    longValue = r + (ch - '0');
-                } else {
-                    overflow = true;
-                }
-            }
+            longValue = (longValue << 3) + (longValue << 1) + (ch & 0xf);
+            digitCount++;
 
             if (offset == end) {
                 ch = EOI;
@@ -6843,10 +6837,6 @@ class JSONReaderUTF8
             ch = bytes[offset++];
         }
 
-        if (longValue < 0) {
-            overflow = true;
-        }
-
         this.scale = 0;
         if (ch == '.') {
             valueType = JSON_TYPE_DEC;
@@ -6854,14 +6844,8 @@ class JSONReaderUTF8
             while (ch >= '0' && ch <= '9') {
                 valid = true;
                 this.scale++;
-                if (!overflow) {
-                    long r = longValue * 10;
-                    if ((longValue | 10) >>> 31 == 0L || (r / 10 == longValue)) {
-                        longValue = r + (ch - '0');
-                    } else {
-                        overflow = true;
-                    }
-                }
+                longValue = (longValue << 3) + (longValue << 1) + (ch & 0xf);
+                digitCount++;
 
                 if (offset == end) {
                     ch = EOI;
@@ -6871,6 +6855,9 @@ class JSONReaderUTF8
                 ch = bytes[offset++];
             }
         }
+
+        // Check overflow: more than 18 digits, or 19 digits with negative value (sign bit set)
+        boolean overflow = digitCount > 18 && (digitCount > 19 || longValue < 0);
 
         int expValue = 0;
         if (ch == 'e' || ch == 'E') {
@@ -6959,8 +6946,12 @@ class JSONReaderUTF8
             }
         }
         if (!value) {
-            if (expValue == 0 && !overflow && longValue != 0) {
-                decimal = BigDecimal.valueOf(negative ? -longValue : longValue, scale);
+            if (!overflow && longValue != 0) {
+                // Combine scale and exponent: scale - expValue
+                // For 1.5E3: scale=1, exp=3 => combined=-2 => 1500
+                // For 1.5E-3: scale=1, exp=-3 => combined=4 => 0.0015
+                int combinedScale = scale - expValue;
+                decimal = BigDecimal.valueOf(negative ? -longValue : longValue, combinedScale);
                 value = true;
             }
 


### PR DESCRIPTION
- Use bit-shift operations for faster digit parsing
- Simplify overflow detection to single check after digit loop
- Handle exponent with combined scale to avoid string-based parsing

### What this PR does / why we need it?



### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
