### PR TITLE
fix: honor serialize false in JSONCompiled writers

### DIFF
--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
@@ -206,13 +206,11 @@ public class Analysis {
                     }
 
                     AttributeInfo attr = info.getAttributeByMethod(name, type, getter, setter);
-                    if (annotations.length != 0) {
-                        if (readerFieldInfo.ignore) {
-                            attr.reader = false;
-                        }
-                        if (writerFieldInfo.ignore) {
-                            attr.writer = false;
-                        }
+                    if (readerFieldInfo.ignore) {
+                        attr.reader = false;
+                    }
+                    if (writerFieldInfo.ignore) {
+                        attr.writer = false;
                     }
                 }
             }

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
@@ -189,7 +189,29 @@ public class Analysis {
                     } else {
                         continue;
                     }
+
+                    FieldInfo readerFieldInfo = new FieldInfo();
+                    FieldInfo writerFieldInfo = new FieldInfo();
+                    JSONField[] annotations = method.getAnnotationsByType(JSONField.class);
+                    for (JSONField annotation : annotations) {
+                        CodeGenUtils.getFieldInfo(readerFieldInfo, annotation, false);
+                        CodeGenUtils.getFieldInfo(writerFieldInfo, annotation, true);
+                    }
+                    if (readerFieldInfo.fieldName != null) {
+                        name = readerFieldInfo.fieldName;
+                    } else if (writerFieldInfo.fieldName != null) {
+                        name = writerFieldInfo.fieldName;
+                    }
+
                     AttributeInfo attr = info.getAttributeByMethod(name, type, getter, setter);
+                    if (annotations.length != 0) {
+                        if (readerFieldInfo.ignore) {
+                            attr.reader = false;
+                        }
+                        if (writerFieldInfo.ignore) {
+                            attr.writer = false;
+                        }
+                    }
                 }
             }
         }

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
@@ -127,19 +127,23 @@ public class Analysis {
                         continue;
                     }
 
-                    FieldInfo fieldInfo = new FieldInfo();
+                    FieldInfo readerFieldInfo = new FieldInfo();
+                    FieldInfo writerFieldInfo = new FieldInfo();
 
                     String name = field.getSimpleName().toString();
                     JSONField[] annotations = field.getAnnotationsByType(JSONField.class);
                     for (JSONField annotation : annotations) {
-                        CodeGenUtils.getFieldInfo(fieldInfo, annotation, false);
+                        CodeGenUtils.getFieldInfo(readerFieldInfo, annotation, false);
+                        CodeGenUtils.getFieldInfo(writerFieldInfo, annotation, true);
                     }
 
