### PR TITLE
fix: NameFilter returning null causes Map keys to serialize as null (#7644)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
@@ -674,7 +674,10 @@ public final class ObjectWriterImplMap
                 }
 
                 if (nameFilter != null) {
-                    key = nameFilter.process(object, key, value);
+                    String filteredKey = nameFilter.process(object, key, value);
+                    if (filteredKey != null) {
+                        key = filteredKey;
+                    }
                 }
 
                 if (propertyFilter != null) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7644.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7644.java
@@ -1,0 +1,32 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.filter.NameFilter;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7644 {
+    @Test
+    public void testNameFilterNullReturnPreservesMapKey() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("aaaa", "value");
+
+        NameFilter nameFilter = (object, name, value) -> null;
+
+        assertEquals("{\"aaaa\":\"value\"}", JSON.toJSONString(map, nameFilter));
+    }
+
+    @Test
+    public void testNameFilterReturnValueRenamesMapKey() {
+        Map<String, String> map = new LinkedHashMap<>();
+        map.put("aaaa", "value");
+
+        NameFilter nameFilter = (object, name, value) -> "renamed_" + name;
+
+        assertEquals("{\"renamed_aaaa\":\"value\"}", JSON.toJSONString(map, nameFilter));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

When `NameFilter.process()` returns `null` for a Map entry key in `ObjectWriterImplMap.writeWithFilter()`, the key is directly overwritten with `null` and serialized as `null:"value"` instead of preserving the original key name.

Fixes #7644

### Summary of your change

Added a null guard in `ObjectWriterImplMap.writeWithFilter()` so that when `NameFilter.process()` returns `null`, the original key is preserved — consistent with the existing behavior in:

- `ObjectWriterAdapter` (POJO fields): `boolean nameChanged = filteredName != null && ...`
- `JSONObject.nameFilter()`: `if (processName != null && !processName.equals(key))`

**Before:**
```java
if (nameFilter != null) {
    key = nameFilter.process(object, key, value); // null overwrites key directly
}
```

**After:**
```java
if (nameFilter != null) {
    String filteredKey = nameFilter.process(object, key, value);
    if (filteredKey != null) {
        key = filteredKey; // null → preserve original key
    }
}
```

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
