### PR TITLE
fix generic invalidation in record class, for issue #3156

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -275,6 +275,13 @@ public class ObjectReaderCreatorASM
                     match = false;
                     break;
                 }
+
+                if (fieldReader.fieldClass != fieldReader.fieldType) {
+                    if (fieldReader.fieldClass == Number.class) {
+                        match = false;
+                        break;
+                    }
+                }
             }
         }
 
@@ -392,6 +399,13 @@ public class ObjectReaderCreatorASM
                         && ((FieldReaderMap<?>) fieldReader).arrayToMapKey != null) {
                     match = false;
                     break;
+                }
+
+                if (fieldReader.fieldClass != fieldReader.fieldType) {
+                    if (fieldReader.fieldClass == Number.class) {
+                        match = false;
+                        break;
+                    }
                 }
             }
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -276,11 +276,10 @@ public class ObjectReaderCreatorASM
                     break;
                 }
 
-                if (fieldReader.fieldClass != fieldReader.fieldType) {
-                    if (fieldReader.fieldClass == Number.class) {
-                        match = false;
-                        break;
-                    }
+                if (fieldReader.fieldClass != fieldReader.fieldType
+                        && fieldReader.fieldClass == Number.class) {
+                    match = false;
+                    break;
                 }
             }
         }
@@ -401,11 +400,10 @@ public class ObjectReaderCreatorASM
                     break;
                 }
 
-                if (fieldReader.fieldClass != fieldReader.fieldType) {
-                    if (fieldReader.fieldClass == Number.class) {
-                        match = false;
-                        break;
-                    }
+                if (fieldReader.fieldClass != fieldReader.fieldType
+                        && fieldReader.fieldClass == Number.class) {
+                    match = false;
+                    break;
                 }
             }
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -276,8 +276,8 @@ public class ObjectReaderCreatorASM
                     break;
                 }
 
-                if (fieldReader.fieldClass != fieldReader.fieldType
-                        && fieldReader.fieldClass == Number.class) {
+                if (fieldReader.fieldClass == Number.class
+                        && !Number.class.equals(fieldReader.fieldType)) {
                     match = false;
                     break;
                 }
@@ -400,8 +400,8 @@ public class ObjectReaderCreatorASM
                     break;
                 }
 
