### PR TITLE
fix: respect custom readers for map subtypes

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderCollectionReadOnly.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderCollectionReadOnly.java
@@ -108,7 +108,7 @@ class FieldReaderCollectionReadOnly<T>
                     .getObjectReader(fieldType);
         }
         Object value = jsonReader.jsonb
-                ? initReader.readJSONBObject(jsonReader, fieldType, fieldName, 0)
+                ? FieldReaderObject.readJSONBObject(initReader, jsonReader, fieldType, fieldClass, fieldName, 0)
                 : initReader.readObject(jsonReader, fieldType, fieldName, 0);
         accept(object, value);
     }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
@@ -100,6 +100,12 @@ public class FieldReaderList<T, V>
         JSONReader.Context context = jsonReader.getContext();
         ObjectReader objectReader = getObjectReader(context);
 
+        if (FieldReaderObject.isCustomReader(objectReader)) {
+            Object value = objectReader.readObject(jsonReader, fieldType, fieldName, features);
+            accept(object, value);
+            return;
+        }
+
         Function builder = null;
 
         if (initReader != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
@@ -164,7 +164,7 @@ public class FieldReaderList<T, V>
         }
 
         Object value = jsonReader.jsonb
-                ? objectReader.readJSONBObject(jsonReader, null, null, features)
+                ? FieldReaderObject.readJSONBObject(objectReader, jsonReader, fieldType, fieldClass, fieldName, features)
                 : objectReader.readObject(jsonReader, null, null, features);
         accept(object, value);
     }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderMapReadOnly.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderMapReadOnly.java
@@ -131,7 +131,7 @@ class FieldReaderMapReadOnly<T>
 
         Object value;
         if (jsonReader.jsonb) {
-            value = initReader.readJSONBObject(jsonReader, getItemType(), fieldName, features);
+            value = FieldReaderObject.readJSONBObject(initReader, jsonReader, fieldType, fieldClass, fieldName, features);
         } else {
             value = initReader.readObject(jsonReader, getItemType(), fieldName, features);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderObject.java
@@ -9,11 +9,15 @@ import com.alibaba.fastjson2.writer.ObjectWriter;
 import java.lang.reflect.*;
 import java.time.temporal.Temporal;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 public class FieldReaderObject<T>
         extends FieldReader<T> {
+    static final ConcurrentMap<Class<?>, Boolean> JSONB_SUPPORTED_CACHE = new ConcurrentHashMap<>();
+
     protected ObjectReader initReader;
 
     public FieldReaderObject(
@@ -139,24 +143,27 @@ public class FieldReaderObject<T>
         return objectReader != null
                 && !(objectReader instanceof ObjectReaderImplMap)
                 && !(objectReader instanceof ObjectReaderImplMapTyped)
+                && !(objectReader instanceof ObjectReaderImplMapMultiValueType)
                 && !(objectReader instanceof ObjectReaderImplList)
                 && !(objectReader instanceof ObjectReaderImplListStr)
                 && !(objectReader instanceof ObjectReaderImplListInt64);
     }
 
     static boolean isReadJSONBObjectSupported(ObjectReader objectReader) {
-        try {
-            Method method = objectReader.getClass().getMethod(
-                    "readJSONBObject",
-                    JSONReader.class,
-                    Type.class,
-                    Object.class,
-                    long.class
-            );
-            return method.getDeclaringClass() != ObjectReader.class;
-        } catch (NoSuchMethodException e) {
-            return false;
-        }
+        return JSONB_SUPPORTED_CACHE.computeIfAbsent(objectReader.getClass(), objectReaderClass -> {
+            try {
+                Method method = objectReaderClass.getMethod(
+                        "readJSONBObject",
+                        JSONReader.class,
+                        Type.class,
+                        Object.class,
+                        long.class
+                );
+                return method.getDeclaringClass() != ObjectReader.class;
+            } catch (NoSuchMethodException e) {
+                return false;
+            }
+        });
     }
 
     public static Object readJSONBObject(
@@ -268,7 +275,7 @@ public class FieldReaderObject<T>
                         value = jsonReader.readAny();
                     }
                 } else {
-                    value = objectReader.readJSONBObject(jsonReader, fieldType, fieldName, features);
+                    value = readJSONBObject(objectReader, jsonReader, fieldType, fieldClass, fieldName, features);
                 }
             } else {
                 value = objectReader.readObject(jsonReader, fieldType, fieldName, features);
@@ -394,7 +401,7 @@ public class FieldReaderObject<T>
         }
 
         Object object = jsonReader.jsonb
