### PR TITLE
fix: ISO8601 should take priority over yyyyMMddHHmmss in Instant write, for issue #4003

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplInstant.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplInstant.java
@@ -36,13 +36,24 @@ final class ObjectWriterImplInstant
                 : context.getDateFormat();
 
         Instant instant = (Instant) object;
-        if (dateFormat == null) {
+
+        // Honor formatISO8601 / context.isDateFormatISO8601() ahead of any
+        // string-pattern shape flags (yyyyMMddHHmmss19 etc.) — when the caller
+        // explicitly requested ISO8601 (e.g. SerializerFeature.UseISO8601DateFormat
+        // or JSONWriter.Feature.WriteISO8601DateFormat) it must take priority over
+        // a default dateFormat that may have been set on the context (issue #4003).
+        boolean iso8601 = formatISO8601 || (this.format == null && context.isDateFormatISO8601());
+
+        if (dateFormat == null && !iso8601) {
             jsonWriter.writeInstant(instant);
             return;
         }
 
-        boolean yyyyMMddhhmmss19 = this.yyyyMMddhhmmss19 || (context.isFormatyyyyMMddhhmmss19() && this.format == null);
-        if (yyyyMMddhhmmss14 || yyyyMMddhhmmss19 || yyyyMMdd8 || yyyyMMdd10) {
+        boolean yyyyMMddhhmmss19 = !iso8601 && (this.yyyyMMddhhmmss19 || (context.isFormatyyyyMMddhhmmss19() && this.format == null));
+        boolean yyyyMMddhhmmss14local = !iso8601 && yyyyMMddhhmmss14;
+        boolean yyyyMMdd8local = !iso8601 && yyyyMMdd8;
+        boolean yyyyMMdd10local = !iso8601 && yyyyMMdd10;
+        if (yyyyMMddhhmmss14local || yyyyMMddhhmmss19 || yyyyMMdd8local || yyyyMMdd10local) {
             final long SECONDS_PER_DAY = 60 * 60 * 24;
             ZoneId zoneId = context.getZoneId();
             long epochSecond = instant.getEpochSecond();
@@ -173,7 +184,7 @@ final class ObjectWriterImplInstant
 
         int year = zdt.getYear();
         if (year >= 0 && year <= 9999) {
-            if (formatISO8601 || (format == null && context.isDateFormatISO8601())) {
+            if (iso8601) {
                 jsonWriter.writeDateTimeISO8601(
                         year,
                         zdt.getMonthValue(),

--- a/core/src/test/java/com/alibaba/fastjson2/issues_4000/Issue4003.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_4000/Issue4003.java
@@ -1,0 +1,75 @@
+package com.alibaba.fastjson2.issues_4000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Issue 4003: when WriteISO8601DateFormat is requested at runtime but the
+ * JSONWriter context already carries a default dateFormat such as
+ * "yyyy-MM-dd HH:mm:ss" (for example via Spring Boot's FastJsonConfig),
+ * Instant was being serialized as "yyyy-MM-dd HH:mm:ss" — the explicit
+ * ISO8601 feature should take priority.
+ */
+public class Issue4003 {
+    public static class Bean {
+        public Instant time;
+    }
+
+    private static JSONWriter.Context utcContext() {
+        JSONWriter.Context ctx = new JSONWriter.Context();
+        ctx.setZoneId(ZoneId.of("UTC"));
+        return ctx;
+    }
+
+    private static JSONWriter.Context utcContext(String dateFormat) {
+        JSONWriter.Context ctx = new JSONWriter.Context(dateFormat);
+        ctx.setZoneId(ZoneId.of("UTC"));
+        return ctx;
+    }
+
+    @Test
+    public void testIso8601ContextDateFormat() {
+        Bean b = new Bean();
+        b.time = Instant.parse("2026-02-24T14:50:00Z");
+        JSONWriter.Context ctx = utcContext();
+        ctx.setDateFormat("iso8601");
+        String json = JSON.toJSONString(b, ctx);
+        assertEquals("{\"time\":\"2026-02-24T14:50:00Z\"}", json);
+    }
+
+    @Test
+    public void testIso8601OverridesDefaultDateFormat() {
+        Bean b = new Bean();
+        b.time = Instant.parse("2026-02-24T14:50:00Z");
+        // Simulates Spring Boot's FastJsonConfig: default dateFormat is
+        // "yyyy-MM-dd HH:mm:ss", then the user later switches to ISO8601.
+        JSONWriter.Context ctx = utcContext("yyyy-MM-dd HH:mm:ss");
+        ctx.setDateFormat("iso8601");
+        String json = JSON.toJSONString(b, ctx);
+        assertEquals("{\"time\":\"2026-02-24T14:50:00Z\"}", json);
+    }
+
+    @Test
+    public void testDefaultDateFormatStillUsedWithoutIso8601() {
+        Bean b = new Bean();
+        b.time = Instant.parse("2026-02-24T14:50:00Z");
+        JSONWriter.Context ctx = utcContext("yyyy-MM-dd HH:mm:ss");
+        String json = JSON.toJSONString(b, ctx);
+        assertEquals("{\"time\":\"2026-02-24 14:50:00\"}", json);
+    }
+
+    @Test
+    public void testNoFeatureNoFormat() {
+        Bean b = new Bean();
+        b.time = Instant.parse("2026-02-24T14:50:00Z");
+        JSONWriter.Context ctx = utcContext();
+        String json = JSON.toJSONString(b, ctx);
+        assertEquals("{\"time\":\"2026-02-24T14:50:00Z\"}", json);
+    }
+}


### PR DESCRIPTION
## Summary
- When the `JSONWriter.Context` has `dateFormat="iso8601"` (the runtime form that fastjson1's `SerializerFeature.UseISO8601DateFormat` resolves into) ISO8601 must take priority over any string-pattern shape flags such as `yyyyMMddhhmmss19`/`14`/`8`/`10`.
- Previously the codec evaluated those flags purely against the codec instance + context's pattern flags, so a setup that had been initialized with `dateFormat="yyyy-MM-dd HH:mm:ss"` and later switched to ISO8601 could still hit the `yyyyMMddhhmmss19` path and produce `"2026-02-24 14:50:00"` instead of `"2026-02-24T14:50:00Z"`.
- Compute a single `iso8601` effective flag and gate the `yyyyMMddhhmmss` shape paths on `!iso8601`, so an explicit ISO8601 request always wins.

Fixes #4003.

## Test plan
- [x] New `Issue4003` test covering: ISO8601 alone, ISO8601 after a default `yyyy-MM-dd HH:mm:ss`, default `yyyy-MM-dd HH:mm:ss` without ISO8601 (regression), and no-format default.
- [x] All `*Instant*`, `*ISO8601*`, `*DateTimeCodec*`, `Issue*` tests pass (37 tests).