### PR TITLE
fix: seeAlsoDefault NPE when @type is missing

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
@@ -350,6 +350,22 @@ final class ObjectReaderSeeAlso<T>
             }
         }
 
+        if (object == null && seeAlsoDefault != null && seeAlsoDefault != Void.class) {
+            ObjectReader defaultReader = jsonReader.getContext().getObjectReader(seeAlsoDefault);
+            if (defaultReader != null) {
+                object = (T) defaultReader.createInstance(jsonReader.getContext().getFeatures() | features);
+                if (object != null && fieldValues != null) {
+                    for (Map.Entry<Long, Object> entry : fieldValues.entrySet()) {
+                        FieldReader fieldReader = defaultReader.getFieldReader(entry.getKey());
+                        if (fieldReader != null) {
+                            fieldReader.accept(object, entry.getValue());
+                        }
+                    }
+                    fieldValues = null;
+                }
+            }
+        }
+
         if (fieldValues != null) {
             for (Map.Entry<Long, Object> entry : fieldValues.entrySet()) {
                 FieldReader fieldReader = getFieldReader(entry.getKey());


### PR DESCRIPTION
## Problem

When deserializing JSON without `@type` field into an interface annotated with `@JSONType(seeAlso = {Dog.class}, seeAlsoDefault = Dog.class)`, a `NullPointerException` is thrown:

```
NullPointerException
  at FieldReaderStringMethod.accept(FieldReaderStringMethod.java:88)
  at ObjectReaderSeeAlso.readObject(ObjectReaderSeeAlso.java:356)
```

Reproduction:
```java
@JSONType(seeAlso = Dog.class, seeAlsoDefault = Dog.class)
interface IAnimal { ... }

// Throws NPE - no @type in JSON
JSON.parseObject("{\"name\":\"tom\",\"age\":18}", IAnimal.class);
```

## Root Cause

`ObjectReaderSeeAlso.createInstance()` returns null for interfaces (no creator supplier). When JSON has no `@type` field:
1. Field values are buffered in a `LinkedHashMap` (since object is null)
2. After the loop, the code tries to apply buffered values to the still-null object
3. NPE at `fieldReader.accept(null, value)`

The `seeAlsoDefault` class is never consulted as a fallback.

## Fix

After parsing completes, if `object` is still null and `seeAlsoDefault` is configured:
1. Get the `ObjectReader` for the `seeAlsoDefault` class
2. Create an instance using that reader
3. Apply buffered field values using the default class's field readers

This correctly falls back to the default type when `@type` is absent, matching the documented behavior of `seeAlsoDefault`.

## Tests

The existing test file `Issue3540.java` (3 test cases) already covers this scenario:
- `exceptUseSeeAlsoDefault` — JSON without `@type` → should use default class
- `exceptUseSeeAlsoDefault2` — JSON with empty `@type` → should use default class  
- `useTypeForSeeAlso` — JSON with explicit `@type` → works correctly

All 3 tests pass. Additionally, `SeeAlsoTest`, `SeeAlsoTest3`, and `SeeAlsoTest5` pass with no regressions.

## Impact

Only affects deserialization with `seeAlsoDefault` on interfaces/abstract classes when `@type` is missing. No impact on normal deserialization paths.

Fixes #3540