-                    if (fieldInfo.fieldName != null) {
-                        name = fieldInfo.fieldName;
+                    if (readerFieldInfo.fieldName != null) {
+                        name = readerFieldInfo.fieldName;
                     }
 
-                    info.getAttributeByField(name, field);
+                    AttributeInfo attr = info.getAttributeByField(name, field);
+                    attr.reader = !readerFieldInfo.ignore;
+                    attr.writer = !writerFieldInfo.ignore;
                 }
 
                 for (ExecutableElement method : ElementFilter.methodsIn(inheritance.getEnclosedElements())) {

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
@@ -203,8 +203,6 @@ public class Analysis {
                     }
                     if (readerFieldInfo.fieldName != null) {
                         name = readerFieldInfo.fieldName;
-                    } else if (writerFieldInfo.fieldName != null) {
-                        name = writerFieldInfo.fieldName;
                     }
 
                     AttributeInfo attr = info.getAttributeByMethod(name, type, getter, setter);

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
@@ -142,8 +142,12 @@ public class Analysis {
                     }
 
                     AttributeInfo attr = info.getAttributeByField(name, field);
-                    attr.reader = !readerFieldInfo.ignore;
-                    attr.writer = !writerFieldInfo.ignore;
+                    if (readerFieldInfo.ignore) {
+                        attr.reader = false;
+                    }
+                    if (writerFieldInfo.ignore) {
+                        attr.writer = false;
+                    }
                 }
 
                 for (ExecutableElement method : ElementFilter.methodsIn(inheritance.getEnclosedElements())) {

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/AttributeInfo.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/AttributeInfo.java
@@ -16,6 +16,8 @@ public class AttributeInfo
     ExecutableElement setMethod;
     VariableElement argument;
     long readerFeatures;
+    boolean reader = true;
+    boolean writer = true;
 
     public AttributeInfo(
             String name,
@@ -35,7 +37,11 @@ public class AttributeInfo
     }
 
     public boolean supportSet() {
-        return field != null || setMethod != null;
+        return reader && (field != null || setMethod != null);
+    }
+
+    public boolean supportGet() {
+        return writer && (field != null || getMethod != null);
     }
 
     @Override

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/CodeGenUtils.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/CodeGenUtils.java
@@ -542,7 +542,7 @@ public class CodeGenUtils {
 
         for (JSONReader.Feature feature : jsonField.deserializeFeatures()) {
             fieldInfo.features |= feature.mask;
-            if (fieldInfo.ignore && feature == JSONReader.Feature.FieldBased) {
+            if (!serialize && fieldInfo.ignore && feature == JSONReader.Feature.FieldBased) {
                 fieldInfo.ignore = false;
             }
         }

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
@@ -89,11 +89,13 @@ public class JSONCompiledAnnotationProcessor
         Set<ReflectionMetadata> reflects = new HashSet<>(elementsAnnotatedWith.size() * 2);
         elementsAnnotatedWith.forEach(element -> {
             StructInfo structInfo = structs.get(element.toString());
-            java.util.List<AttributeInfo> attributeInfos = structInfo.getReaderAttributes();
-            int fieldsSize = attributeInfos.size();
+            java.util.List<AttributeInfo> readerAttributeInfos = structInfo.getReaderAttributes();
+            java.util.List<AttributeInfo> writerAttributeInfos = structInfo.getWriterAttributes();
+            int readerFieldsSize = readerAttributeInfos.size();
+            int writerFieldsSize = writerAttributeInfos.size();
             boolean record = structInfo.record;
-            Class readSuperClass = getReadSuperClass(fieldsSize);
-            Class writeSuperClass = getWriteSuperClass(fieldsSize);
+            Class readSuperClass = getReadSuperClass(readerFieldsSize);
+            Class writeSuperClass = getWriteSuperClass(writerFieldsSize);
 
             JCTree tree = javacTrees.getTree(element);
             pos(tree.pos);
@@ -129,31 +131,32 @@ public class JSONCompiledAnnotationProcessor
                         JCTree.JCClassDecl innerReadClass = genInnerClass(innerReadClassName, readSuperClass);
 
                         // generate fields if necessary
-                        final boolean generatedFields = fieldsSize < 128;
-                        if (generatedFields) {
-                            innerReadClass.defs = innerReadClass.defs.prependList(genFields(attributeInfos, readSuperClass));
+                        final boolean generatedReadFields = readerFieldsSize < 128;
+                        if (generatedReadFields) {
+                            innerReadClass.defs = innerReadClass.defs.prependList(genFields(readerAttributeInfos, readSuperClass));
                         }
 
                         // generate constructor
-                        innerReadClass.defs = innerReadClass.defs.append(genReadConstructor(beanType, beanNew, attributeInfos, readSuperClass, generatedFields, record));
+                        innerReadClass.defs = innerReadClass.defs.append(genReadConstructor(
+                                beanType, beanNew, readerAttributeInfos, readSuperClass, generatedReadFields, record));
 
                         // generate createInstance
                         innerReadClass.defs = innerReadClass.defs.append(
                                 record
-                                        ? genCreateRecordInstance(objectType, beanType, attributeInfos)
+                                        ? genCreateRecordInstance(objectType, beanType, readerAttributeInfos)
                                         : genCreateInstance(objectType, beanNew));
 
                         // generate readObject
                         innerReadClass.defs = innerReadClass.defs.append(
                                 record
-                                        ? genReadRecordObject(objectType, beanType, attributeInfos, structInfo, false)
-                                        : genReadObject(objectType, beanType, beanNew, attributeInfos, structInfo, false));
+                                        ? genReadRecordObject(objectType, beanType, readerAttributeInfos, structInfo, false)
+                                        : genReadObject(objectType, beanType, beanNew, readerAttributeInfos, structInfo, false));
 
                         // generate readJSONBObject
                         innerReadClass.defs = innerReadClass.defs.append(
                                 record
-                                        ? genReadRecordObject(objectType, beanType, attributeInfos, structInfo, true)
-                                        : genReadObject(objectType, beanType, beanNew, attributeInfos, structInfo, true));
+                                        ? genReadRecordObject(objectType, beanType, readerAttributeInfos, structInfo, true)
+                                        : genReadObject(objectType, beanType, beanNew, readerAttributeInfos, structInfo, true));
 
                         // link with inner class
                         beanClassDecl.defs = beanClassDecl.defs.append(innerReadClass);
@@ -169,15 +172,18 @@ public class JSONCompiledAnnotationProcessor
                         JCTree.JCClassDecl innerWriteClass = genInnerClass(innerWriteClassName, writeSuperClass);
 
                         // generate fields if necessary
-                        if (generatedFields) {
-                            innerWriteClass.defs = innerWriteClass.defs.prependList(genFields(attributeInfos, writeSuperClass));
+                        final boolean generatedWriteFields = writerFieldsSize < 128;
+                        if (generatedWriteFields) {
+                            innerWriteClass.defs = innerWriteClass.defs.prependList(genFields(writerAttributeInfos, writeSuperClass));
                         }
 
                         // generate constructor
-                        innerWriteClass.defs = innerWriteClass.defs.append(genWriteConstructor(beanType, beanNew, attributeInfos, writeSuperClass, generatedFields));
+                        innerWriteClass.defs = innerWriteClass.defs.append(genWriteConstructor(
+                                beanType, beanNew, writerAttributeInfos, writeSuperClass, generatedWriteFields));
 
                         // generate write
-                        innerWriteClass.defs = innerWriteClass.defs.append(genWrite(objectType, beanType, beanNew, attributeInfos, structInfo, false));
+                        innerWriteClass.defs = innerWriteClass.defs.append(
+                                genWrite(objectType, beanType, beanNew, writerAttributeInfos, structInfo, false));
 
                         // link with inner class
                         beanClassDecl.defs = beanClassDecl.defs.append(innerWriteClass);

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/StructInfo.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/StructInfo.java
@@ -139,6 +139,13 @@ public class StructInfo {
     }
 
     public List<AttributeInfo> getWriterAttributes() {
+        if (record) {
+            return attributes.values()
+                    .stream()
+                    .filter(AttributeInfo::supportGet)
+                    .collect(Collectors.toList());
+        }
+
         return attributes.values()
                 .stream()
                 .filter(AttributeInfo::supportGet)

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/StructInfo.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/StructInfo.java
@@ -137,4 +137,12 @@ public class StructInfo {
                 .sorted()
                 .collect(Collectors.toList());
     }
+
+    public List<AttributeInfo> getWriterAttributes() {
+        return attributes.values()
+                .stream()
+                .filter(AttributeInfo::supportGet)
+                .sorted()
+                .collect(Collectors.toList());
+    }
 }

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -101,6 +101,56 @@ public class Issue7660Test {
     }
 
     @Test
+    public void jsonCompiledKeepsChildAccessorDisableWhenParentFieldExists() throws Exception {
+        assertEquals("{\"name\":\"Ada\"}", runSource(
+                "Issue7660InheritedBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660InheritedBean {",
+                    "    public static class BasePerson {",
+                    "        public String internalCode;",
+                    "        public String name;",
+                    "",
+                    "        public BasePerson() {",
+                    "        }",
+                    "",
+                    "        public BasePerson(String internalCode, String name) {",
+                    "            this.internalCode = internalCode;",
+                    "            this.name = name;",
+                    "        }",
+                    "    }",
+                    "",
+                    "    @JSONCompiled",
+                    "    public static class Person extends BasePerson {",
+                    "        public Person() {",
+                    "        }",
+                    "",
+                    "        public Person(String internalCode, String name) {",
+                    "            super(internalCode, name);",
+                    "        }",
+                    "",
+                    "        @JSONField(serialize = false)",
+                    "        public String getInternalCode() {",
+                    "            return internalCode;",
+                    "        }",
+                    "",
+                    "        public String getName() {",
+                    "            return name;",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        System.out.println(JSON.toJSONString(new Person(\"secret\", \"Ada\")));",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
     public void jsonCompiledHonorsDeserializeFalse() throws Exception {
         assertEquals("null:Ada", runSource(
                 "Issue7660ReaderBean",
@@ -123,6 +173,35 @@ public class Issue7660Test {
                     "    public static void main(String[] args) {",
                     "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
                     "        System.out.println(person.internalCode + \":\" + person.name);",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
+    public void jsonCompiledSerializeFalseStillAllowsDeserialization() throws Exception {
+        assertEquals("secret:{\"name\":\"Ada\"}", runSource(
+                "Issue7660RoundTripBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660RoundTripBean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        @JSONField(serialize = false)",
+                    "        public String internalCode;",
+                    "        public String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
+                    "        System.out.println(person.internalCode + \":\" + JSON.toJSONString(person));",
                     "    }",
                     "}"
                 )

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson2.internal.processor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,40 +20,142 @@ public class Issue7660Test {
 
     @Test
     public void jsonCompiledHonorsSerializeFalse() throws Exception {
-        Path classes = tempDir.resolve("classes");
+        assertEquals("{\"name\":\"Ada\"}", runSource(
+                "Issue7660Bean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660Bean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        @JSONField(serialize = false)",
+                    "        public String internalCode;",
+                    "        public String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "",
+                    "        public Person(String internalCode, String name) {",
+                    "            this.internalCode = internalCode;",
+                    "            this.name = name;",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        System.out.println(JSON.toJSONString(new Person(\"secret\", \"Ada\")));",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
+    public void jsonCompiledHonorsSerializeFalseOnGetter() throws Exception {
+        assertEquals("{\"name\":\"Ada\"}", runSource(
+                "Issue7660GetterBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660GetterBean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        private String internalCode;",
+                    "        private String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "",
+                    "        public Person(String internalCode, String name) {",
+                    "            this.internalCode = internalCode;",
+                    "            this.name = name;",
+                    "        }",
+                    "",
+                    "        @JSONField(serialize = false)",
+                    "        public String getInternalCode() {",
+                    "            return internalCode;",
+                    "        }",
+                    "",
+                    "        public void setInternalCode(String internalCode) {",
+                    "            this.internalCode = internalCode;",
+                    "        }",
+                    "",
+                    "        public String getName() {",
+                    "            return name;",
+                    "        }",
+                    "",
+                    "        public void setName(String name) {",
+                    "            this.name = name;",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        System.out.println(JSON.toJSONString(new Person(\"secret\", \"Ada\")));",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
+    public void jsonCompiledHonorsDeserializeFalse() throws Exception {
+        assertEquals("null:Ada", runSource(
+                "Issue7660ReaderBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660ReaderBean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        @JSONField(deserialize = false)",
+                    "        public String internalCode;",
+                    "        public String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
+                    "        System.out.println(person.internalCode + \":\" + person.name);",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    private static List<String> command(String first, String... rest) {
+        List<String> command = new ArrayList<>();
+        command.add(first);
+        command.addAll(Arrays.asList(rest));
+        return command;
+    }
+
+    private static ProcessResult run(List<String> command) throws Exception {
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int len;
+        while ((len = process.getInputStream().read(buffer)) != -1) {
+            baos.write(buffer, 0, len);
+        }
+        byte[] output = baos.toByteArray();
+        return new ProcessResult(process.waitFor(), new String(output, StandardCharsets.UTF_8));
+    }
+
+    private String runSource(String className, List<String> sourceLines) throws Exception {
+        Path classes = tempDir.resolve(className + "-classes");
         Files.createDirectories(classes);
 
-        Path source = tempDir.resolve("Issue7660Bean.java");
-        Files.write(
-                source,
-                Arrays.asList(
-                        "import com.alibaba.fastjson2.JSON;",
-                        "import com.alibaba.fastjson2.annotation.JSONCompiled;",
-                        "import com.alibaba.fastjson2.annotation.JSONField;",
-                        "",
-                        "public class Issue7660Bean {",
-                        "    @JSONCompiled",
-                        "    public static class Person {",
-                        "        @JSONField(serialize = false)",
-                        "        public String internalCode;",
-                        "        public String name;",
-                        "",
-                        "        public Person() {",
-                        "        }",
-                        "",
-                        "        public Person(String internalCode, String name) {",
-                        "            this.internalCode = internalCode;",
-                        "            this.name = name;",
-                        "        }",
-                        "    }",
-                        "",
-                        "    public static void main(String[] args) {",
-                        "        System.out.println(JSON.toJSONString(new Person(\"secret\", \"Ada\")));",
-                        "    }",
-                        "}"
-                ),
-                StandardCharsets.UTF_8
-        );
+        Path source = tempDir.resolve(className + ".java");
+        Files.write(source, sourceLines, StandardCharsets.UTF_8);
 
         String javaClassPath = System.getProperty("java.class.path");
         ProcessResult javac = run(command(
@@ -83,25 +186,10 @@ public class Issue7660Test {
                 java(),
                 "-cp",
                 classes + File.pathSeparator + javaClassPath,
-                "Issue7660Bean"
+                className
         ));
         assertEquals(0, java.exitCode, java.output);
-        assertEquals("{\"name\":\"Ada\"}", lastLine(java.output));
-    }
-
-    private static List<String> command(String first, String... rest) {
-        List<String> command = new ArrayList<>();
-        command.add(first);
-        command.addAll(Arrays.asList(rest));
-        return command;
-    }
-
-    private static ProcessResult run(List<String> command) throws Exception {
-        Process process = new ProcessBuilder(command)
-                .redirectErrorStream(true)
-                .start();
-        byte[] output = process.getInputStream().readAllBytes();
-        return new ProcessResult(process.waitFor(), new String(output, StandardCharsets.UTF_8));
+        return lastLine(java.output);
     }
 
     private static String javac() {

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -325,7 +325,21 @@ public class Issue7660Test {
     }
 
     private static String executable(String name) {
-        return System.getProperty("java.home") + File.separator + "bin" + File.separator + name;
+        File javaHome = new File(System.getProperty("java.home"));
+        File executable = new File(new File(javaHome, "bin"), name);
+        if (executable.isFile()) {
+            return executable.getAbsolutePath();
+        }
+
+        File parent = javaHome.getParentFile();
+        if (parent != null) {
+            File parentExecutable = new File(new File(parent, "bin"), name);
+            if (parentExecutable.isFile()) {
+                return parentExecutable.getAbsolutePath();
+            }
+        }
+
+        return executable.getAbsolutePath();
     }
 
     private static String lastLine(String output) {

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -282,14 +282,18 @@ public class Issue7660Test {
         Files.write(source, sourceLines, StandardCharsets.UTF_8);
 
         String javaClassPath = System.getProperty("java.class.path");
-        ProcessResult javac = run(command(
-                javac(),
-                "-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-                "-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                "-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-                "-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                "-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-                "-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        List<String> javacCommand = command(javac());
+        if (isJdk9OrLater()) {
+            javacCommand.addAll(Arrays.asList(
+                    "-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                    "-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                    "-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                    "-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                    "-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                    "-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED"
+            ));
+        }
+        javacCommand.addAll(Arrays.asList(
                 "-cp",
                 javaClassPath,
                 "-processorpath",
@@ -304,6 +308,7 @@ public class Issue7660Test {
                 classes.toString(),
                 source.toString()
         ));
+        ProcessResult javac = run(javacCommand);
         assertEquals(0, javac.exitCode, javac.output);
 
         ProcessResult java = run(command(
@@ -322,6 +327,10 @@ public class Issue7660Test {
 
     private static String java() {
         return executable("java");
+    }
+
+    private static boolean isJdk9OrLater() {
+        return !System.getProperty("java.specification.version").startsWith("1.");
     }
 
     private static String executable(String name) {

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -1,0 +1,133 @@
+package com.alibaba.fastjson2.internal.processor;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7660Test {
+    @TempDir
+    public Path tempDir;
+
+    @Test
+    public void jsonCompiledHonorsSerializeFalse() throws Exception {
+        Path classes = tempDir.resolve("classes");
+        Files.createDirectories(classes);
+
+        Path source = tempDir.resolve("Issue7660Bean.java");
+        Files.write(
+                source,
+                Arrays.asList(
+                        "import com.alibaba.fastjson2.JSON;",
+                        "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                        "import com.alibaba.fastjson2.annotation.JSONField;",
+                        "",
+                        "public class Issue7660Bean {",
+                        "    @JSONCompiled",
+                        "    public static class Person {",
+                        "        @JSONField(serialize = false)",
+                        "        public String internalCode;",
+                        "        public String name;",
+                        "",
+                        "        public Person() {",
+                        "        }",
+                        "",
+                        "        public Person(String internalCode, String name) {",
+                        "            this.internalCode = internalCode;",
+                        "            this.name = name;",
+                        "        }",
+                        "    }",
+                        "",
+                        "    public static void main(String[] args) {",
+                        "        System.out.println(JSON.toJSONString(new Person(\"secret\", \"Ada\")));",
+                        "    }",
+                        "}"
+                ),
+                StandardCharsets.UTF_8
+        );
+
+        String javaClassPath = System.getProperty("java.class.path");
+        ProcessResult javac = run(command(
+                javac(),
+                "-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                "-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                "-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                "-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "-cp",
+                javaClassPath,
+                "-processorpath",
+                javaClassPath,
+                "-processor",
+                JSONCompiledAnnotationProcessor.class.getName(),
+                "-source",
+                "1.8",
+                "-target",
+                "1.8",
+                "-d",
+                classes.toString(),
+                source.toString()
+        ));
+        assertEquals(0, javac.exitCode, javac.output);
+
+        ProcessResult java = run(command(
+                java(),
+                "-cp",
+                classes + File.pathSeparator + javaClassPath,
+                "Issue7660Bean"
+        ));
+        assertEquals(0, java.exitCode, java.output);
+        assertEquals("{\"name\":\"Ada\"}", lastLine(java.output));
+    }
+
+    private static List<String> command(String first, String... rest) {
+        List<String> command = new ArrayList<>();
+        command.add(first);
+        command.addAll(Arrays.asList(rest));
+        return command;
+    }
+
+    private static ProcessResult run(List<String> command) throws Exception {
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        byte[] output = process.getInputStream().readAllBytes();
+        return new ProcessResult(process.waitFor(), new String(output, StandardCharsets.UTF_8));
+    }
+
+    private static String javac() {
+        return executable("javac");
+    }
+
+    private static String java() {
+        return executable("java");
+    }
+
+    private static String executable(String name) {
+        return System.getProperty("java.home") + File.separator + "bin" + File.separator + name;
+    }
+
+    private static String lastLine(String output) {
+        String[] lines = output.trim().split("\\R");
+        return lines[lines.length - 1];
+    }
+
+    private static final class ProcessResult {
+        final int exitCode;
+        final String output;
+
+        ProcessResult(int exitCode, String output) {
+            this.exitCode = exitCode;
+            this.output = output;
+        }
+    }
+}

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -180,6 +180,51 @@ public class Issue7660Test {
     }
 
     @Test
+    public void jsonCompiledHonorsDeserializeFalseOnSetter() throws Exception {
+        assertEquals("null:Ada", runSource(
+                "Issue7660SetterReaderBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660SetterReaderBean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        private String internalCode;",
+                    "        private String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "",
+                    "        public String getInternalCode() {",
+                    "            return internalCode;",
+                    "        }",
+                    "",
+                    "        @JSONField(deserialize = false)",
+                    "        public void setInternalCode(String internalCode) {",
+                    "            this.internalCode = internalCode;",
+                    "        }",
+                    "",
+                    "        public String getName() {",
+                    "            return name;",
+                    "        }",
+                    "",
+                    "        public void setName(String name) {",
+                    "            this.name = name;",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
+                    "        System.out.println(person.getInternalCode() + \":\" + person.getName());",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
     public void jsonCompiledSerializeFalseStillAllowsDeserialization() throws Exception {
         assertEquals("secret:{\"name\":\"Ada\"}", runSource(
                 "Issue7660RoundTripBean",

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -152,7 +152,7 @@ public class Issue7660Test {
 
     @Test
     public void jsonCompiledHonorsDeserializeFalse() throws Exception {
-        assertEquals("null:Ada", runSource(
+        assertEquals("visible:Ada:{\"internalCode\":\"visible\",\"name\":\"Ada\"}", runSource(
                 "Issue7660ReaderBean",
                 Arrays.asList(
                     "import com.alibaba.fastjson2.JSON;",
@@ -172,7 +172,68 @@ public class Issue7660Test {
                     "",
                     "    public static void main(String[] args) {",
                     "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
-                    "        System.out.println(person.internalCode + \":\" + person.name);",
+                    "        person.internalCode = \"visible\";",
+                    "        System.out.println(person.internalCode + \":\" + person.name + \":\" + JSON.toJSONString(person));",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
+    public void jsonCompiledHonorsSerializeFalseWithFieldBasedDeserializeFeature() throws Exception {
+        assertEquals("secret:{\"name\":\"Ada\"}", runSource(
+                "Issue7660FieldBasedBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.JSONReader;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660FieldBasedBean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        @JSONField(serialize = false, deserializeFeatures = {JSONReader.Feature.FieldBased})",
+                    "        public String internalCode;",
+                    "        public String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
+                    "        System.out.println(person.internalCode + \":\" + JSON.toJSONString(person));",
+                    "    }",
+                    "}"
+                )
+        ));
+    }
+
+    @Test
+    public void jsonCompiledHonorsSerializeFalseAndDeserializeFalseTogether() throws Exception {
+        assertEquals("visible:{\"name\":\"Ada\"}", runSource(
+                "Issue7660ReadWriteIgnoredBean",
+                Arrays.asList(
+                    "import com.alibaba.fastjson2.JSON;",
+                    "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                    "import com.alibaba.fastjson2.annotation.JSONField;",
+                    "",
+                    "public class Issue7660ReadWriteIgnoredBean {",
+                    "    @JSONCompiled",
+                    "    public static class Person {",
+                    "        @JSONField(serialize = false, deserialize = false)",
+                    "        public String internalCode;",
+                    "        public String name;",
+                    "",
+                    "        public Person() {",
+                    "        }",
+                    "    }",
+                    "",
+                    "    public static void main(String[] args) {",
+                    "        Person person = JSON.parseObject(\"{\\\"internalCode\\\":\\\"secret\\\",\\\"name\\\":\\\"Ada\\\"}\", Person.class);",
+                    "        person.internalCode = \"visible\";",
+                    "        System.out.println(person.internalCode + \":\" + JSON.toJSONString(person));",
                     "    }",
                     "}"
                 )

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/Issue7660Test.java
@@ -396,20 +396,28 @@ public class Issue7660Test {
 
     private static String executable(String name) {
         File javaHome = new File(System.getProperty("java.home"));
-        File executable = new File(new File(javaHome, "bin"), name);
+        File executable = executable(new File(javaHome, "bin"), name);
         if (executable.isFile()) {
             return executable.getAbsolutePath();
         }
 
         File parent = javaHome.getParentFile();
         if (parent != null) {
-            File parentExecutable = new File(new File(parent, "bin"), name);
+            File parentExecutable = executable(new File(parent, "bin"), name);
             if (parentExecutable.isFile()) {
                 return parentExecutable.getAbsolutePath();
             }
         }
 
         return executable.getAbsolutePath();
+    }
+
+    private static File executable(File directory, String name) {
+        File executable = new File(directory, name);
+        if (executable.isFile()) {
+            return executable;
+        }
+        return new File(directory, name + ".exe");
     }
 
     private static String lastLine(String output) {


### PR DESCRIPTION
## Summary

- split JSONCompiled analysis into reader and writer attribute lists
- exclude fields annotated with `@JSONField(serialize = false)` from generated writers
- keep deserialize-only handling independent from serialization filtering

## Root Cause

The annotation processor built both generated readers and writers from `StructInfo#getReaderAttributes()`. Field annotations were analyzed with deserialize semantics only, so `serialize = false` did not remove the field from the generated writer.

## Tests

- `./mvnw -Penable-codegen -pl codegen -am -Dtest=Issue7660Test -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -Penable-codegen -pl codegen,codegen-test -am -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -Penable-codegen -pl codegen,codegen-test -am validate`

Fixes #7660
