### PR TITLE
fix: support negative year (BC date) deserialization

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -2522,6 +2522,32 @@ public abstract class JSONReader
             wasNull = true;
             return null;
         }
+
+        // Handle negative year dates: -yyyy-MM-dd HH:mm:ss or -yyyy-MM-ddTHH:mm:ss
+        if (str.length() == 20 && str.charAt(0) == '-') {
+            char c5 = str.charAt(5);
+            char c8 = str.charAt(8);
+            char c11 = str.charAt(11);
+            char c14 = str.charAt(14);
+            char c17 = str.charAt(17);
+            if ((c5 == '-' || c5 == '/') && (c8 == '-' || c8 == '/')
+                    && (c11 == ' ' || c11 == 'T') && c14 == ':' && c17 == ':') {
+                int year = -(((str.charAt(1) - '0') * 1000)
+                        + ((str.charAt(2) - '0') * 100)
+                        + ((str.charAt(3) - '0') * 10)
+                        + (str.charAt(4) - '0'));
+                int month = ((str.charAt(6) - '0') * 10) + (str.charAt(7) - '0');
+                int dom = ((str.charAt(9) - '0') * 10) + (str.charAt(10) - '0');
+                int hour = ((str.charAt(12) - '0') * 10) + (str.charAt(13) - '0');
+                int minute = ((str.charAt(15) - '0') * 10) + (str.charAt(16) - '0');
+                int second = ((str.charAt(18) - '0') * 10) + (str.charAt(19) - '0');
+                if (month >= 1 && month <= 12 && dom >= 1 && dom <= 31
+                        && hour <= 23 && minute <= 59 && second <= 59) {
+                    return LocalDateTime.of(year, month, dom, hour, minute, second);
+                }
+            }
+        }
+
         throw new JSONException(info("read LocalDateTime error " + str));
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3800/Issue3845.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3800/Issue3845.java
@@ -1,0 +1,82 @@
+package com.alibaba.fastjson2.issues_3800;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * #3845 BC date (negative year) deserialization error
+ */
+public class Issue3845 {
+    @Test
+    public void testNegativeYearRoundTrip() {
+        // Year 0 minus 8 hours = year -1, Dec 31, 16:00:00
+        LocalDateTime time = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0).minusHours(8);
+        JSONObject bean = new JSONObject().fluentPut("time", time);
+        String s = bean.toJSONString();
+        LocalDateTime parsed = JSON.parseObject(s).getLocalDateTime("time");
+        assertNotNull(parsed);
+        assertEquals(time, parsed);
+    }
+
+    @Test
+    public void testNegativeYearDirectParse() {
+        // Parse a negative year datetime string directly
+        String json = "{\"time\":\"-0001-12-31 16:00:00\"}";
+        LocalDateTime parsed = JSON.parseObject(json).getLocalDateTime("time");
+        assertNotNull(parsed);
+        assertEquals(-1, parsed.getYear());
+        assertEquals(12, parsed.getMonthValue());
+        assertEquals(31, parsed.getDayOfMonth());
+        assertEquals(16, parsed.getHour());
+        assertEquals(0, parsed.getMinute());
+        assertEquals(0, parsed.getSecond());
+    }
+
+    @Test
+    public void testNegativeYearWithT() {
+        // Parse with T separator instead of space
+        String json = "{\"time\":\"-0001-12-31T16:00:00\"}";
+        LocalDateTime parsed = JSON.parseObject(json).getLocalDateTime("time");
+        assertNotNull(parsed);
+        assertEquals(-1, parsed.getYear());
+        assertEquals(12, parsed.getMonthValue());
+        assertEquals(31, parsed.getDayOfMonth());
+    }
+
+    @Test
+    public void testNegativeYearWithSlash() {
+        // Parse with / separator
+        String json = "{\"time\":\"-0001/12/31 16:00:00\"}";
+        LocalDateTime parsed = JSON.parseObject(json).getLocalDateTime("time");
+        assertNotNull(parsed);
+        assertEquals(-1, parsed.getYear());
+    }
+
+    @Test
+    public void testNegativeYearLarger() {
+        // Year -100 (101 BC)
+        LocalDateTime time = LocalDateTime.of(-100, 6, 15, 12, 30, 45);
+        JSONObject bean = new JSONObject().fluentPut("time", time);
+        String s = bean.toJSONString();
+        LocalDateTime parsed = JSON.parseObject(s).getLocalDateTime("time");
+        assertNotNull(parsed);
+        assertEquals(time, parsed);
+    }
+
+    @Test
+    public void testPositiveYearStillWorks() {
+        // Ensure normal dates are not affected
+        LocalDateTime time = LocalDateTime.of(2026, 3, 25, 10, 30, 0);
+        JSONObject bean = new JSONObject().fluentPut("time", time);
+        String s = bean.toJSONString();
+        LocalDateTime parsed = JSON.parseObject(s).getLocalDateTime("time");
+        assertNotNull(parsed);
+        assertEquals(time, parsed);
+    }
+}


### PR DESCRIPTION
## Problem

`LocalDateTime` with negative years (BC dates) serializes correctly (e.g. `"-0001-12-31 16:00:00"`) but fails to deserialize with:

```
JSONException: read LocalDateTime error -0001-12-31 16:00:00
```

Reproduction:
```java
LocalDateTime time = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0).minusHours(8);
JSONObject bean = new JSONObject().fluentPut("time", time);
String s = bean.toJSONString();  // {"time":"-0001-12-31 16:00:00"}
JSON.parseObject(s).getLocalDateTime("time");  // throws JSONException
```

## Root Cause

The negative year date string `"-0001-12-31 16:00:00"` has length 20 (due to the leading `-`). The `readLocalDateTime()` method dispatches length-20 strings to `parseLocalDateTime20()`, which expects a completely different format (`dd Mon yyyy HH:mm:ss`). This returns null, and the string eventually falls through to an error.

## Fix

Added handling for the `-yyyy-MM-dd HH:mm:ss` format in the string fallback path of `readLocalDateTime()`. The fix:
- Checks if the string is 20 chars starting with `-`
- Validates the format matches `-yyyy-MM-dd HH:mm:ss` (supporting both ` ` and `T` separators, and `/` delimiters)
- Manually parses the year, month, day, hour, minute, second components
- Follows the same manual parsing style used throughout the codebase

## Tests Added

- `testNegativeYearRoundTrip` — Serialize then deserialize a BC date, verify equality
- `testNegativeYearDirectParse` — Parse `"-0001-12-31 16:00:00"` and verify all components
- `testNegativeYearWithT` — Parse with `T` separator: `"-0001-12-31T16:00:00"`
- `testNegativeYearWithSlash` — Parse with `/` delimiter: `"-0001/12/31 16:00:00"`
- `testNegativeYearLarger` — Year -100 (101 BC) round-trip
- `testPositiveYearStillWorks` — Regression test for normal dates

## Impact

Minimal — only affects deserialization of negative year datetime strings (20 chars starting with `-`). Normal date parsing is unaffected.

Fixes #3845