### PR TITLE
fix: writeFloat(float[]) ArrayIndexOutOfBoundsException when WriteNon…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
@@ -2085,7 +2085,7 @@ class JSONWriterUTF16
         boolean writeSpecialAsString = (context.features & WriteFloatSpecialAsString.mask) != 0;
 
         int off = this.off;
-        int minCapacity = off + values.length * (writeAsString ? 16 : 18) + 1;
+        int minCapacity = off + values.length * 18 + 2;
         char[] chars = this.chars;
         if (minCapacity > chars.length) {
             chars = grow(minCapacity);

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
@@ -1948,7 +1948,7 @@ final class JSONWriterUTF8
         boolean writeSpecialAsString = (context.features & WriteFloatSpecialAsString.mask) != 0;
 
         int off = this.off;
-        int minCapacity = off + values.length * (writeAsString ? 16 : 18) + 1;
+        int minCapacity = off + values.length * 18 + 2;
         byte[] bytes = this.bytes;
         if (minCapacity > bytes.length) {
             bytes = grow(minCapacity);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1591.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1591.java
@@ -7,11 +7,36 @@ import com.alibaba.fastjson2.JSONWriter;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("regression")
 public class Issue1591 {
+    /**
+     * Regression test for writeFloat(float[]) buffer overflow when
+     * WriteNonStringValueAsString is enabled. Max float representation
+     * is 15 chars (e.g. "-1.00017205E-36"), and the capacity calculation
+     * must account for comma + 2 quotes + number per element.
+     */
+    @Test
+    public void testWriteFloatArrayAsString() {
+        float worstCaseFloat = -1.00017205E-36f;
+        for (int len : new int[]{1, 10, 100, 456, 500, 1000}) {
+            float[] arr = new float[len];
+            Arrays.fill(arr, worstCaseFloat);
+            {
+                String str = JSON.toJSONString(arr, JSONWriter.Feature.WriteNonStringValueAsString);
+                assertNotNull(str);
+            }
+            {
+                String str = JSON.toJSONString(arr, JSONWriter.Feature.WriteNonStringValueAsString, JSONWriter.Feature.OptimizedForAscii);
+                assertNotNull(str);
+            }
+        }
+    }
+
     @Test
     public void test() {
         JSONArray array = new JSONArray();


### PR DESCRIPTION
…StringValueAsString enabled, for issue #1591

The capacity calculation for writeFloat(float[]) underestimated buffer size when WriteNonStringValueAsString was enabled — allocating only 16 chars per element instead of the 18 needed (comma + 2 quotes + up to 15-char float). This caused ArrayIndexOutOfBoundsException at buffer boundaries (e.g. 8192).

### What this PR does / why we need it?



### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
