### PR TITLE
fix: ClassFormatError when generating writers for array-typed fields (#4009)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/internal/asm/ASMUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/asm/ASMUtils.java
@@ -221,6 +221,39 @@ public final class ASMUtils {
         descMapping.put(FieldReader[].class, DESC_FIELD_READER_ARRAY);
     }
 
+    /**
+     * Sanitizes a class simple name so that it can be embedded in a generated class name.
+     * Array types like {@code "Class[]"} become {@code "ClassArray"}, and any other character
+     * that is not valid in a class name is replaced with an underscore.
+     *
+     * @param simpleName the simple name to sanitize, may be null
+     * @return a name safe to use in a generated class name, never null
+     */
+    public static String sanitizeClassName(String simpleName) {
+        if (simpleName == null || simpleName.isEmpty()) {
+            return "";
+        }
+        if (simpleName.endsWith("[]")) {
+            return sanitizeClassName(simpleName.substring(0, simpleName.length() - 2)) + "Array";
+        }
+        StringBuilder buf = null;
+        for (int i = 0; i < simpleName.length(); i++) {
+            char c = simpleName.charAt(i);
+            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+                if (buf != null) {
+                    buf.append(c);
+                }
+            } else {
+                if (buf == null) {
+                    buf = new StringBuilder(simpleName.length());
+                    buf.append(simpleName, 0, i);
+                }
+                buf.append('_');
+            }
+        }
+        return buf != null ? buf.toString() : simpleName;
+    }
+
     public static String type(Class<?> clazz) {
         String type = typeMapping.get(clazz);
         if (type != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -4173,7 +4173,7 @@ public class ObjectReaderCreatorASM
             this.fieldNameCharLengthMin = charLenMin;
             this.fieldNameCharLengthMax = charLenMax;
 
-            String className = "ORG_" + seed.incrementAndGet() + "_" + fieldReaders.length + (objectClass == null ? "" : "_" + objectClass.getSimpleName());
+            String className = "ORG_" + seed.incrementAndGet() + "_" + fieldReaders.length + (objectClass == null ? "" : "_" + sanitizeClassName(objectClass.getSimpleName()));
 
             Package pkg = ObjectReaderCreatorASM.class.getPackage();
             if (pkg != null) {
@@ -4237,7 +4237,7 @@ public class ObjectReaderCreatorASM
         String className = (bytes ? "VBACG_" : "VCACG_")
                 + seed.incrementAndGet()
                 + "_" + fieldReaderArray.length
-                + "_" + objectClass.getSimpleName();
+                + "_" + sanitizeClassName(objectClass.getSimpleName());
         String classNameType;
         String classNameFull;
 

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -471,7 +471,7 @@ public class ObjectWriterCreatorASM
 
         ClassWriter cw = new ClassWriter(null);
 
-        String className = "OWG_" + seed.incrementAndGet() + "_" + fieldWriters.size() + (objectClass == null ? "" : ("_" + objectClass.getSimpleName()));
+        String className = "OWG_" + seed.incrementAndGet() + "_" + fieldWriters.size() + (objectClass == null ? "" : ("_" + sanitizeClassName(objectClass.getSimpleName())));
         String classNameType;
         String classNameFull;
 
@@ -4636,7 +4636,7 @@ public class ObjectWriterCreatorASM
 
             ClassWriter cw = new ClassWriter(null);
 
-            String className = "OWF_" + seed.incrementAndGet() + "_" + fieldWriters.size() + "_" + itemClass.getSimpleName();
+            String className = "OWF_" + seed.incrementAndGet() + "_" + fieldWriters.size() + "_" + sanitizeClassName(itemClass.getSimpleName());
             String classNameType;
             String classNameFull;
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_4000/Issue4009Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_4000/Issue4009Test.java
@@ -1,0 +1,96 @@
+package com.alibaba.fastjson2.issues_4000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue4009Test {
+    @Test
+    public void testClassArrayField() {
+        // Test that a class with a Class[] field can be serialized without ClassFormatError
+        BeanWithClassArray bean = new BeanWithClassArray();
+        bean.setClasses(new Class[]{String.class, Integer.class});
+        bean.setName("test");
+
+        // This should not throw ClassFormatError
+        Object json = JSON.toJSON(bean);
+        assertNotNull(json);
+
+        String jsonString = JSON.toJSONString(bean);
+        assertNotNull(jsonString);
+        assertTrue(jsonString.contains("test"));
+
+        // the reader generates class names the same way, so deserialization must work too
+        // (SupportClassForName is required only because the field type is Class[])
+        BeanWithClassArray parsed = JSON.parseObject(
+                jsonString, BeanWithClassArray.class, JSONReader.Feature.SupportClassForName);
+        assertNotNull(parsed);
+        assertEquals("test", parsed.getName());
+        assertArrayEquals(new Class[]{String.class, Integer.class}, parsed.getClasses());
+    }
+
+    @Test
+    public void testClassArrayFieldNull() {
+        BeanWithClassArray bean = new BeanWithClassArray();
+        bean.setClasses(null);
+        bean.setName("test");
+
+        Object json = JSON.toJSON(bean);
+        assertNotNull(json);
+    }
+
+    @Test
+    public void test2DArrayField() {
+        // Test multi-dimensional arrays
+        BeanWith2DArray bean = new BeanWith2DArray();
+        bean.setMatrix(new int[][]{{1, 2}, {3, 4}});
+
+        Object json = JSON.toJSON(bean);
+        assertNotNull(json);
+
+        String jsonString = JSON.toJSONString(bean);
+        assertNotNull(jsonString);
+
+        BeanWith2DArray parsed = JSON.parseObject(jsonString, BeanWith2DArray.class);
+        assertNotNull(parsed);
+        assertArrayEquals(new int[][]{{1, 2}, {3, 4}}, parsed.getMatrix());
+    }
+
+    public static class BeanWithClassArray {
+        private String name;
+        private Class<?>[] classes;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Class<?>[] getClasses() {
+            return classes;
+        }
+
+        public void setClasses(Class<?>[] classes) {
+            this.classes = classes;
+        }
+    }
+
+    public static class BeanWith2DArray {
+        private int[][] matrix;
+
+        public int[][] getMatrix() {
+            return matrix;
+        }
+
+        public void setMatrix(int[][] matrix) {
+            this.matrix = matrix;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/util/ASMUtilsTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/util/ASMUtilsTest.java
@@ -7,7 +7,9 @@ import java.io.IOException;
 import java.time.format.DateTimeParseException;
 
 import static com.alibaba.fastjson2.internal.asm.ASMUtils.lookupParameterNames;
+import static com.alibaba.fastjson2.internal.asm.ASMUtils.sanitizeClassName;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("util")
 public class ASMUtilsTest {
@@ -47,5 +49,33 @@ public class ASMUtilsTest {
                         DateTimeParseException.class.getConstructor(String.class, CharSequence.class, int.class, Throwable.class)
                 )
         );
+    }
+
+    @Test
+    public void sanitizeClassNameNullOrEmpty() {
+        assertEquals("", sanitizeClassName(null));
+        assertEquals("", sanitizeClassName(""));
+    }
+
+    @Test
+    public void sanitizeClassNameUnchanged() {
+        assertEquals("String", sanitizeClassName("String"));
+        assertEquals("MyClass", sanitizeClassName("MyClass"));
+        assertEquals("MyClass2", sanitizeClassName("MyClass2"));
+        assertEquals("My_Class", sanitizeClassName("My_Class"));
+    }
+
+    @Test
+    public void sanitizeClassNameArray() {
+        assertEquals("ClassArray", sanitizeClassName("Class[]"));
+        assertEquals("StringArray", sanitizeClassName("String[]"));
+        assertEquals("intArrayArray", sanitizeClassName("int[][]"));
+    }
+
+    @Test
+    public void sanitizeClassNameSpecialChars() {
+        assertEquals("My_Class", sanitizeClassName("My$Class"));
+        assertEquals("My_Class_2", sanitizeClassName("My-Class-2"));
+        assertEquals("My_ClassArray", sanitizeClassName("My$Class[]"));
     }
 }


### PR DESCRIPTION
## Problem

`JSON.toJSON(bean)` throws `ClassFormatError` when the bean has an array-typed field:

```java
public class BeanWithClassArray {
    private String name;
    private Class<?>[] classes;
    // getters / setters
}

JSON.toJSON(bean);
```

```
java.lang.ClassFormatError: Illegal class name "com/alibaba/fastjson2/writer/OWG_5_0_Class[]"
        in class file com/alibaba/fastjson2/writer/OWG_5_0_Class[]
```

## Root cause

`ObjectWriterCreatorASM` embeds `objectClass.getSimpleName()` in the name of the class it generates:

```java
String className = "OWG_" + seed.incrementAndGet() + "_" + fieldWriters.size()
        + (objectClass == null ? "" : ("_" + objectClass.getSimpleName()));
```

For an array type the simple name ends in `[]` — `Class[]` — and `[` is not legal in a class name, so `defineClass` rejects the generated bytes.

## Fix

Sanitize the simple name before embedding it: array notation becomes a suffix (`Class[]` → `ClassArray`), and any other character that is not valid in a class name becomes an underscore.

The helper lives in `com.alibaba.fastjson2.internal.asm.ASMUtils`, which both `ObjectWriterCreatorASM` and `ObjectReaderCreatorASM` already static-import, so the two cannot drift apart:

```java
public static String sanitizeClassName(String simpleName)
```

### Scope

The writer is the only path that could produce an illegal name. The reader call sites are defensive symmetry, verified rather than assumed:

```
reader(Class[]) -> com.alibaba.fastjson2.reader.ObjectReaderAdapter
writer(Class[]) -> com.alibaba.fastjson2.writer.OWG_1_0_ClassArray
```

`ObjectReaderCreatorASM` never generates a class for an array type — it returns `ObjectReaderAdapter`, so the `ORG_` path is not reached. Its other call site (`VBACG_`/`VCACG_` in `createValueConsumer0`) bails out earlier still, since it requires a default constructor and a public class, and an array type has neither.

## Tests

- `Issue4009Test` — serialization and round-trip for `Class[]` and `int[][]` fields.
- `ASMUtilsTest` — unit coverage for `sanitizeClassName`: null/empty, unchanged names, arrays including `int[][]`, special characters, and the combined `My$Class[]`.

## Verification

Revert-probe — removing `sanitizeClassName` from `ObjectWriterCreatorASM` makes the integration test fail with the exact error from #4009:

```
[ERROR] Issue4009Test.testClassArrayField
        java.lang.ClassFormatError: Illegal class name "com/alibaba/fastjson2/writer/OWG_2_0_Class[]"
```

Full suites green locally on JDK 26 — core 7965, extension 56, fastjson1-compatible 1355, kotlin 36, safemode-test 2 — and core again with `-Dfastjson2.creator=reflect`.

Closes #4009

<details>
<summary>中文说明</summary>

## 问题

Bean 中含有数组类型字段时，`JSON.toJSON(bean)` 抛 `ClassFormatError`：

```java
public class BeanWithClassArray {
    private String name;
    private Class<?>[] classes;
    // getters / setters
}

JSON.toJSON(bean);
```

```
java.lang.ClassFormatError: Illegal class name "com/alibaba/fastjson2/writer/OWG_5_0_Class[]"
        in class file com/alibaba/fastjson2/writer/OWG_5_0_Class[]
```

## 根因

`ObjectWriterCreatorASM` 会把 `objectClass.getSimpleName()` 拼进它生成的类名：

```java
String className = "OWG_" + seed.incrementAndGet() + "_" + fieldWriters.size()
        + (objectClass == null ? "" : ("_" + objectClass.getSimpleName()));
```

数组类型的 simple name 以 `[]` 结尾（`Class[]`），而 `[` 在类名中非法，`defineClass` 因此拒绝生成的字节码。

## 修复

拼接前先对 simple name 做净化：数组记法转成后缀（`Class[]` → `ClassArray`），其余在类名中非法的字符替换为下划线。

方法放在 `com.alibaba.fastjson2.internal.asm.ASMUtils` —— `ObjectWriterCreatorASM` 和 `ObjectReaderCreatorASM` 本来就 static import 了它，两边不会各自演化：

```java
public static String sanitizeClassName(String simpleName)
```

### 影响范围

只有 writer 会产生非法类名。reader 那两处是防御性对称，这一点是实测确认的，不是推断：

```
reader(Class[]) -> com.alibaba.fastjson2.reader.ObjectReaderAdapter
writer(Class[]) -> com.alibaba.fastjson2.writer.OWG_1_0_ClassArray
```

`ObjectReaderCreatorASM` 对数组类型根本不生成类，直接返回 `ObjectReaderAdapter`，走不到 `ORG_` 路径。另一处（`createValueConsumer0` 里的 `VBACG_`/`VCACG_`）退出得更早：它要求有默认构造器且类是 public，数组类型两条都不满足。

## 测试

- `Issue4009Test` —— `Class[]` 与 `int[][]` 字段的序列化及 round-trip。
- `ASMUtilsTest` —— `sanitizeClassName` 的单测：null/空、无需改写的名字、数组（含 `int[][]`）、特殊字符，以及组合场景 `My$Class[]`。

## 验证

Revert-probe：把 `sanitizeClassName` 从 `ObjectWriterCreatorASM` 移除后，集成测试以 #4009 中一模一样的错误失败：

```
[ERROR] Issue4009Test.testClassArrayField
        java.lang.ClassFormatError: Illegal class name "com/alibaba/fastjson2/writer/OWG_2_0_Class[]"
```

本地 JDK 26 全量通过 —— core 7965、extension 56、fastjson1-compatible 1355、kotlin 36、safemode-test 2；`-Dfastjson2.creator=reflect` 下 core 同样通过。

</details>