-                if (fieldReader.fieldClass != fieldReader.fieldType
-                        && fieldReader.fieldClass == Number.class) {
+                if (fieldReader.fieldClass == Number.class
+                        && !Number.class.equals(fieldReader.fieldType)) {
                     match = false;
                     break;
                 }

--- a/test-jdk17/src/test/java/com/alibaba/fastjson2/issues/Issue3156.java
+++ b/test-jdk17/src/test/java/com/alibaba/fastjson2/issues/Issue3156.java
@@ -71,41 +71,47 @@ public class Issue3156 {
 
     @Test
     public void test_2() { // 泛型 无默认构造器
-        String json = "{\"temperature\":{\"enabled\":true,\"value\":0.1},\"presencePenalty\":{\"enabled\":false,\"value\":0},\"frequencyPenalty\":{\"enabled\":false,\"value\":0}}";
+        String json = "{\"temperature\":{\"enabled\":true,\"value\":0.1},\"presencePenalty\":{\"enabled\":false,\"value\":0},\"frequencyPenalty\":{\"enabled\":false,\"value\":0},\"maxToken\":{\"enabled\":false,\"value\":1024}}";
         Options options = JSONObject.parseObject(json, new TypeReference<Options>() {});
         Object val = options.getTemperature().value();
         Object val2 = options.getPresencePenalty().value();
+        Object val3 = options.getMaxToken().value();
         assertInstanceOf(Double.class, val);
         assertInstanceOf(Double.class, val2);
+        assertInstanceOf(Integer.class, val3);
     }
 
     @Data
-    public class Options {
+    public static class Options {
         private Parameter<Double> temperature;
         private Parameter<Double> presencePenalty;
         private Parameter<Double> frequencyPenalty;
+        private Parameter<Integer> maxToken;
         public record Parameter<T extends Number>(Boolean enabled, T value) {}
     }
 
     @Test
     public void test_3() { // 泛型 有默认构造器
-        String json = "{\"temperature\":{\"enabled\":true,\"value\":0.1},\"presencePenalty\":{\"enabled\":false,\"value\":0},\"frequencyPenalty\":{\"enabled\":false,\"value\":0}}";
+        String json = "{\"temperature\":{\"enabled\":true,\"value\":0.1},\"presencePenalty\":{\"enabled\":false,\"value\":0},\"frequencyPenalty\":{\"enabled\":false,\"value\":0},\"maxToken\":{\"enabled\":false,\"value\":1024}}";
         Options2 options = JSONObject.parseObject(json, new TypeReference<Options2>() {});
         Object val = options.getTemperature().getValue();
         Object val2 = options.getPresencePenalty().getValue();
+        Object val3 = options.getMaxToken().getValue();
         assertInstanceOf(Double.class, val);
         assertInstanceOf(Double.class, val2);
+        assertInstanceOf(Integer.class, val3);
     }
 
     @Data
-    public class Options2 {
+    public static class Options2 {
         private Parameter<Double> temperature;
         private Parameter<Double> presencePenalty;
         private Parameter<Double> frequencyPenalty;
+        private Parameter<Integer> maxToken;
 
         @NoArgsConstructor
         @Data
-        public class Parameter<T extends Number>{
+        public static class Parameter<T extends Number>{
             private Boolean enabled;
             private T value;
         }

--- a/test-jdk17/src/test/java/com/alibaba/fastjson2/issues/Issue3156.java
+++ b/test-jdk17/src/test/java/com/alibaba/fastjson2/issues/Issue3156.java
@@ -1,14 +1,17 @@
 package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.TypeReference;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 public class Issue3156 {
     @Test
@@ -66,39 +69,45 @@ public class Issue3156 {
     public record MapListResult<K, V>(int code, String msg, Map<String, List<V>> data) {
     }
 
-//    public static class AjaxResult<T> {
-//        private int code;
-//        private String msg;
-//        private T data;
-//
-//        public AjaxResult() {
-//        }
-//
-//        public int getCode() {
-//            return code;
-//        }
-//
-//        public AjaxResult<T> setCode(int code) {
-//            this.code = code;
-//            return this;
-//        }
-//
-//        public String getMsg() {
-//            return msg;
-//        }
-//
-//        public AjaxResult<T> setMsg(String msg) {
-//            this.msg = msg;
-//            return this;
-//        }
-//
-//        public T getData() {
-//            return data;
-//        }
-//
-//        public AjaxResult<T> setData(T data) {
-//            this.data = data;
-//            return this;
-//        }
-//    }
+    @Test
+    public void test_2() { // 泛型 无默认构造器
+        String json = "{\"temperature\":{\"enabled\":true,\"value\":0.1},\"presencePenalty\":{\"enabled\":false,\"value\":0},\"frequencyPenalty\":{\"enabled\":false,\"value\":0}}";
+        Options options = JSONObject.parseObject(json, new TypeReference<Options>() {});
+        Object val = options.getTemperature().value();
+        Object val2 = options.getPresencePenalty().value();
+        assertInstanceOf(Double.class, val);
+        assertInstanceOf(Double.class, val2);
+    }
+
+    @Data
+    public class Options {
+        private Parameter<Double> temperature;
+        private Parameter<Double> presencePenalty;
+        private Parameter<Double> frequencyPenalty;
+        public record Parameter<T extends Number>(Boolean enabled, T value) {}
+    }
+
+    @Test
+    public void test_3() { // 泛型 有默认构造器
+        String json = "{\"temperature\":{\"enabled\":true,\"value\":0.1},\"presencePenalty\":{\"enabled\":false,\"value\":0},\"frequencyPenalty\":{\"enabled\":false,\"value\":0}}";
+        Options2 options = JSONObject.parseObject(json, new TypeReference<Options2>() {});
+        Object val = options.getTemperature().getValue();
+        Object val2 = options.getPresencePenalty().getValue();
+        assertInstanceOf(Double.class, val);
+        assertInstanceOf(Double.class, val2);
+    }
+
+    @Data
+    public class Options2 {
+        private Parameter<Double> temperature;
+        private Parameter<Double> presencePenalty;
+        private Parameter<Double> frequencyPenalty;
+
+        @NoArgsConstructor
+        @Data
+        public class Parameter<T extends Number>{
+            private Boolean enabled;
+            private T value;
+        }
+    }
 }


### PR DESCRIPTION
### What this PR does / why we need it?
修复了泛型字段擦除为 Number.class 时，asm 解析器未考虑真实泛型上下文而调用 readNumber()，导致小数被默认解析为 BigDecimal 从而引发 ClassCastException 的缺陷。修复逻辑是在 ObjectReaderCreatorASM 中增加校验，当字段擦除类型为 Number.class ，降级为反射模式进行动态解析。


### Summary of your change



#### Please indicate you've done the following:

- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
