### PR TITLE
fix: Map subclass loses @type when serialized with ValueFilter (#3984)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
@@ -617,6 +617,12 @@ public final class ObjectWriterImplMap
         jsonWriter.startObject();
         Map map = (Map) object;
 
+        boolean writeTypeInfo = (fieldType == this.objectType && jsonWriter.isWriteMapTypeInfo(object, this.objectClass, features))
+                || jsonWriter.isWriteTypeInfo(object, fieldType, features);
+        if (writeTypeInfo) {
+            writeTypeInfo(jsonWriter);
+        }
+
         features |= jsonWriter.getFeatures();
         if ((features & (MapSortField.mask | SortMapEntriesByKeys.mask)) != 0) {
             if (!(map instanceof SortedMap)

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3984.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3984.java
@@ -1,0 +1,63 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.filter.ValueFilter;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue3984 {
+    public static class CustomMap extends HashMap<String, Object> {
+    }
+
+    @Test
+    public void testWriteClassNameWithValueFilter() {
+        CustomMap map = new CustomMap();
+        map.put("key1", "value1");
+
+        ValueFilter valueFilter = (object, name, value) -> value;
+
+        String json = JSON.toJSONString(map,
+                new ValueFilter[]{valueFilter},
+                JSONWriter.Feature.WriteClassName);
+
+        assertTrue(json.contains("@type"), "JSON should contain @type when WriteClassName is enabled with ValueFilter: " + json);
+        assertTrue(json.contains("CustomMap"), "JSON should contain class name: " + json);
+    }
+
+    @Test
+    public void testWriteClassNameWithoutFilter() {
+        CustomMap map = new CustomMap();
+        map.put("key1", "value1");
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.WriteClassName);
+
+        assertTrue(json.contains("@type"), "JSON should contain @type when WriteClassName is enabled: " + json);
+        assertTrue(json.contains("CustomMap"), "JSON should contain class name: " + json);
+    }
+
+    @Test
+    public void testNestedMapWithValueFilter() {
+        CustomMap inner = new CustomMap();
+        inner.put("msg", 123);
+
+        CustomMap outer = new CustomMap();
+        outer.put("key1", "value1");
+        outer.put("nested", inner);
+
+        ValueFilter valueFilter = (object, name, value) -> value;
+
+        String json = JSON.toJSONString(outer,
+                new ValueFilter[]{valueFilter},
+                JSONWriter.Feature.WriteClassName);
+
+        // Both outer and inner maps should have @type
+        int firstIdx = json.indexOf("@type");
+        int lastIdx = json.lastIndexOf("@type");
+        assertTrue(firstIdx >= 0, "Should contain @type: " + json);
+        assertTrue(firstIdx != lastIdx, "Should contain @type for both outer and inner maps: " + json);
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3984.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3984.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.issues_3900;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.ValueFilter;
 import org.junit.jupiter.api.Test;
@@ -8,9 +9,10 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue3984 {
+    static final String CUSTOM_MAP_TYPE = CustomMap.class.getName();
+
     public static class CustomMap extends HashMap<String, Object> {
     }
 
@@ -25,9 +27,9 @@ public class Issue3984 {
                 new ValueFilter[]{valueFilter},
                 JSONWriter.Feature.WriteClassName);
 
-        String expectedType = "\"@type\":\"" + CustomMap.class.getName() + "\"";
-        assertTrue(json.contains(expectedType),
-                "JSON should contain " + expectedType + ", actual: " + json);
+        JSONObject parsed = JSON.parseObject(json);
+        assertEquals(CUSTOM_MAP_TYPE, parsed.getString("@type"));
+        assertEquals("value1", parsed.getString("key1"));
     }
 
     @Test
@@ -37,9 +39,9 @@ public class Issue3984 {
 
         String json = JSON.toJSONString(map, JSONWriter.Feature.WriteClassName);
 
-        String expectedType = "\"@type\":\"" + CustomMap.class.getName() + "\"";
-        assertTrue(json.contains(expectedType),
-                "JSON should contain " + expectedType + ", actual: " + json);
+        JSONObject parsed = JSON.parseObject(json);
+        assertEquals(CUSTOM_MAP_TYPE, parsed.getString("@type"));
+        assertEquals("value1", parsed.getString("key1"));
     }
 
     @Test
@@ -57,14 +59,12 @@ public class Issue3984 {
                 new ValueFilter[]{valueFilter},
                 JSONWriter.Feature.WriteClassName);
 
-        String typeToken = "\"@type\":\"" + CustomMap.class.getName() + "\"";
-        int count = 0;
-        int idx = 0;
-        while ((idx = json.indexOf(typeToken, idx)) != -1) {
-            count++;
-            idx += typeToken.length();
-        }
-        assertEquals(2, count,
-                "Should contain exactly 2 @type entries for outer and inner maps: " + json);
+        JSONObject parsed = JSON.parseObject(json);
+        assertEquals(CUSTOM_MAP_TYPE, parsed.getString("@type"));
+        assertEquals("value1", parsed.getString("key1"));
+
+        JSONObject nestedParsed = parsed.getJSONObject("nested");
+        assertEquals(CUSTOM_MAP_TYPE, nestedParsed.getString("@type"));
+        assertEquals(123, nestedParsed.getIntValue("msg"));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3984.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3984.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue3984 {
@@ -24,8 +25,9 @@ public class Issue3984 {
                 new ValueFilter[]{valueFilter},
                 JSONWriter.Feature.WriteClassName);
 
-        assertTrue(json.contains("@type"), "JSON should contain @type when WriteClassName is enabled with ValueFilter: " + json);
-        assertTrue(json.contains("CustomMap"), "JSON should contain class name: " + json);
+        String expectedType = "\"@type\":\"" + CustomMap.class.getName() + "\"";
+        assertTrue(json.contains(expectedType),
+                "JSON should contain " + expectedType + ", actual: " + json);
     }
 
     @Test
@@ -35,8 +37,9 @@ public class Issue3984 {
 
         String json = JSON.toJSONString(map, JSONWriter.Feature.WriteClassName);
 
-        assertTrue(json.contains("@type"), "JSON should contain @type when WriteClassName is enabled: " + json);
-        assertTrue(json.contains("CustomMap"), "JSON should contain class name: " + json);
+        String expectedType = "\"@type\":\"" + CustomMap.class.getName() + "\"";
+        assertTrue(json.contains(expectedType),
+                "JSON should contain " + expectedType + ", actual: " + json);
     }
 
     @Test
@@ -54,10 +57,14 @@ public class Issue3984 {
                 new ValueFilter[]{valueFilter},
                 JSONWriter.Feature.WriteClassName);
 
-        // Both outer and inner maps should have @type
-        int firstIdx = json.indexOf("@type");
-        int lastIdx = json.lastIndexOf("@type");
-        assertTrue(firstIdx >= 0, "Should contain @type: " + json);
-        assertTrue(firstIdx != lastIdx, "Should contain @type for both outer and inner maps: " + json);
+        String typeToken = "\"@type\":\"" + CustomMap.class.getName() + "\"";
+        int count = 0;
+        int idx = 0;
+        while ((idx = json.indexOf(typeToken, idx)) != -1) {
+            count++;
+            idx += typeToken.length();
+        }
+        assertEquals(2, count,
+                "Should contain exactly 2 @type entries for outer and inner maps: " + json);
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #3984

当使用 `WriteClassName` 特性序列化 `HashMap` 子类时，如果同时设置了 `ValueFilter`，`@type` 字段会被静默丢弃，导致反序列化时丢失类型信息。

**复现代码：**
```java
CustomMap map = new CustomMap(); // extends HashMap
map.put("key1", "value1");
ValueFilter filter = (object, name, value) -> value;
String json = JSON.toJSONString(map, new ValueFilter[]{filter}, JSONWriter.Feature.WriteClassName);
// 实际输出: {"key1":"value1"}  — 缺少 @type
// 期望输出: {"@type":"...CustomMap","key1":"value1"}

Summary of your change

根因： ObjectWriterImplMap.write() 方法在写入 Map 条目前会调用 writeTypeInfo()，但 writeWithFilter() 方法完全缺失了这一逻辑。当存在 Filter 时，write() 会委托给 writeWithFilter()，导致 @type 丢失。

修复： 在 writeWithFilter() 的 startObject() 之后、写入 Map 条目之前，添加与 write() 一致的 writeTypeInfo 判断和调用逻辑：

boolean writeTypeInfo = (fieldType == this.objectType
        && jsonWriter.isWriteMapTypeInfo(object, this.objectClass, features))
        || jsonWriter.isWriteTypeInfo(object, fieldType, features);
if (writeTypeInfo) {
    writeTypeInfo(jsonWriter);
}

测试覆盖：
- 单层 Map 子类 + ValueFilter + WriteClassName
- 无 Filter 时行为不变（对照）
- 嵌套 Map 子类，验证内外层均写入 @type

Please indicate you've done the following:

- Made sure tests are passing and test coverage is added if needed.
- Made sure commit message follow the rule of https://www.conventionalcommits.org/.
- Considered the docs impact and opened a new docs issue or PR with docs changes if needed.