### PR TITLE
fix: recent errors in CI

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -4877,6 +4877,9 @@ final class JSONReaderJSONB
     public Instant readInstant() {
         int type = bytes[offset++];
         switch (type) {
+            case BC_NULL: {
+                return null;
+            }
             case BC_TIMESTAMP: {
                 return Instant.ofEpochSecond(
                         readInt64Value(),


### PR DESCRIPTION
### What this PR does / why we need it?
@wenshao 最近的 PR 都有几个 ci test 机器不通过（Issue1855 23行），看了下貌似是 #3965 让测试更严格（增加 reflect 检查）引起的。您回头可以先合并这个，然后重新运行其它 PR 的 CI 应该就没问题了


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