-                ? initReader.readJSONBObject(jsonReader, fieldType, fieldName, features)
+                ? readJSONBObject(initReader, jsonReader, fieldType, fieldClass, fieldName, features)
                 : initReader.readObject(jsonReader, fieldType, fieldName, features);
 
         Function builder = initReader.getBuildFunction();

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderObject.java
@@ -92,8 +92,16 @@ public class FieldReaderObject<T>
         }
 
         if (fieldClass != null && Map.class.isAssignableFrom(fieldClass)) {
+            ObjectReader fieldObjectReader = jsonReader.getObjectReader(fieldType);
+            if (isCustomReader(fieldObjectReader)) {
+                return reader = fieldObjectReader;
+            }
             return reader = ObjectReaderImplMap.of(fieldType, fieldClass, features);
         } else if (fieldClass != null && Collection.class.isAssignableFrom(fieldClass)) {
+            ObjectReader fieldObjectReader = jsonReader.getObjectReader(fieldType);
+            if (isCustomReader(fieldObjectReader)) {
+                return reader = fieldObjectReader;
+            }
             return reader = ObjectReaderImplList.of(fieldType, fieldClass, features);
         }
 
@@ -111,12 +119,27 @@ public class FieldReaderObject<T>
         }
 
         if (Map.class.isAssignableFrom(fieldClass)) {
+            ObjectReader fieldObjectReader = context.getObjectReader(fieldType);
+            if (isCustomReader(fieldObjectReader)) {
+                return reader = fieldObjectReader;
+            }
             return reader = ObjectReaderImplMap.of(fieldType, fieldClass, features);
         } else if (Collection.class.isAssignableFrom(fieldClass)) {
+            ObjectReader fieldObjectReader = context.getObjectReader(fieldType);
+            if (isCustomReader(fieldObjectReader)) {
+                return reader = fieldObjectReader;
+            }
             return reader = ObjectReaderImplList.of(fieldType, fieldClass, features);
         }
 
         return reader = context.getObjectReader(fieldType);
+    }
+
+    private static boolean isCustomReader(ObjectReader objectReader) {
+        return objectReader != null
+                && !(objectReader instanceof ObjectReaderImplMap)
+                && !(objectReader instanceof ObjectReaderImplMapTyped)
+                && !(objectReader instanceof ObjectReaderImplList);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderObject.java
@@ -135,11 +135,67 @@ public class FieldReaderObject<T>
         return reader = context.getObjectReader(fieldType);
     }
 
