### PR TITLE
fix: JSONB ASM direct-write skips level tracking causing false 'level too large' on flat lists, for issue #3616

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -5023,6 +5023,28 @@ public abstract class JSONWriter
     }
 
     /**
+     * Increments the nesting level and verifies it does not exceed {@code context.maxLevel}.
+     * Used by code paths that emit BC_OBJECT directly to the byte buffer instead of going
+     * through {@link #startObject()}, so that nesting depth is still tracked correctly.
+     *
+     * @throws JSONException if the level exceeds the configured maximum
+     */
+    public final void incrementLevel() {
+        if (++level > context.maxLevel) {
+            overflowLevel();
+        }
+    }
+
+    /**
+     * Decrements the nesting level. Used by code paths that emit BC_OBJECT_END directly
+     * to the byte buffer instead of going through {@link #endObject()}, so that nesting
+     * depth is still tracked correctly.
+     */
+    public final void decrementLevel() {
+        level--;
+    }
+
+    /**
      * Gets the current offset in the internal buffer.
      * The offset represents the position where the next character will be written.
      *

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -896,6 +896,9 @@ public class ObjectWriterCreatorASM
                     // bytes[off++] = BC_OBJECT;
                     gwWriteByte(mw, BYTES, OFFSET, BC_OBJECT);
                     mw.visitIincInsn(OFFSET, 1);
+                    // jsonWriter.incrementLevel(); — keep nesting depth in sync with startObject()
+                    mw.aload(JSON_WRITER);
+                    mw.invokevirtual(TYPE_JSON_WRITER, "incrementLevel", "()V");
                 }
                 for (FieldWriterRecord item : group.fieldWriters) {
                     writeFieldValueDirectJSONB(
@@ -916,6 +919,9 @@ public class ObjectWriterCreatorASM
 
                 if (group.end) {
                     gwWriteByte(mw, BYTES, OFFSET, BC_OBJECT_END);
+                    // jsonWriter.decrementLevel(); — keep nesting depth in sync with endObject()
+                    mw.aload(JSON_WRITER);
+                    mw.invokevirtual(TYPE_JSON_WRITER, "decrementLevel", "()V");
                 }
 
                 mw.aload(JSON_WRITER);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3600/Issue3616.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3600/Issue3616.java
@@ -1,0 +1,108 @@
+package com.alibaba.fastjson2.issues_3600;
+
+import com.alibaba.fastjson2.JSONB;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("regression")
+public class Issue3616 {
+    /**
+     * Issue #3616: a flat list of JavaBeans whose field groups split between the
+     * direct-write path (e.g. String) and the non-direct-write path (e.g. BigDecimal)
+     * caused {@code JSONException: level too large} after ~2049 elements, even though
+     * the structure has no real nesting. Each bean called {@code startObject()}
+     * (level++) but the matching object end was emitted as a raw byte on the direct
+     * path, so {@code level} never decremented.
+     */
+    @Test
+    public void testFlatListBigDecimalAndString() {
+        List<MixedBean> list = new ArrayList<>();
+        for (int i = 0; i < 2100; i++) {
+            list.add(new MixedBean("a" + i, new BigDecimal("1232132")));
+        }
+
+        byte[] bytes = assertDoesNotThrow(() -> JSONB.toBytes(list));
+        List<MixedBean> parsed = JSONB.parseArray(bytes, MixedBean.class);
+        assertEquals(list.size(), parsed.size());
+        assertEquals("a0", parsed.get(0).getD());
+        assertEquals(new BigDecimal("1232132"), parsed.get(0).getC());
+        assertEquals("a2099", parsed.get(2099).getD());
+    }
+
+    @Test
+    public void testFlatListWithDateObject() {
+        List<DateBean> list = new ArrayList<>();
+        for (int i = 0; i < 2100; i++) {
+            list.add(new DateBean("name" + i, new java.util.Date(0)));
+        }
+        assertDoesNotThrow(() -> JSONB.toBytes(list));
+    }
+
+    public static class MixedBean implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String d;
+        private BigDecimal c;
+
+        public MixedBean() {
+        }
+
+        public MixedBean(String d, BigDecimal c) {
+            this.d = d;
+            this.c = c;
+        }
+
+        public String getD() {
+            return d;
+        }
+
+        public void setD(String d) {
+            this.d = d;
+        }
+
+        public BigDecimal getC() {
+            return c;
+        }
+
+        public void setC(BigDecimal c) {
+            this.c = c;
+        }
+    }
+
+    public static class DateBean implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private String name;
+        private java.util.Date time;
+
+        public DateBean() {
+        }
+
+        public DateBean(String name, java.util.Date time) {
+            this.name = name;
+            this.time = time;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public java.util.Date getTime() {
+            return time;
+        }
+
+        public void setTime(java.util.Date time) {
+            this.time = time;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`JSONB.toBytes(list)` on a flat list of JavaBeans throws `JSONException: level too large : 2049` after ~2049 elements, even though the structure has no actual nesting. Reported reproducer (issue #3616):

```java
List<TestObject> list = new ArrayList<>();
for (int i = 0; i < 2100; i++) {
    list.add(new TestObject("a" + i, new BigDecimal("1232132")));
}
JSONB.toBytes(list);  // throws "level too large : 2049"
```

`TestObject` has a `String` field and a `BigDecimal` field — both standard, both unrelated to nesting. Stack trace:

```
JSONException: level too large : 2049
  at JSONWriter.overflowLevel
  at JSONWriterJSONB.startObject (line 81)
  at OWG_x_x_TestObject.writeJSONB (ASM-generated)
  at ObjectWriterImplList.writeJSONB
```

## Root cause

`ObjectWriterCreatorASM.genMethodWriteJSONB` partitions the bean's field writers into "direct" and "non-direct" groups. The two paths emit the BC_OBJECT / BC_OBJECT_END framing differently:

- Non-direct path (`group.start`): calls `JSONWriter.startObject()` — writes BC_OBJECT **and** increments `level`.
- Non-direct path (`group.end`):   calls `JSONWriter.endObject()`   — writes BC_OBJECT_END **and** decrements `level`.
- Direct path     (`group.start`): writes BC_OBJECT raw to the byte buffer — does **not** touch `level`.
- Direct path     (`group.end`):   writes BC_OBJECT_END raw to the byte buffer — does **not** touch `level`.

For `TestObject`, the field groups order out as `[BigDecimal c (non-direct, start=true)] + [String d (direct, end=true)]`. So `startObject()` increments `level` but the matching end is the raw-byte direct path, which leaves `level` incremented. Each bean in the list leaks 1 level. At iteration 2049 we hit `context.maxLevel` and `overflowLevel()` fires.

The same imbalance occurs on any field-group split where start and end fall on different paths.

## Fix

Mirror the level bookkeeping on the direct-write path so it stays consistent with `startObject()` / `endObject()`:

- New `JSONWriter.incrementLevel()` — bumps `level` and runs the same overflow check as `startObject()`. No byte output.
- New `JSONWriter.decrementLevel()` — decrements `level`. No byte output.

`ObjectWriterCreatorASM` calls `incrementLevel()` after writing BC_OBJECT raw and `decrementLevel()` after writing BC_OBJECT_END raw. The direct path keeps its raw-byte field-value writes, so the performance optimisation is preserved.

## Tests

`core/src/test/java/com/alibaba/fastjson2/issues_3600/Issue3616.java`:

- `testFlatListBigDecimalAndString` — 2100-element list of `(String, BigDecimal)` beans; serialise to JSONB and round-trip back, asserting size and field values. Reproduces the issue exactly and verifies it is gone.
- `testFlatListWithDateObject` — 2100-element list of `(String, Date)` beans, exercising another non-direct field type to guard against future regressions.

Existing regression tests still pass:
- `Issue3657` (intentional `level too large` for genuinely deep nesting) — 6 tests
- `Issue7616` (related fix for direct-write byte-frame capacity) — 3 tests
- `*Writer*` test suite — 394 tests, all green

## Impact

Surgical: 2 helper methods on `JSONWriter` (no behaviour change for existing callers) plus 6 lines of bytecode emission in the JSONB ASM generator. No JSON-text serialiser changes, no API surface broken.

Fixes #3616