### PR TITLE
fix: add setter for FastjsonConfig.writer/readerContext, for issue #4000

### DIFF
--- a/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
+++ b/extension-spring5/src/main/java/com/alibaba/fastjson2/support/spring/http/converter/FastJsonHttpMessageConverter.java
@@ -183,7 +183,7 @@ public class FastJsonHttpMessageConverter
         final long contentLength = inputMessage.getHeaders().getContentLength(); // -1 表示未知
         try {
             final byte[] body = fastRead(inputMessage.getBody(), contentLength);
-            return JSON.parseObject(body, type, config.readerContext());
+            return JSON.parseObject(body, type, config.getReaderContext());
         } catch (JSONException ex) {
             throw new HttpMessageNotReadableException("JSON parse error: " + ex.getMessage(), ex, inputMessage);
         } catch (IOException ex) {
@@ -211,7 +211,7 @@ public class FastJsonHttpMessageConverter
                 }
 
                 contentLength = JSON.writeTo(
-                        baos, object, config.writerContext()
+                        baos, object, config.getWriterContext()
                 );
             }
 

--- a/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
@@ -268,7 +268,7 @@ public class FastJsonConfig {
         writerContext = null;
     }
 
-    public JSONReader.Context readerContext() {
+    public JSONReader.Context getReaderContext() {
         JSONReader.Context context = readerContext;
         if (context == null) { // Concurrency may occur, but it will not cause any problems
             context = new JSONReader.Context(JSONFactory.getDefaultObjectReaderProvider(), jsonb ? symbolTable : null, readerFilters, readerFeatures);
@@ -278,7 +278,7 @@ public class FastJsonConfig {
         return context;
     }
 
-    public JSONWriter.Context writerContext() {
+    public JSONWriter.Context getWriterContext() {
         JSONWriter.Context context = writerContext;
         if (context == null) {
             context = new JSONWriter.Context(dateFormat, writerFeatures);
@@ -292,5 +292,13 @@ public class FastJsonConfig {
             this.writerContext = context;
         }
         return context;
+    }
+
+    public void setReaderContext(JSONReader.Context context) {
+        this.readerContext = context;
+    }
+
+    public void setWriterContext(JSONWriter.Context context) {
+        this.writerContext = context;
     }
 }

--- a/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
+++ b/extension/src/main/java/com/alibaba/fastjson2/support/config/FastJsonConfig.java
@@ -294,6 +294,26 @@ public class FastJsonConfig {
         return context;
     }
 
+    /**
+     * Gets the JSONReader context.
+     * @deprecated Use {@link #getReaderContext()} instead to comply with JavaBean naming conventions.
+     * @return the JSONReader context
+     */
+    @Deprecated
+    public JSONReader.Context readerContext() {
+        return getReaderContext();
+    }
+
+    /**
+     * Gets the JSONWriter context.
+     * @deprecated Use {@link #getWriterContext()} instead to comply with JavaBean naming conventions.
+     * @return the JSONWriter context
+     */
+    @Deprecated
+    public JSONWriter.Context writerContext() {
+        return getWriterContext();
+    }
+
     public void setReaderContext(JSONReader.Context context) {
         this.readerContext = context;
     }


### PR DESCRIPTION
### What this PR does / why we need it?
允许用户像 1.x 中那样限定自定义序列化器影响范围，如下所示：
```
        FastJsonConfig config = new FastJsonConfig();
        
        ObjectWriterProvider provider = new ObjectWriterProvider();
        provider.register(Long.class, ObjectWriters.ofToString(Object::toString));
        provider.register(Integer.class, ObjectWriters.ofToString(Object::toString));
        
        config.setWriterContext(JSONFactory.createWriteContext(provider));
```


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
