### PR TITLE
fix: honor IgnoreSetNullValue in specialized FieldReader subclasses, for issue #7618

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReader.java
@@ -746,4 +746,16 @@ public abstract class FieldReader<T>
     public final boolean isParameter() {
         return paramNameHash != 0;
     }
+
+    protected final boolean ignoreSetNullValue() {
+        return (features & JSONReader.Feature.IgnoreSetNullValue.mask) != 0;
+    }
+
+    protected final boolean ignoreSetNullValue(JSONReader jsonReader) {
+        long allFeatures = features;
+        if (jsonReader != null) {
+            allFeatures |= jsonReader.getContext().getFeatures();
+        }
+        return (allFeatures & JSONReader.Feature.IgnoreSetNullValue.mask) != 0;
+    }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderBigDecimal.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderBigDecimal.java
@@ -29,6 +29,9 @@ final class FieldReaderBigDecimal<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -43,6 +46,10 @@ final class FieldReaderBigDecimal<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (fieldValue == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, fieldValue);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderBigInteger.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderBigInteger.java
@@ -41,11 +41,17 @@ final class FieldReaderBigInteger<T>
                 throw ex;
             }
         }
+        if (value == null && ignoreSetNullValue(jsonReader)) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderBool.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderBool.java
@@ -32,6 +32,9 @@ final class FieldReaderBool<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object,
                 TypeUtils.toBoolean(value));
     }
@@ -47,6 +50,10 @@ final class FieldReaderBool<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (fieldValue == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, fieldValue);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderDate.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderDate.java
@@ -69,6 +69,9 @@ final class FieldReaderDate<T>
 
     @Override
     protected void accept(T object, Date value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderDate.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderDate.java
@@ -64,6 +64,9 @@ final class FieldReaderDate<T>
             }
             date = null;
         }
+        if (date == null && ignoreSetNullValue(jsonReader)) {
+            return;
+        }
         accept(object, date);
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderDouble.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderDouble.java
@@ -31,6 +31,9 @@ final class FieldReaderDouble<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -48,6 +51,10 @@ final class FieldReaderDouble<T, V>
         }
 
         if (value == null && defaultValue != null) {
+            return;
+        }
+
+        if (value == null && ignoreSetNullValue(jsonReader)) {
             return;
         }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderFloat.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderFloat.java
@@ -31,6 +31,9 @@ final class FieldReaderFloat<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -45,6 +48,10 @@ final class FieldReaderFloat<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (value == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, value);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt16.java
@@ -31,6 +31,9 @@ final class FieldReaderInt16<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -46,6 +49,10 @@ final class FieldReaderInt16<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (value == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, value);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt32.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt32.java
@@ -31,6 +31,9 @@ final class FieldReaderInt32<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -45,6 +48,10 @@ final class FieldReaderInt32<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (value == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, value);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt64.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt64.java
@@ -32,6 +32,10 @@ final class FieldReaderInt64<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
+
         Long longValue = TypeUtils.toLong(value);
 
         if (schema != null) {
@@ -52,6 +56,10 @@ final class FieldReaderInt64<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (value == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         if (schema != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderInt8.java
@@ -31,6 +31,9 @@ final class FieldReaderInt8<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -46,6 +49,10 @@ final class FieldReaderInt8<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (value == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, value);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderNumber.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderNumber.java
@@ -28,6 +28,9 @@ final class FieldReaderNumber<T, V>
 
     @Override
     public void accept(T object, Object value) {
+        if (value == null && ignoreSetNullValue()) {
+            return;
+        }
         propertyAccessor.setObject(object, value);
     }
 
@@ -52,6 +55,10 @@ final class FieldReaderNumber<T, V>
             } else {
                 throw e;
             }
+        }
+
+        if (fieldValue == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         propertyAccessor.setObject(object, fieldValue);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderString.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderString.java
@@ -69,6 +69,10 @@ final class FieldReaderString<T, V>
             }
         }
 
+        if (fieldValue == null && ignoreSetNullValue()) {
+            return;
+        }
+
         if (schema != null) {
             schema.assertValidate(fieldValue);
         }
@@ -98,6 +102,10 @@ final class FieldReaderString<T, V>
             }
         }
 
+        if (fieldValue == null && ignoreSetNullValue(jsonReader)) {
+            return;
+        }
+
         if (schema != null) {
             schema.assertValidate(fieldValue);
         }
@@ -125,6 +133,10 @@ final class FieldReaderString<T, V>
             if (emptyToNull && fieldValue.isEmpty()) {
                 fieldValue = null;
             }
