### PR TITLE
Fix JSONPath syntax error with in filter after other filters

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -860,8 +860,10 @@ class JSONPathParser {
                     filterNests--;
                     segment = parseFilterRest(segment);
                 }
-                if (!jsonReader.nextIfMatch(')')) {
-                    throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                if (parentheses) {
+                    if (!jsonReader.nextIfMatch(')')) {
+                        throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                    }
                 }
 
                 return segment;

--- a/core/src/test/java/com/alibaba/fastjson2/jsonpath/JSONPath_in_filter_issue3997.java
+++ b/core/src/test/java/com/alibaba/fastjson2/jsonpath/JSONPath_in_filter_issue3997.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson2.jsonpath;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONPath_in_filter_issue3997 {
+    @Test
+    public void testInFilterAfterOtherFilter() {
+        JSONArray riskRequests = JSONArray.of(
+                JSONObject.of("requestRiskType", "05", "customerType", "01", "customerName", "Alice"),
+                JSONObject.of("requestRiskType", "05", "customerType", "04", "customerName", "Bob"),
+                JSONObject.of("requestRiskType", "05", "customerType", "02", "customerName", "Carol"),
+                JSONObject.of("requestRiskType", "06", "customerType", "01", "customerName", "Dave")
+        );
+        JSONObject root = JSONObject.of("riskRequests", riskRequests);
+
+        Object result = JSONPath.of("$.riskRequests[?(@.requestRiskType=='05' && @.customerType in ('01','04'))].customerName")
+                .eval(root);
+        assertEquals("[\"Alice\",\"Bob\"]", JSON.toJSONString(result));
+    }
+
+    @Test
+    public void testInFilterBeforeOtherFilter() {
+        JSONArray riskRequests = JSONArray.of(
+                JSONObject.of("requestRiskType", "05", "customerType", "01", "customerName", "Alice"),
+                JSONObject.of("requestRiskType", "05", "customerType", "04", "customerName", "Bob"),
+                JSONObject.of("requestRiskType", "05", "customerType", "02", "customerName", "Carol"),
+                JSONObject.of("requestRiskType", "06", "customerType", "01", "customerName", "Dave")
+        );
+        JSONObject root = JSONObject.of("riskRequests", riskRequests);
+
+        Object result = JSONPath.of("$.riskRequests[?(@.customerType in ('01','04') && @.requestRiskType=='05')].customerName")
+                .eval(root);
+        assertEquals("[\"Alice\",\"Bob\"]", JSON.toJSONString(result));
+    }
+}


### PR DESCRIPTION
## Summary
Fix a parser error that occurred when using an 'in' filter in combination with other filters in JSONPath expressions. The parser was unconditionally requiring a closing parenthesis after parsing filters, which caused syntax errors when the 'in' filter's own parentheses were present.

## Changes
Modify the filter parsing logic in `JSONPathParser` to only enforce the closing parenthesis requirement when the filter expression itself is wrapped in parentheses. This allows 'in' filters with their own parenthetical syntax to work correctly after other filter conditions.

## Testing
Add test cases validating:
1. An 'in' filter used after other filter conditions (e.g., `@.field=='value' && @.type in ('01','04')`)
2. An 'in' filter used before other filter conditions

Both scenarios now parse and evaluate correctly.

Fixes #3997