-    private static boolean isCustomReader(ObjectReader objectReader) {
+    static boolean isCustomReader(ObjectReader objectReader) {
         return objectReader != null
                 && !(objectReader instanceof ObjectReaderImplMap)
                 && !(objectReader instanceof ObjectReaderImplMapTyped)
-                && !(objectReader instanceof ObjectReaderImplList);
+                && !(objectReader instanceof ObjectReaderImplList)
+                && !(objectReader instanceof ObjectReaderImplListStr)
+                && !(objectReader instanceof ObjectReaderImplListInt64);
+    }
+
+    static boolean isReadJSONBObjectSupported(ObjectReader objectReader) {
+        try {
+            Method method = objectReader.getClass().getMethod(
+                    "readJSONBObject",
+                    JSONReader.class,
+                    Type.class,
+                    Object.class,
+                    long.class
+            );
+            return method.getDeclaringClass() != ObjectReader.class;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    public static Object readJSONBObject(
+            ObjectReader objectReader,
+            JSONReader jsonReader,
+            Type fieldType,
+            Object fieldName,
+            long features
+    ) {
+        return readJSONBObject(
+                objectReader,
+                jsonReader,
+                fieldType,
+                TypeUtils.getClass(fieldType),
+                fieldName,
+                features
+        );
+    }
+
+    public static Object readJSONBObject(
+            ObjectReader objectReader,
+            JSONReader jsonReader,
+            Type fieldType,
+            Class fieldClass,
+            Object fieldName,
+            long features
+    ) {
+        if (isCustomReader(objectReader)
+                && !isReadJSONBObjectSupported(objectReader)
+                && fieldClass != null
+        ) {
+            if (Map.class.isAssignableFrom(fieldClass)) {
+                objectReader = ObjectReaderImplMap.of(fieldType, fieldClass, features);
+            } else if (Collection.class.isAssignableFrom(fieldClass)) {
+                objectReader = ObjectReaderImplList.of(fieldType, fieldClass, features);
+            }
+        }
+
+        return objectReader.readJSONBObject(jsonReader, fieldType, fieldName, features);
     }
 
     @Override
@@ -255,7 +311,7 @@ public class FieldReaderObject<T>
         }
 
         if (initReader == null) {
-            initReader = jsonReader.getContext().getObjectReader(fieldType);
+            initReader = getObjectReader(jsonReader.getContext());
         }
 
         if (jsonReader.isReference()) {
@@ -268,7 +324,7 @@ public class FieldReaderObject<T>
             return;
         }
 
-        Object value = initReader.readJSONBObject(jsonReader, fieldType, fieldName, features);
+        Object value = readJSONBObject(initReader, jsonReader, fieldType, fieldClass, fieldName, features);
         if (value == null
                 && (jsonReader.features(this.features) & JSONReader.Feature.ErrorOnNullForPrimitives.mask) != 0
                 && fieldClass.isPrimitive()

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -2049,6 +2049,10 @@ public class ObjectReaderBaseModule
                 return null;
             }
 
+            if (hasCustomDeserializer(objectClass)) {
+                return null;
+            }
+
             if (Map.class.isAssignableFrom(objectClass)) {
                 return ObjectReaderImplMap.of(null, objectClass, 0);
             }
@@ -2348,6 +2352,11 @@ public class ObjectReaderBaseModule
         }
 
         return null;
+    }
+
+    private static boolean hasCustomDeserializer(Class objectClass) {
+        JSONType jsonType = (JSONType) objectClass.getAnnotation(JSONType.class);
+        return jsonType != null && ObjectReader.class.isAssignableFrom(jsonType.deserializer());
     }
 
     public static ObjectReader typedMap(Class mapType, Class instanceType, Type keyType, Type valueType) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -3562,7 +3562,8 @@ public class ObjectReaderCreatorASM
         gwGetFieldType(classNameType, mw, i, fieldType);
         mw.visitLdcInsn(fieldReader.fieldName);
         mw.visitLdcInsn(fieldFeatures);