+        }
+
+        if (fieldValue == null && ignoreSetNullValue(jsonReader)) {
+            return;
         }
 
         if (schema != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -3014,7 +3014,7 @@ public class ObjectReaderCreatorASM
 
         MethodWriter mw = mwc.mw;
 
-        if ((fieldFeatures & JSONReader.Feature.NullOnError.mask) != 0) {
+        if ((fieldFeatures & (JSONReader.Feature.NullOnError.mask | JSONReader.Feature.IgnoreSetNullValue.mask)) != 0) {
             mw.aload(THIS);
             mw.getfield(classNameType, fieldReader(fieldReaderIndex), DESC_FIELD_READER);
             mw.aload(JSON_READER);
@@ -3027,6 +3027,31 @@ public class ObjectReaderCreatorASM
         Method method = fieldReader.method;
 
         Label endSet_ = new Label();
+
+        // Honor JSONReader.Feature.IgnoreSetNullValue passed at parse time (context-level).
+        // Annotation-level IgnoreSetNullValue is handled by the fieldFeatures branch above.
+        // NoneDefaultConstructor uses temp locals (no OBJECT slot yet), so skip — that
+        // path needs a different fix.
+        if (!fieldClass.isPrimitive()
+                && !(context.objectReaderAdapter instanceof ObjectReaderNoneDefaultConstructor)) {
+            // if ((FEATURES & IgnoreSetNullValue.mask) != 0) { fieldReader.readFieldValue(jsonReader, object); goto endSet_; }
+            Label noFallback_ = new Label();
+            mw.lload(FEATURES);
+            mw.visitLdcInsn(JSONReader.Feature.IgnoreSetNullValue.mask);
+            mw.land();
+            mw.lconst_0();
+            mw.lcmp();
+            mw.ifeq(noFallback_);
+
+            mw.aload(THIS);
+            mw.getfield(classNameType, fieldReader(fieldReaderIndex), DESC_FIELD_READER);
+            mw.aload(JSON_READER);
+            mw.aload(OBJECT);
+            mw.invokevirtual(TYPE_FIELD_READE, "readFieldValue", METHOD_DESC_READ_FIELD_VALUE);
+            mw.goto_(endSet_);
+
+            mw.visitLabel(noFallback_);
+        }
 
         String TYPE_FIELD_CLASS = ASMUtils.type(fieldClass);
         String DESC_FIELD_CLASS = ASMUtils.desc(fieldClass);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -3014,7 +3014,9 @@ public class ObjectReaderCreatorASM
 
         MethodWriter mw = mwc.mw;
 
-        if ((fieldFeatures & (JSONReader.Feature.NullOnError.mask | JSONReader.Feature.IgnoreSetNullValue.mask)) != 0) {
+        if ((fieldFeatures & JSONReader.Feature.NullOnError.mask) != 0
+                || ((fieldFeatures & JSONReader.Feature.IgnoreSetNullValue.mask) != 0
+                    && !(context.objectReaderAdapter instanceof ObjectReaderNoneDefaultConstructor))) {
             mw.aload(THIS);
             mw.getfield(classNameType, fieldReader(fieldReaderIndex), DESC_FIELD_READER);
             mw.aload(JSON_READER);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7600/Issue7618.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7600/Issue7618.java
@@ -1,0 +1,146 @@
+package com.alibaba.fastjson2.issues_7600;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.annotation.JSONType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue 7618: JSONReader.Feature.IgnoreSetNullValue is silently ignored by
+ * specialized FieldReader subclasses (FieldReaderString, FieldReaderInt32 etc.)
+ * because the null-skip gate present in FieldReaderObject was not duplicated
+ * into them. The feature must work both via @JSONType.deserializeFeatures and
+ * via JSONReader.Feature passed at parse time.
+ */
+public class Issue7618 {
+    @JSONType(deserializeFeatures = JSONReader.Feature.IgnoreSetNullValue)
+    public static class StringSample {
+        private String name = "Default";
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String n) {
+            this.name = n;
+        }
+    }
+
+    @Test
+    public void testStringAnnotation() {
+        StringSample s = JSON.parseObject("{\"name\":null}", StringSample.class);
+        assertEquals("Default", s.getName());
+    }
+
+    @Test
+    public void testStringJSONBAnnotation() {
+        java.util.Map<String, Object> map = new java.util.HashMap<>();
+        map.put("name", null);
+        byte[] bytes = JSONB.toBytes(map);
+        StringSample s = JSONB.parseObject(bytes, StringSample.class);
+        assertEquals("Default", s.getName());
+    }
+
+    public static class StringSamplePlain {
+        private String name = "Default";
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String n) {
+            this.name = n;
+        }
+    }
+
+    @Test
+    public void testStringContextFeature() {
+        StringSamplePlain s = JSON.parseObject(
+                "{\"name\":null}",
+                StringSamplePlain.class,
+                JSONReader.Feature.IgnoreSetNullValue);
+        assertEquals("Default", s.getName());
+    }
+
+    @JSONType(deserializeFeatures = JSONReader.Feature.IgnoreSetNullValue)
+    public static class BoxedSample {
+        private Integer i = 42;
+        private Long l = 100L;
+        private Boolean b = Boolean.TRUE;
+        private BigDecimal bd = new BigDecimal("3.14");
+        private BigInteger bi = BigInteger.TEN;
+        private Date d = new Date(0L);
+
+        public Integer getI() { return i; }
+        public Long getL() { return l; }
+        public Boolean getB() { return b; }
+        public BigDecimal getBd() { return bd; }
+        public BigInteger getBi() { return bi; }
+        public Date getD() { return d; }
+
+        public void setI(Integer i) { this.i = i; }
+        public void setL(Long l) { this.l = l; }
+        public void setB(Boolean b) { this.b = b; }
+        public void setBd(BigDecimal bd) { this.bd = bd; }
+        public void setBi(BigInteger bi) { this.bi = bi; }
+        public void setD(Date d) { this.d = d; }
+    }
+
+    @Test
+    public void testBoxedAnnotation() {
+        BoxedSample s = JSON.parseObject(
+                "{\"i\":null,\"l\":null,\"b\":null,\"bd\":null,\"bi\":null,\"d\":null}",
+                BoxedSample.class);
+        assertEquals(Integer.valueOf(42), s.getI());
+        assertEquals(Long.valueOf(100L), s.getL());
+        assertEquals(Boolean.TRUE, s.getB());
+        assertEquals(new BigDecimal("3.14"), s.getBd());
+        assertEquals(BigInteger.TEN, s.getBi());
+        assertEquals(new Date(0L), s.getD());
+    }
+
+    public static class BoxedSamplePlain {
+        private Integer i = 42;
+        private Long l = 100L;
+        private Boolean b = Boolean.TRUE;
+        private String s = "kept";
+
+        public Integer getI() { return i; }
+        public Long getL() { return l; }
+        public Boolean getB() { return b; }
+        public String getS() { return s; }
+
+        public void setI(Integer i) { this.i = i; }
+        public void setL(Long l) { this.l = l; }
+        public void setB(Boolean b) { this.b = b; }
+        public void setS(String s) { this.s = s; }
+    }
+
+    @Test
+    public void testBoxedContextFeature() {
+        BoxedSamplePlain s = JSON.parseObject(
+                "{\"i\":null,\"l\":null,\"b\":null,\"s\":null}",
+                BoxedSamplePlain.class,
+                JSONReader.Feature.IgnoreSetNullValue);
+        assertEquals(Integer.valueOf(42), s.getI());
+        assertEquals(Long.valueOf(100L), s.getL());
+        assertEquals(Boolean.TRUE, s.getB());
+        assertEquals("kept", s.getS());
+    }
+
+    @Test
+    public void testNonNullValueStillSet() {
+        StringSamplePlain s = JSON.parseObject(
+                "{\"name\":\"hello\"}",
+                StringSamplePlain.class,
+                JSONReader.Feature.IgnoreSetNullValue);
+        assertEquals("hello", s.getName());
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7600/Issue7618.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7600/Issue7618.java
@@ -77,6 +77,11 @@ public class Issue7618 {
         private BigDecimal bd = new BigDecimal("3.14");
         private BigInteger bi = BigInteger.TEN;
         private Date d = new Date(0L);
+        private Float f = 1.5f;
+        private Double db = 2.5d;
+        private Short sh = 7;
+        private Byte by = 3;
+        private Number n = 99;
 
         public Integer getI() { return i; }
         public Long getL() { return l; }
@@ -84,6 +89,11 @@ public class Issue7618 {
         public BigDecimal getBd() { return bd; }
         public BigInteger getBi() { return bi; }
         public Date getD() { return d; }
+        public Float getF() { return f; }
+        public Double getDb() { return db; }
+        public Short getSh() { return sh; }
+        public Byte getBy() { return by; }
+        public Number getN() { return n; }
 
         public void setI(Integer i) { this.i = i; }
         public void setL(Long l) { this.l = l; }
@@ -91,12 +101,18 @@ public class Issue7618 {
         public void setBd(BigDecimal bd) { this.bd = bd; }
         public void setBi(BigInteger bi) { this.bi = bi; }
         public void setD(Date d) { this.d = d; }
+        public void setF(Float f) { this.f = f; }
+        public void setDb(Double db) { this.db = db; }
+        public void setSh(Short sh) { this.sh = sh; }
+        public void setBy(Byte by) { this.by = by; }
+        public void setN(Number n) { this.n = n; }
     }
 
     @Test
     public void testBoxedAnnotation() {
         BoxedSample s = JSON.parseObject(
-                "{\"i\":null,\"l\":null,\"b\":null,\"bd\":null,\"bi\":null,\"d\":null}",
+                "{\"i\":null,\"l\":null,\"b\":null,\"bd\":null,\"bi\":null,\"d\":null,"
+                        + "\"f\":null,\"db\":null,\"sh\":null,\"by\":null,\"n\":null}",
                 BoxedSample.class);
         assertEquals(Integer.valueOf(42), s.getI());
         assertEquals(Long.valueOf(100L), s.getL());
@@ -104,6 +120,11 @@ public class Issue7618 {
         assertEquals(new BigDecimal("3.14"), s.getBd());
         assertEquals(BigInteger.TEN, s.getBi());
         assertEquals(new Date(0L), s.getD());
+        assertEquals(Float.valueOf(1.5f), s.getF());
+        assertEquals(Double.valueOf(2.5d), s.getDb());
+        assertEquals(Short.valueOf((short) 7), s.getSh());
+        assertEquals(Byte.valueOf((byte) 3), s.getBy());
+        assertEquals(99, s.getN());
     }
 
     public static class BoxedSamplePlain {
@@ -111,28 +132,49 @@ public class Issue7618 {
         private Long l = 100L;
         private Boolean b = Boolean.TRUE;
         private String s = "kept";
+        private Float f = 1.5f;
+        private Double db = 2.5d;
+        private Short sh = 7;
+        private Byte by = 3;
+        private Date d = new Date(0L);
 
         public Integer getI() { return i; }
         public Long getL() { return l; }
         public Boolean getB() { return b; }
         public String getS() { return s; }
+        public Float getF() { return f; }
+        public Double getDb() { return db; }
+        public Short getSh() { return sh; }
+        public Byte getBy() { return by; }
+        public Date getD() { return d; }
 
         public void setI(Integer i) { this.i = i; }
         public void setL(Long l) { this.l = l; }
         public void setB(Boolean b) { this.b = b; }
         public void setS(String s) { this.s = s; }
+        public void setF(Float f) { this.f = f; }
+        public void setDb(Double db) { this.db = db; }
+        public void setSh(Short sh) { this.sh = sh; }
+        public void setBy(Byte by) { this.by = by; }
+        public void setD(Date d) { this.d = d; }
     }
 
     @Test
     public void testBoxedContextFeature() {
         BoxedSamplePlain s = JSON.parseObject(
-                "{\"i\":null,\"l\":null,\"b\":null,\"s\":null}",
+                "{\"i\":null,\"l\":null,\"b\":null,\"s\":null,"
+                        + "\"f\":null,\"db\":null,\"sh\":null,\"by\":null,\"d\":null}",
                 BoxedSamplePlain.class,
                 JSONReader.Feature.IgnoreSetNullValue);
         assertEquals(Integer.valueOf(42), s.getI());
         assertEquals(Long.valueOf(100L), s.getL());
         assertEquals(Boolean.TRUE, s.getB());
         assertEquals("kept", s.getS());
+        assertEquals(Float.valueOf(1.5f), s.getF());
+        assertEquals(Double.valueOf(2.5d), s.getDb());
+        assertEquals(Short.valueOf((short) 7), s.getSh());
+        assertEquals(Byte.valueOf((byte) 3), s.getBy());
+        assertEquals(new Date(0L), s.getD());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The null-skip gate present in `FieldReaderObject` was missing from type-specialized `FieldReader` subclasses (`FieldReaderString`, boxed primitives, `BigDecimal`/`BigInteger`, `Number`, `Date`), so `JSONReader.Feature.IgnoreSetNullValue` was silently ignored for those fields — both when configured via `@JSONType(deserializeFeatures = ...)` and when passed at parse time.
- Adds `ignoreSetNullValue()` helpers on `FieldReader` so the gate is reused consistently, and applies it in `accept(T, Object)` and `readFieldValue(JSONReader, T)` for the affected specialized readers.
- `ObjectReaderCreatorASM.genReadFieldValue`:
  - extends the existing `NullOnError` fallback so it also falls back to `fieldReader.readFieldValue` when `IgnoreSetNullValue` is in `fieldFeatures` (annotation-driven case),
  - emits a runtime check on `FEATURES` for non-primitive fields on default-constructor beans, so the parse-time context feature also takes effect on the ASM hot path.
- The `NoneDefaultConstructor` ASM path uses temp locals (no OBJECT slot yet), so the runtime check is skipped there — that path needs a separate fix.

Fixes #7618.

## Test plan
- [x] New `Issue7618` test covering all four combinations: String / boxed primitives × annotation-level / context-level feature.
- [x] Existing related tests (`Issue3789`, `Issue1745`, `Issue2164`) still pass.
- [x] All 2189 `Issue*` regression tests pass.
- [x] All `FieldReader*` and `ObjectReader*Test` tests pass.