### PR TITLE
fix: JSONPath syntax error when 'in'/'rlike' filter follows other filters (#3997)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -816,7 +816,7 @@ class JSONPathParser {
                     filterNests--;
                     segment = parseFilterRest(segment);
                 }
-                if (parentheses) {
+                if (parentheses || filterNests > 0) {
                     if (!jsonReader.nextIfMatch(')')) {
                         throw new JSONException(jsonReader.info("jsonpath syntax error"));
                     }
@@ -865,7 +865,7 @@ class JSONPathParser {
                     filterNests--;
                     segment = parseFilterRest(segment);
                 }
-                if (parentheses) {
+                if (parentheses || filterNests > 0) {
                     if (!jsonReader.nextIfMatch(')')) {
                         throw new JSONException(jsonReader.info("jsonpath syntax error"));
                     }
@@ -923,7 +923,7 @@ class JSONPathParser {
                     filterNests--;
                     segment = parseFilterRest(segment);
                 }
-                if (parentheses) {
+                if (parentheses || filterNests > 0) {
                     if (!jsonReader.nextIfMatch(')')) {
                         throw new JSONException(jsonReader.info("jsonpath syntax error"));
                     }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathParser.java
@@ -816,8 +816,10 @@ class JSONPathParser {
                     filterNests--;
                     segment = parseFilterRest(segment);
                 }
-                if (!jsonReader.nextIfMatch(')')) {
-                    throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                if (parentheses) {
+                    if (!jsonReader.nextIfMatch(')')) {
+                        throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                    }
                 }
                 return segment;
             }
@@ -863,8 +865,10 @@ class JSONPathParser {
                     filterNests--;
                     segment = parseFilterRest(segment);
                 }
-                if (!jsonReader.nextIfMatch(')')) {
-                    throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                if (parentheses) {
+                    if (!jsonReader.nextIfMatch(')')) {
+                        throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                    }
                 }
 
                 return segment;
@@ -915,8 +919,14 @@ class JSONPathParser {
                 if (!jsonReader.nextIfMatch(')')) {
                     throw new JSONException(jsonReader.info("jsonpath syntax error"));
                 }
-                if (!jsonReader.nextIfMatch(')')) {
-                    throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                if (jsonReader.ch == '&' || jsonReader.ch == '|' || jsonReader.ch == 'a' || jsonReader.ch == 'o') {
+                    filterNests--;
+                    segment = parseFilterRest(segment);
+                }
+                if (parentheses) {
+                    if (!jsonReader.nextIfMatch(')')) {
+                        throw new JSONException(jsonReader.info("jsonpath syntax error"));
+                    }
                 }
 
                 return segment;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3997.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3997.java
@@ -1,12 +1,16 @@
 package com.alibaba.fastjson2.issues_3900;
 
+import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONPath;
+import com.alibaba.fastjson2.JSONReader;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@Tag("regression")
 public class Issue3997 {
     static final String JSON_STR = "{\n"
             + "  \"riskRequests\": [\n"
@@ -18,7 +22,6 @@ public class Issue3997 {
 
     @Test
     public void testInFilterAfterEquality() {
-        // This was the failing case: 'in' filter after '==' filter with '&&'
         Object result = JSONPath.eval(JSON_STR,
                 "$.riskRequests[?(@.requestRiskType=='05' && @.customerType in ('01','04'))].customerName");
         assertNotNull(result);
@@ -29,7 +32,6 @@ public class Issue3997 {
 
     @Test
     public void testInFilterBeforeEquality() {
-        // This was the working case: 'in' filter before '==' filter
         Object result = JSONPath.eval(JSON_STR,
                 "$.riskRequests[?(@.customerType in ('01','04') && @.requestRiskType=='05')].customerName");
         assertNotNull(result);
@@ -75,5 +77,21 @@ public class Issue3997 {
         JSONArray arr = (JSONArray) result;
         assertEquals(1, arr.size());
         assertEquals(1, arr.get(0));
+    }
+
+    @Test
+    public void testRlikeAfterEquality() {
+        String jsonArray = "[{\"name\":\"abc\",\"age\":18},{\"name\":\"def\",\"age\":18},{\"name\":\"xyz\",\"age\":20}]";
+        String path = "$[?(@.age==18 && @.name =~ /abc/)]";
+        Object result = JSONPath.of(path).extract(JSONReader.of(jsonArray));
+        assertEquals("[{\"name\":\"abc\",\"age\":18}]", JSON.toJSONString(result));
+    }
+
+    @Test
+    public void testRlikeAfterEqualityWithOr() {
+        String jsonArray = "[{\"name\":\"abc\",\"age\":18},{\"name\":\"def\",\"age\":20},{\"name\":\"xyz\",\"age\":20}]";
+        String path = "$[?(@.age==20 || @.name =~ /abc/)]";
+        Object result = JSONPath.of(path).extract(JSONReader.of(jsonArray));
+        assertEquals("[{\"name\":\"abc\",\"age\":18},{\"name\":\"def\",\"age\":20},{\"name\":\"xyz\",\"age\":20}]", JSON.toJSONString(result));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3997.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3900/Issue3997.java
@@ -1,0 +1,79 @@
+package com.alibaba.fastjson2.issues_3900;
+
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Issue3997 {
+    static final String JSON_STR = "{\n"
+            + "  \"riskRequests\": [\n"
+            + "    {\"requestRiskType\": \"05\", \"customerType\": \"01\", \"customerName\": \"Alice\"},\n"
+            + "    {\"requestRiskType\": \"05\", \"customerType\": \"02\", \"customerName\": \"Bob\"},\n"
+            + "    {\"requestRiskType\": \"06\", \"customerType\": \"04\", \"customerName\": \"Charlie\"}\n"
+            + "  ]\n"
+            + "}";
+
+    @Test
+    public void testInFilterAfterEquality() {
+        // This was the failing case: 'in' filter after '==' filter with '&&'
+        Object result = JSONPath.eval(JSON_STR,
+                "$.riskRequests[?(@.requestRiskType=='05' && @.customerType in ('01','04'))].customerName");
+        assertNotNull(result);
+        JSONArray arr = (JSONArray) result;
+        assertEquals(1, arr.size());
+        assertEquals("Alice", arr.get(0));
+    }
+
+    @Test
+    public void testInFilterBeforeEquality() {
+        // This was the working case: 'in' filter before '==' filter
+        Object result = JSONPath.eval(JSON_STR,
+                "$.riskRequests[?(@.customerType in ('01','04') && @.requestRiskType=='05')].customerName");
+        assertNotNull(result);
+        JSONArray arr = (JSONArray) result;
+        assertEquals(1, arr.size());
+        assertEquals("Alice", arr.get(0));
+    }
+
+    @Test
+    public void testInFilterAlone() {
+        Object result = JSONPath.eval(JSON_STR,
+                "$.riskRequests[?(@.customerType in ('01','04'))].customerName");
+        assertNotNull(result);
+        JSONArray arr = (JSONArray) result;
+        assertEquals(2, arr.size());
+    }
+
+    @Test
+    public void testInFilterWithOr() {
+        Object result = JSONPath.eval(JSON_STR,
+                "$.riskRequests[?(@.requestRiskType=='06' || @.customerType in ('01'))].customerName");
+        assertNotNull(result);
+        JSONArray arr = (JSONArray) result;
+        assertEquals(2, arr.size());
+    }
+
+    @Test
+    public void testNotInAfterEquality() {
+        Object result = JSONPath.eval(JSON_STR,
+                "$.riskRequests[?(@.requestRiskType=='05' && @.customerType not in ('01'))].customerName");
+        assertNotNull(result);
+        JSONArray arr = (JSONArray) result;
+        assertEquals(1, arr.size());
+        assertEquals("Bob", arr.get(0));
+    }
+
+    @Test
+    public void testNumericInAfterEquality() {
+        String json = "{\"items\":[{\"type\":\"a\",\"code\":1},{\"type\":\"a\",\"code\":2},{\"type\":\"b\",\"code\":1}]}";
+        Object result = JSONPath.eval(json,
+                "$.items[?(@.type=='a' && @.code in (1))].code");
+        assertNotNull(result);
+        JSONArray arr = (JSONArray) result;
+        assertEquals(1, arr.size());
+        assertEquals(1, arr.get(0));
+    }
+}


### PR DESCRIPTION
**Body:**

```markdown
### What this PR does / why we need it?

Fixes #3997

JSONPath 复合过滤表达式中，当 `in` / `not in` / `=~` (rlike) / `contains` 操作符不在第一个位置时（即通过 `&&` / `||` 连接在其他过滤条件之后），会抛出 `jsonpath syntax error`。

**复现代码：**
```java
// 失败 — in 在第二个位置
JSONPath.eval(json, "$.riskRequests[?(@.requestRiskType=='05' && @.customerType in ('01','04'))].customerName");

// 成功 — in 在第一个位置
JSONPath.eval(json, "$.riskRequests[?(@.customerType in ('01','04') && @.requestRiskType=='05')].customerName");

Summary of your change

根因： parseFilter() 方法中 IN/NOT_IN、RLIKE/NOT_RLIKE、CONTAINS 三个 case 在末尾无条件调用 nextIfMatch(')') 消费一个右括号。当这些操作符作为复合表达式的第二个条件（由 parseFilterRest 调用，此时 parentheses=false）时，会错误地消费掉外层过滤器的闭合 )，导致外层 parseFilter 找不到匹配的 ) 而报语法错误。

对比同文件中 BETWEEN case（line 939）和 parseFilter 末尾 default 路径（line 1090），它们正确地使用了 if (parentheses) 守卫。

修复： 将三个 case 的末尾 ) 消费改为条件式：if (parentheses || filterNests > 0)。
- parentheses：当前 parseFilter 调用自身拥有一个开括号
- filterNests > 0：存在通过 filterNests 机制追踪的分组括号（如 (@.name =~ /aa/ && (...)) 中的外层 ()）

同时为 CONTAINS case 补充了缺失的 &&/|| 后续处理逻辑（parseFilterRest 调用）。

测试覆盖：
- in 在 == 之后（&& @.customerType in (...)）— 原始 bug
- in 在 == 之前 — 对照
- in 单独使用
- in 与 || 组合
- not in 在 == 之后
- 数字类型 in 在 == 之后
- 已有 Issue1516 回归测试全部通过（含 rlike + && 嵌套分组括号场景）