-        if (jsonb && (Map.class.isAssignableFrom(fieldReader.fieldClass)
+        if (jsonb && hasCustomDeserializer(fieldReader.fieldClass)
+                && (Map.class.isAssignableFrom(fieldReader.fieldClass)
                 || Collection.class.isAssignableFrom(fieldReader.fieldClass))) {
             mw.invokestatic(
                     type(FieldReaderObject.class),
@@ -3578,6 +3579,9 @@ public class ObjectReaderCreatorASM
     }
 
     private static boolean hasCustomDeserializer(Class fieldClass) {
+        if (fieldClass == null) {
+            return false;
+        }
         JSONType jsonType = (JSONType) fieldClass.getAnnotation(JSONType.class);
         return jsonType != null && ObjectReader.class.isAssignableFrom(jsonType.deserializer());
     }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.*;
+import com.alibaba.fastjson2.annotation.JSONType;
 import com.alibaba.fastjson2.codec.BeanInfo;
 import com.alibaba.fastjson2.codec.FieldInfo;
 import com.alibaba.fastjson2.function.*;
@@ -3207,6 +3208,7 @@ public class ObjectReaderCreatorASM
 
             boolean list = List.class.isAssignableFrom(fieldClass)
                     && fieldReader.getInitReader() == null
+                    && !hasCustomDeserializer(fieldClass)
                     && !fieldClass.getName().startsWith("com.google.common.collect.Immutable");
 
             if (list) {
@@ -3560,10 +3562,24 @@ public class ObjectReaderCreatorASM
         gwGetFieldType(classNameType, mw, i, fieldType);
         mw.visitLdcInsn(fieldReader.fieldName);
         mw.visitLdcInsn(fieldFeatures);
-        mw.invokeinterface(
-                TYPE_OBJECT_READER,
-                jsonb ? "readJSONBObject" : "readObject",
-                METHOD_DESC_READ_OBJECT);
+        if (jsonb && (Map.class.isAssignableFrom(fieldReader.fieldClass)
+                || Collection.class.isAssignableFrom(fieldReader.fieldClass))) {
+            mw.invokestatic(
+                    type(FieldReaderObject.class),
+                    "readJSONBObject",
+                    "(" + DESC_OBJECT_READER + DESC_JSON_READER + "Ljava/lang/reflect/Type;Ljava/lang/Object;J)Ljava/lang/Object;"
+            );
+        } else {
+            mw.invokeinterface(
+                    TYPE_OBJECT_READER,
+                    jsonb ? "readJSONBObject" : "readObject",
+                    METHOD_DESC_READ_OBJECT);
+        }
+    }
+
+    private static boolean hasCustomDeserializer(Class fieldClass) {
+        JSONType jsonType = (JSONType) fieldClass.getAnnotation(JSONType.class);
+        return jsonType != null && ObjectReader.class.isAssignableFrom(jsonType.deserializer());
     }
 
     private void genReadEnumValueRaw(

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapMultiValueType.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapMultiValueType.java
@@ -3,9 +3,11 @@ package com.alibaba.fastjson2.reader;
 import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONPath;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.util.GuavaSupport;
 import com.alibaba.fastjson2.util.MapMultiValueType;
+import com.alibaba.fastjson2.util.ReferenceKey;
 import com.alibaba.fastjson2.util.TypeUtils;
 
 import java.lang.reflect.Type;
@@ -17,6 +19,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.alibaba.fastjson2.JSONB.Constants.*;
 import static com.alibaba.fastjson2.reader.ObjectReaderImplMap.*;
 
 public class ObjectReaderImplMapMultiValueType
@@ -167,6 +170,95 @@ public class ObjectReaderImplMapMultiValueType
         }
 
         jsonReader.nextIfMatch(',');
+
+        if (builder != null) {
+            return builder.apply(object);
+        }
+
+        return object;
+    }
+
+    @Override
+    public Object readJSONBObject(JSONReader jsonReader, Type fieldType, Object fieldName1, long features) {
+        if (jsonReader.nextIfNull()) {
+            return null;
+        }
+
+        jsonReader.nextIfMatch(BC_OBJECT);
+
+        JSONReader.Context context = jsonReader.getContext();
+        long contextFeatures = context.getFeatures() | features;
+        Map object, innerMap = null;
+        if (instanceType == HashMap.class) {
+            Supplier<Map> objectSupplier = context.getObjectSupplier();
+            if (mapType == Map.class && objectSupplier != null) {
+                object = objectSupplier.get();
+                innerMap = TypeUtils.getInnerMap(object);
+            } else {
+                object = new HashMap<>();
+            }
+        } else if (instanceType == JSONObject.class) {
+            object = new JSONObject();
+        } else {
+            object = (Map) createInstance(contextFeatures);
+        }
+
+        for (int i = 0; ; i++) {
+            byte type = jsonReader.getType();
+            if (type == BC_OBJECT_END) {
+                jsonReader.next();
+                break;
+            }
+
+            Object name;
+            if (type >= BC_STR_ASCII_FIX_MIN) {
+                name = jsonReader.readFieldName();
+            } else if (jsonReader.nextIfMatch(BC_REFERENCE)) {
+                String reference = jsonReader.readString();
+                name = new ReferenceKey(i);
+                jsonReader.addResolveTask(object, name, JSONPath.of(reference));
+            } else {
+                name = jsonReader.readAny();
+            }
+
+            Type valueType = name instanceof String ? multiValueType.getType((String) name) : null;
+            Object value;
+            if (jsonReader.isReference()) {
+                String reference = jsonReader.readReference();
+                if ("..".equals(reference)) {
+                    value = object;
+                } else {
+                    value = null;
+                    jsonReader.addResolveTask(object, name, JSONPath.of(reference));
+                }
+            } else if (valueType == null) {
+                value = jsonReader.readAny();
+            } else {
+                ObjectReader valueObjectReader = jsonReader.getObjectReader(valueType);
+                value = valueObjectReader.readJSONBObject(jsonReader, valueType, name, 0);
+            }
+
+            if (value == null && (contextFeatures & JSONReader.Feature.IgnoreNullPropertyValue.mask) != 0) {
+                continue;
+            }
+
+            Object origin;
+            if (innerMap != null) {
+                origin = innerMap.put(name, value);
+            } else {
+                origin = object.put(name, value);
+            }
+
+            if (origin != null && (contextFeatures & JSONReader.Feature.DuplicateKeyValueAsArray.mask) != 0) {
+                if (origin instanceof Collection) {
+                    ((Collection) origin).add(value);
+                    object.put(name, origin);
+                } else {
+                    JSONArray array = JSONArray.of(origin, value);
+                    object.put(name, array);
+                }
+            }
+        }
 
         if (builder != null) {
             return builder.apply(object);

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7636.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7636.java
@@ -1,0 +1,80 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.annotation.JSONType;
+import com.alibaba.fastjson2.reader.ObjectReader;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7636 {
+    @Test
+    public void testCustomReaderForMapSubtypeField() {
+        Bean bean = JSON.parseObject("{\"entity\":{\"id\":123}}", Bean.class);
+
+        assertEquals(123, bean.entity.id);
+        assertEquals("custom", bean.entity.get("reader"));
+    }
+
+    @Test
+    public void testCustomReaderForMapSubtype() {
+        Entity entity = JSON.parseObject("{\"id\":123}", Entity.class);
+
+        assertEquals(123, entity.id);
+        assertEquals("custom", entity.get("reader"));
+    }
+
+    @Test
+    public void testMapSubtypeWithoutCustomReader() {
+        RawBean bean = JSON.parseObject("{\"entity\":{\"id\":123}}", RawBean.class);
+
+        assertEquals(0, bean.entity.id);
+        assertEquals(123, bean.entity.get("id"));
+    }
+
+    public static class Bean {
+        public Entity entity;
+    }
+
+    public static class RawBean {
+        public RawEntity entity;
+    }
+
+    @JSONType(deserializer = EntityReader.class)
+    public static class Entity
+            extends HashMap<String, Object> {
+        public int id;
+    }
+
+    public static class RawEntity
+            extends HashMap<String, Object> {
+        public int id;
+    }
+
+    public static class EntityReader
+            implements ObjectReader<Entity> {
+        @Override
+        public Entity readObject(JSONReader jsonReader, Type fieldType,
+                                 Object fieldName, long features) {
+            Entity entity = new Entity();
+            jsonReader.nextIfObjectStart();
+            for (; ; ) {
+                if (jsonReader.nextIfObjectEnd()) {
+                    break;
+                }
+                String name = jsonReader.readFieldName();
+                if ("id".equals(name)) {
+                    entity.id = jsonReader.readInt32Value();
+                } else {
+                    jsonReader.skipValue();
+                }
+            }
+            entity.put("reader", "custom");
+            return entity;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7636.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7636.java
@@ -56,6 +56,35 @@ public class Issue7636 {
     }
 
     @Test
+    public void testCustomReaderForListSubtypeFieldJSONB() {
+        byte[] bytes = JSONB.toBytes(JSON.parseObject("{\"items\":[\"a\",\"b\"]}"));
+        ListBean bean = JSONB.parseObject(bytes, ListBean.class);
+
+        assertEquals(2, bean.items.size());
+        assertEquals("a", bean.items.get(0));
+        assertEquals("b", bean.items.get(1));
+    }
+
+    @Test
+    public void testReadOnlyCustomReaderForMapSubtypeFieldJSONB() {
+        byte[] bytes = JSONB.toBytes(JSON.parseObject("{\"entity\":{\"id\":123}}"));
+        ReadOnlyBean bean = JSONB.parseObject(bytes, ReadOnlyBean.class);
+
+        assertEquals(0, bean.getEntity().id);
+        assertEquals(123, bean.getEntity().get("id"));
+    }
+
+    @Test
+    public void testReadOnlyCustomReaderForListSubtypeFieldJSONB() {
+        byte[] bytes = JSONB.toBytes(JSON.parseObject("{\"items\":[\"a\",\"b\"]}"));
+        ReadOnlyListBean bean = JSONB.parseObject(bytes, ReadOnlyListBean.class);
+
+        assertEquals(2, bean.getItems().size());
+        assertEquals("a", bean.getItems().get(0));
+        assertEquals("b", bean.getItems().get(1));
+    }
+
+    @Test
     public void testCustomReaderForListSubtype() {
         EntityList list = JSON.parseObject("[\"a\",\"b\"]", EntityList.class);
 
@@ -85,6 +114,22 @@ public class Issue7636 {
 
     public static class RawListBean {
         public RawEntityList items;
+    }
+
+    public static class ReadOnlyBean {
+        private final Entity entity = new Entity();
+
+        public Entity getEntity() {
+            return entity;
+        }
+    }
+
+    public static class ReadOnlyListBean {
+        private final EntityList items = new EntityList();
+
+        public EntityList getItems() {
+            return items;
+        }
     }
 
     @JSONType(deserializer = EntityReader.class)

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7636.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7636.java
@@ -1,12 +1,14 @@
 package com.alibaba.fastjson2.issues_7000;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.annotation.JSONType;
 import com.alibaba.fastjson2.reader.ObjectReader;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,12 +38,53 @@ public class Issue7636 {
         assertEquals(123, bean.entity.get("id"));
     }
 
+    @Test
+    public void testCustomReaderForMapSubtypeFieldJSONB() {
+        byte[] bytes = JSONB.toBytes(JSON.parseObject("{\"entity\":{\"id\":123}}"));
+        Bean bean = JSONB.parseObject(bytes, Bean.class);
+
+        assertEquals(0, bean.entity.id);
+        assertEquals(123, bean.entity.get("id"));
+    }
+
+    @Test
+    public void testCustomReaderForListSubtypeField() {
+        ListBean bean = JSON.parseObject("{\"items\":[\"a\",\"b\"]}", ListBean.class);
+
+        assertEquals(2, bean.items.count);
+        assertEquals("custom", bean.items.get(0));
+    }
+
+    @Test
+    public void testCustomReaderForListSubtype() {
+        EntityList list = JSON.parseObject("[\"a\",\"b\"]", EntityList.class);
+
+        assertEquals(2, list.count);
+        assertEquals("custom", list.get(0));
+    }
+
+    @Test
+    public void testListSubtypeWithoutCustomReader() {
+        RawListBean bean = JSON.parseObject("{\"items\":[\"a\",\"b\"]}", RawListBean.class);
+
+        assertEquals(2, bean.items.size());
+        assertEquals("a", bean.items.get(0));
+    }
+
     public static class Bean {
         public Entity entity;
     }
 
     public static class RawBean {
         public RawEntity entity;
+    }
+
+    public static class ListBean {
+        public EntityList items;
+    }
+
+    public static class RawListBean {
+        public RawEntityList items;
     }
 
     @JSONType(deserializer = EntityReader.class)
@@ -53,6 +96,16 @@ public class Issue7636 {
     public static class RawEntity
             extends HashMap<String, Object> {
         public int id;
+    }
+
+    @JSONType(deserializer = EntityListReader.class)
+    public static class EntityList
+            extends ArrayList<String> {
+        public int count;
+    }
+
+    public static class RawEntityList
+            extends ArrayList<String> {
     }
 
     public static class EntityReader
@@ -75,6 +128,26 @@ public class Issue7636 {
             }
             entity.put("reader", "custom");
             return entity;
+        }
+    }
+
+    public static class EntityListReader
+            implements ObjectReader<EntityList> {
+        @Override
+        public EntityList readObject(JSONReader jsonReader, Type fieldType,
+                                     Object fieldName, long features) {
+            EntityList list = new EntityList();
+            jsonReader.nextIfArrayStart();
+            for (; ; ) {
+                if (jsonReader.nextIfArrayEnd()) {
+                    break;
+                }
+                jsonReader.skipValue();
+                list.count++;
+                jsonReader.nextIfComma();
+            }
+            list.add("custom");
+            return list;
         }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/reader/FieldReaderObjectTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/FieldReaderObjectTest.java
@@ -1,8 +1,15 @@
 package com.alibaba.fastjson2.reader;
 
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.util.MapMultiValueType;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class FieldReaderObjectTest {
@@ -13,6 +20,25 @@ public class FieldReaderObjectTest {
         );
 
         assertFalse(FieldReaderObject.isCustomReader(objectReader));
+    }
+
+    @Test
+    public void testMapMultiValueTypeReaderJSONB() {
+        MapMultiValueType<JSONObject> type = MapMultiValueType.of("data", Bean.class);
+        ObjectReader objectReader = new ObjectReaderImplMapMultiValueType(type);
+        byte[] bytes = JSONB.toBytes(JSON.parseObject("{\"data\":{\"id\":123}}"));
+
+        Object value = FieldReaderObject.readJSONBObject(
+                objectReader,
+                JSONReader.ofJSONB(bytes),
+                type,
+                JSONObject.class,
+                "data",
+                0
+        );
+
+        Bean bean = (Bean) ((Map) value).get("data");
+        assertEquals(123, bean.id);
     }
 
     public static class Bean {

--- a/core/src/test/java/com/alibaba/fastjson2/reader/FieldReaderObjectTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/FieldReaderObjectTest.java
@@ -1,0 +1,21 @@
+package com.alibaba.fastjson2.reader;
+
+import com.alibaba.fastjson2.util.MapMultiValueType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class FieldReaderObjectTest {
+    @Test
+    public void testMapMultiValueTypeReaderIsBuiltIn() {
+        ObjectReader objectReader = new ObjectReaderImplMapMultiValueType(
+                MapMultiValueType.of("data", Bean.class)
+        );
+
+        assertFalse(FieldReaderObject.isCustomReader(objectReader));
+    }
+
+    public static class Bean {
+        public int id;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #7636.

When a class extends `Map` and declares `@JSONType(deserializer = ...)`, parsing it as a bean field was still handled by the default map reader. This skipped the custom `ObjectReader`.

### Summary of your change

- Let explicitly annotated custom deserializers bypass the base Map/Collection reader shortcut.
- Make object field reader prefer a provider-resolved custom reader before falling back to default Map/List readers.
- Add regression coverage for the field case, direct parse case, and an unannotated map subtype to keep the existing default behavior unchanged.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Docs impact: none, this preserves the documented custom deserializer behavior.

Tests:

- `mvn -pl core -Dtest=Issue7636 test -DskipITs -ntp`
- `mvn -pl core -Dtest=Issue7636,JSONType_deserializer,Issue1168,Issue2329,Issue2726 test -DskipITs -ntp`
- `mvn -pl core -Dfastjson2.creator=reflect -Dtest=Issue7636,JSONType_deserializer,Issue1168,Issue2329,Issue2726 test -DskipITs -ntp`