### PR TITLE
fix: support JSONCompiled records

### DIFF
--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/Analysis.java
@@ -174,6 +174,10 @@ public class Analysis {
                         name = BeanUtils.getterName(methodName, null);
                         getter = method;
                         type = method.getReturnType();
+                    } else if (info.record && parameters.isEmpty() && info.attributes.containsKey(methodName)) {
+                        name = methodName;
+                        getter = method;
+                        type = method.getReturnType();
                     } else if (methodName.startsWith("set") && method.getParameters().size() == 1) {
                         name = BeanUtils.setterName(methodName, null);
                         setter = method;

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
@@ -665,6 +665,7 @@ public class JSONCompiledAnnotationProcessor
         if (genericStart != -1) {
             fieldClass = fieldClass.substring(0, genericStart);
         }
+        JCTree.JCExpression fieldTypeRef = genTypeReference(fieldType);
         JCTree.JCExpression fieldClassRef = field(getFieldValueType(fieldClass), names._class);
         JCTree.JCFieldAccess beanClassRef = field(beanType, names._class);
         return method(
@@ -676,13 +677,48 @@ public class JSONCompiledAnnotationProcessor
                 literal(0),
                 literal(0L),
                 defNull(),
-                fieldClassRef,
+                fieldTypeRef,
                 fieldClassRef,
                 literal(attributeInfo.name),
                 beanClassRef,
                 defNull(),
                 defNull()
         );
+    }
+
+    private JCTree.JCExpression genTypeReference(String type) {
+        int genericStart = type.indexOf('<');
+        if (genericStart == -1) {
+            return field(getFieldValueType(type), names._class);
+        }
+
+        String rawType = type.substring(0, genericStart);
+        String typeArguments = type.substring(genericStart + 1, type.length() - 1);
+        ListBuffer<JCTree.JCExpression> args = new ListBuffer<>();
+        args.append(field(getFieldValueType(rawType), names._class));
+        for (String argument : splitTypeArguments(typeArguments)) {
+            args.append(genTypeReference(argument.trim()));
+        }
+        return method(qualIdent("com.alibaba.fastjson2.TypeReference"), "parametricType", args.toList());
+    }
+
+    private java.util.List<String> splitTypeArguments(String typeArguments) {
+        java.util.List<String> result = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < typeArguments.length(); i++) {
+            char ch = typeArguments.charAt(i);
+            if (ch == '<') {
+                depth++;
+            } else if (ch == '>') {
+                depth--;
+            } else if (ch == ',' && depth == 0) {
+                result.add(typeArguments.substring(start, i));
+                start = i + 1;
+            }
+        }
+        result.add(typeArguments.substring(start));
+        return result;
     }
 
     private JCTree.JCMethodInvocation genFieldReaderList(
@@ -3138,6 +3174,7 @@ public class JSONCompiledAnnotationProcessor
             if (referenceDetect) {
                 referenceDetect = isReference(itemType);
             }
+            JCTree.JCLabeledStatement itemLoopLabel = referenceDetect ? label("_list" + i) : null;
 
             JCTree.JCVariableDecl for_iVar;
             if ("i".equals(attributeInfo.name)) {
@@ -3183,7 +3220,7 @@ public class JSONCompiledAnnotationProcessor
                 );
                 isReferenceStmts.append(exec(addResolveTaskMethod));
                 isReferenceStmts.append(exec(method(fieldValueVar, "add", defNull())));
-                isReferenceStmts.append(defContinue(loopLabel));
+                isReferenceStmts.append(defContinue(itemLoopLabel));
                 whileStmts.append(defIf(method(jsonReaderIdent, "isReference"), block(isReferenceStmts.toList())));
                 whileStmts.append(listItemVar);
                 item = ident(listItemVar);
@@ -3192,25 +3229,32 @@ public class JSONCompiledAnnotationProcessor
             whileStmts.append(exec(method(fieldValueVar, "add", item)));
 
             ListBuffer<JCTree.JCStatement> condStmts = new ListBuffer<>();
+            JCTree.JCStatement itemLoop;
             if (isJsonb) {
                 JCTree.JCVariableDecl itemCntVar = defVar(attributeInfo.name + "_item_cnt", TypeTag.INT, method(jsonReaderIdent, "startArray"));
-                condStmts.append(forLoop(
+                itemLoop = forLoop(
                         List.of(for_iVar, itemCntVar),
                         lt(ident(for_iVar), ident(itemCntVar)),
                         List.of(exec(unary(JCTree.Tag.PREINC, ident(for_iVar)))),
-                        block(whileStmts.toList())));
+                        block(whileStmts.toList()));
             } else if (referenceDetect) {
-                condStmts.append(forLoop(
+                itemLoop = forLoop(
                         List.of(for_iVar),
                         unary(JCTree.Tag.NOT, nextIfArrayEndMethod),
                         List.of(exec(unary(JCTree.Tag.PREINC, ident(for_iVar)))),
-                        block(whileStmts.toList())));
+                        block(whileStmts.toList()));
             } else {
-                condStmts.append(whileLoop(unary(JCTree.Tag.NOT, nextIfArrayEndMethod), block(whileStmts.toList())));
+                itemLoop = whileLoop(unary(JCTree.Tag.NOT, nextIfArrayEndMethod), block(whileStmts.toList()));
+            }
+            if (itemLoopLabel != null) {
+                itemLoopLabel.body = itemLoop;
+                condStmts.append(itemLoopLabel);
+            } else {
+                condStmts.append(itemLoop);
             }
 
             if (isJsonb) {
-                stmts.appendList(condStmts.toList());
+                stmts.append(defIf(ne(fieldValueVar, defNull()), block(condStmts.toList())));
             } else {
                 stmts.append(defIf(nextIfArrayStartMethod, block(condStmts.toList())));
             }

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
@@ -138,9 +138,10 @@ public class JSONCompiledAnnotationProcessor
                         innerReadClass.defs = innerReadClass.defs.append(genReadConstructor(beanType, beanNew, attributeInfos, readSuperClass, generatedFields, record));
 
                         // generate createInstance
-                        if (!record) {
-                            innerReadClass.defs = innerReadClass.defs.append(genCreateInstance(objectType, beanNew));
-                        }
+                        innerReadClass.defs = innerReadClass.defs.append(
+                                record
+                                        ? genCreateRecordInstance(objectType, beanType, attributeInfos)
+                                        : genCreateInstance(objectType, beanNew));
 
                         // generate readObject
                         innerReadClass.defs = innerReadClass.defs.append(
@@ -311,7 +312,7 @@ public class JSONCompiledAnnotationProcessor
         int fieldsSize = fields.size();
         for (int i = 0; i < fieldsSize; ++i) {
             JCTree.JCMethodInvocation readerMethod = record
-                    ? genRecordFieldReader(fields.get(i), objectReadersType)
+                    ? genRecordFieldReader(beanType, fields.get(i))
                     : genFieldReader(beanType, fields.get(i), objectReadersType);
             if (readerMethod != null) {
                 fieldReaders.append(readerMethod);
@@ -655,8 +656,8 @@ public class JSONCompiledAnnotationProcessor
     }
 
     private JCTree.JCMethodInvocation genRecordFieldReader(
-            AttributeInfo attributeInfo,
-            JCTree.JCExpression objectReadersType
+            JCTree.JCExpression beanType,
+            AttributeInfo attributeInfo
     ) {
         String fieldType = attributeInfo.type.toString();
         String fieldClass = fieldType;
@@ -664,11 +665,23 @@ public class JSONCompiledAnnotationProcessor
         if (genericStart != -1) {
             fieldClass = fieldClass.substring(0, genericStart);
         }
+        JCTree.JCExpression fieldClassRef = field(getFieldValueType(fieldClass), names._class);
+        JCTree.JCFieldAccess beanClassRef = field(beanType, names._class);
         return method(
-                objectReadersType,
-                "fieldReader",
+                field(qualIdent("com.alibaba.fastjson2.reader.ObjectReaderCreator"), "INSTANCE"),
+                "createFieldReaderParam",
+                beanClassRef,
+                beanClassRef,
                 literal(attributeInfo.name),
-                field(getFieldValueType(fieldClass), names._class)
+                literal(0),
+                literal(0L),
+                defNull(),
+                fieldClassRef,
+                fieldClassRef,
+                literal(attributeInfo.name),
+                beanClassRef,
+                defNull(),
+                defNull()
         );
     }
 
@@ -797,6 +810,25 @@ public class JSONCompiledAnnotationProcessor
     private JCTree.JCMethodDecl genCreateInstance(JCTree.JCIdent objectType, JCTree.JCNewClass beanNew) {
         JCTree.JCVariableDecl featuresVar = defVar("features", TypeTag.LONG);
         return defMethod(Flags.PUBLIC, "createInstance", objectType, List.of(featuresVar), block(defReturn(beanNew)));
+    }
+
+    private JCTree.JCMethodDecl genCreateRecordInstance(
+            JCTree.JCIdent objectType,
+            JCTree.JCExpression beanType,
+            java.util.List<AttributeInfo> attributeInfos
+    ) {
+        JCTree.JCVariableDecl featuresVar = defVar("features", TypeTag.LONG);
+        ListBuffer<JCTree.JCExpression> args = new ListBuffer<>();
+        for (AttributeInfo attributeInfo : attributeInfos) {
+            args.append(defaultValue(attributeInfo.type.toString()));
+        }
+        return defMethod(
+                Flags.PUBLIC,
+                "createInstance",
+                objectType,
+                List.of(featuresVar),
+                block(defReturn(newClass(null, null, beanType, args.toList(), null)))
+        );
     }
 
     private JCTree.JCMethodDecl genReadObject(
@@ -1112,7 +1144,16 @@ public class JSONCompiledAnnotationProcessor
                         beanType,
                         isJsonb);
             } else if (type.startsWith("java.util.Map<java.lang.String,")) {
-                valueExpr = genFieldValueMap(type, attributeInfo, jsonReaderIdent, fieldValueVar, loopLabel, stmts, i, false, isJsonb);
+                valueExpr = genFieldValueMap(
+                        type,
+                        attributeInfo,
+                        jsonReaderIdent,
+                        fieldValueVar,
+                        loopLabel,
+                        stmts,
+                        i,
+                        structInfo.referenceDetect && isReference(type),
+                        isJsonb);
             }
 
             if (valueExpr == null) {
@@ -3151,7 +3192,14 @@ public class JSONCompiledAnnotationProcessor
             whileStmts.append(exec(method(fieldValueVar, "add", item)));
 
             ListBuffer<JCTree.JCStatement> condStmts = new ListBuffer<>();
-            if (referenceDetect) {
+            if (isJsonb) {
+                JCTree.JCVariableDecl itemCntVar = defVar(attributeInfo.name + "_item_cnt", TypeTag.INT, method(jsonReaderIdent, "startArray"));
+                condStmts.append(forLoop(
+                        List.of(for_iVar, itemCntVar),
+                        lt(ident(for_iVar), ident(itemCntVar)),
+                        List.of(exec(unary(JCTree.Tag.PREINC, ident(for_iVar)))),
+                        block(whileStmts.toList())));
+            } else if (referenceDetect) {
                 condStmts.append(forLoop(
                         List.of(for_iVar),
                         unary(JCTree.Tag.NOT, nextIfArrayEndMethod),
@@ -3161,7 +3209,11 @@ public class JSONCompiledAnnotationProcessor
                 condStmts.append(whileLoop(unary(JCTree.Tag.NOT, nextIfArrayEndMethod), block(whileStmts.toList())));
             }
 
-            stmts.append(defIf(nextIfArrayStartMethod, block(condStmts.toList())));
+            if (isJsonb) {
+                stmts.appendList(condStmts.toList());
+            } else {
+                stmts.append(defIf(nextIfArrayStartMethod, block(condStmts.toList())));
+            }
             return ident(fieldValueVar.name);
         }
         return null;
@@ -3258,7 +3310,9 @@ public class JSONCompiledAnnotationProcessor
 
         elseStmts.append(whileLoop(unary(JCTree.Tag.NOT, nextIfObjectEndMethod), block(whileStmts.toList())));
 
-        elseStmts.append(exec(method(jsonReaderIdent, "nextIfComma")));
+        if (!isJsonb) {
+            elseStmts.append(exec(method(jsonReaderIdent, "nextIfComma")));
+        }
 
         stmts.append(defIf(nextIfNullMethod,
                 block(exec(assign(fieldValueVar, defNull()))),

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/JSONCompiledAnnotationProcessor.java
@@ -91,6 +91,7 @@ public class JSONCompiledAnnotationProcessor
             StructInfo structInfo = structs.get(element.toString());
             java.util.List<AttributeInfo> attributeInfos = structInfo.getReaderAttributes();
             int fieldsSize = attributeInfos.size();
+            boolean record = structInfo.record;
             Class readSuperClass = getReadSuperClass(fieldsSize);
             Class writeSuperClass = getWriteSuperClass(fieldsSize);
 
@@ -134,18 +135,24 @@ public class JSONCompiledAnnotationProcessor
                         }
 
                         // generate constructor
-                        innerReadClass.defs = innerReadClass.defs.append(genReadConstructor(beanType, beanNew, attributeInfos, readSuperClass, generatedFields));
+                        innerReadClass.defs = innerReadClass.defs.append(genReadConstructor(beanType, beanNew, attributeInfos, readSuperClass, generatedFields, record));
 
                         // generate createInstance
-                        innerReadClass.defs = innerReadClass.defs.append(genCreateInstance(objectType, beanNew));
+                        if (!record) {
+                            innerReadClass.defs = innerReadClass.defs.append(genCreateInstance(objectType, beanNew));
+                        }
 
                         // generate readObject
                         innerReadClass.defs = innerReadClass.defs.append(
-                                genReadObject(objectType, beanType, beanNew, attributeInfos, structInfo, false));
+                                record
+                                        ? genReadRecordObject(objectType, beanType, attributeInfos, structInfo, false)
+                                        : genReadObject(objectType, beanType, beanNew, attributeInfos, structInfo, false));
 
                         // generate readJSONBObject
                         innerReadClass.defs = innerReadClass.defs.append(
-                                genReadObject(objectType, beanType, beanNew, attributeInfos, structInfo, true));
+                                record
+                                        ? genReadRecordObject(objectType, beanType, attributeInfos, structInfo, true)
+                                        : genReadObject(objectType, beanType, beanNew, attributeInfos, structInfo, true));
 
                         // link with inner class
                         beanClassDecl.defs = beanClassDecl.defs.append(innerReadClass);
@@ -295,14 +302,17 @@ public class JSONCompiledAnnotationProcessor
             JCTree.JCNewClass beanNew,
             java.util.List<AttributeInfo> fields,
             Class superClass,
-            boolean generatedFields) {
-        JCTree.JCMemberReference lambda = constructorRef(beanType);
+            boolean generatedFields,
+            boolean record) {
+        JCTree.JCExpression creator = record ? defNull() : constructorRef(beanType);
         JCTree.JCExpression fieldReaderType = qualIdent(FieldReader.class.getName());
         ListBuffer<JCTree.JCMethodInvocation> fieldReaders = new ListBuffer<>();
         JCTree.JCExpression objectReadersType = qualIdent(ObjectReaders.class.getName());
         int fieldsSize = fields.size();
         for (int i = 0; i < fieldsSize; ++i) {
-            JCTree.JCMethodInvocation readerMethod = genFieldReader(beanType, fields.get(i), objectReadersType);
+            JCTree.JCMethodInvocation readerMethod = record
+                    ? genRecordFieldReader(fields.get(i), objectReadersType)
+                    : genFieldReader(beanType, fields.get(i), objectReadersType);
             if (readerMethod != null) {
                 fieldReaders.append(readerMethod);
             }
@@ -316,7 +326,7 @@ public class JSONCompiledAnnotationProcessor
                         defNull(),
                         defNull(),
                         literal(features),
-                        lambda,
+                        creator,
                         defNull(),
                         fieldReadersArray
                 )
@@ -644,6 +654,24 @@ public class JSONCompiledAnnotationProcessor
         return readerMethod;
     }
 
+    private JCTree.JCMethodInvocation genRecordFieldReader(
+            AttributeInfo attributeInfo,
+            JCTree.JCExpression objectReadersType
+    ) {
+        String fieldType = attributeInfo.type.toString();
+        String fieldClass = fieldType;
+        int genericStart = fieldClass.indexOf('<');
+        if (genericStart != -1) {
+            fieldClass = fieldClass.substring(0, genericStart);
+        }
+        return method(
+                objectReadersType,
+                "fieldReader",
+                literal(attributeInfo.name),
+                field(getFieldValueType(fieldClass), names._class)
+        );
+    }
+
     private JCTree.JCMethodInvocation genFieldReaderList(
             JCTree.JCExpression objectReadersType,
             String fieldType,
@@ -963,6 +991,182 @@ public class JSONCompiledAnnotationProcessor
                 List.of(jsonReaderVar, fieldTypeVar, fieldNameVar, featuresVar),
                 block(readObjectBody.toList())
         );
+    }
+
+    private JCTree.JCMethodDecl genReadRecordObject(
+            JCTree.JCIdent objectType,
+            JCTree.JCExpression beanType,
+            java.util.List<AttributeInfo> attributeInfos,
+            StructInfo structInfo,
+            boolean isJsonb
+    ) {
+        JCTree.JCVariableDecl jsonReaderVar = defVar("jsonReader", qualIdent(JSONReader.class.getName()));
+        JCTree.JCIdent jsonReaderIdent = ident(jsonReaderVar);
+        JCTree.JCVariableDecl fieldTypeVar = defVar("fieldType", qualIdent(Type.class.getName()));
+        JCTree.JCVariableDecl fieldNameVar = defVar("fieldName", objectType);
+        JCTree.JCVariableDecl featuresVar = defVar("features", TypeTag.LONG);
+
+        ListBuffer<JCTree.JCStatement> readObjectBody = new ListBuffer<>();
+        readObjectBody.append(defIf(method(jsonReaderIdent, "nextIfNull"), defReturn(defNull())));
+        readObjectBody.append(exec(method(jsonReaderIdent, "nextIfObjectStart")));
+
+        JCTree.JCVariableDecl features2Var = defVar(
+                Flags.PARAMETER,
+                "features2",
+                TypeTag.LONG,
+                bitOr(
+                        ident("features"),
+                        field(ident(names._this), "features")
+                )
+        );
+        readObjectBody.append(features2Var);
+
+        for (AttributeInfo attributeInfo : attributeInfos) {
+            readObjectBody.append(defVar(
+                    recordFieldVar(attributeInfo),
+                    getFieldValueType(attributeInfo.type.toString()),
+                    defaultValue(attributeInfo.type.toString())
+            ));
+        }
+
+        JCTree.JCLabeledStatement loopLabel = label("_while");
+        JCTree.JCWhileLoop loopHead = whileLoop(unary(JCTree.Tag.NOT, method(jsonReaderIdent, "nextIfObjectEnd")), null);
+        ListBuffer<JCTree.JCStatement> loopBody = new ListBuffer<>();
+
+        JCTree.JCFieldAccess readFieldNameHashCode = field(jsonReaderIdent, "readFieldNameHashCode");
+        JCTree.JCVariableDecl hashCode64Var = defVar("hashCode64", TypeTag.LONG, method(readFieldNameHashCode));
+        JCTree.JCExpression hashCode64 = ident(hashCode64Var);
+        loopBody.append(hashCode64Var);
+
+        for (int i = 0; i < attributeInfos.size(); ++i) {
+            AttributeInfo attributeInfo = attributeInfos.get(i);
+            loopBody.append(defIf(
+                    eq(hashCode64, attributeInfo.nameHashCode),
+                    block(genReadRecordFieldValue(
+                            attributeInfo,
+                            jsonReaderIdent,
+                            i,
+                            structInfo,
+                            loopLabel,
+                            beanType,
+                            isJsonb))
+            ));
+        }
+
+        loopBody.append(exec(method(jsonReaderIdent, "skipValue")));
+        loopHead.body = block(loopBody.toList());
+        loopLabel.body = loopHead;
+        readObjectBody.append(loopLabel);
+
+        if (!isJsonb) {
+            readObjectBody.append(exec(method(jsonReaderIdent, "nextIfComma")));
+        }
+
+        ListBuffer<JCTree.JCExpression> args = new ListBuffer<>();
+        for (AttributeInfo attributeInfo : attributeInfos) {
+            args.append(ident(recordFieldVar(attributeInfo)));
+        }
+        readObjectBody.append(defReturn(newClass(null, null, beanType, args.toList(), null)));
+
+        return defMethod(
+                Flags.PUBLIC,
+                isJsonb ? "readJSONBObject" : "readObject",
+                objectType,
+                List.of(jsonReaderVar, fieldTypeVar, fieldNameVar, featuresVar),
+                block(readObjectBody.toList())
+        );
+    }
+
+    private List<JCTree.JCStatement> genReadRecordFieldValue(
+            AttributeInfo attributeInfo,
+            JCTree.JCIdent jsonReaderIdent,
+            int i,
+            StructInfo structInfo,
+            JCTree.JCLabeledStatement loopLabel,
+            JCTree.JCExpression beanType,
+            boolean isJsonb) {
+        JCTree.JCExpression valueExpr = null;
+        ListBuffer<JCTree.JCStatement> stmts = new ListBuffer<>();
+        String type = attributeInfo.type.toString();
+
+        JCTree.JCFieldAccess fieldReaderField = field(ident(names._this), fieldReader(i));
+        String readDirectMethod = getReadDirectMethod(type);
+        if (readDirectMethod != null) {
+            valueExpr = method(jsonReaderIdent, readDirectMethod);
+        } else {
+            JCTree.JCExpression fieldValueType = getFieldValueType(type);
+            JCTree.JCVariableDecl fieldValueVar = defVar(recordValueVar(attributeInfo), fieldValueType);
+            stmts.append(fieldValueVar);
+
+            if (type.startsWith("java.util.List<")) {
+                valueExpr = genFieldValueList(
+                        type,
+                        attributeInfo,
+                        jsonReaderIdent,
+                        fieldValueVar,
+                        loopLabel,
+                        stmts,
+                        i,
+                        structInfo.referenceDetect && isReference(type),
+                        fieldReaderField,
+                        beanType,
+                        isJsonb);
+            } else if (type.startsWith("java.util.Map<java.lang.String,")) {
+                valueExpr = genFieldValueMap(type, attributeInfo, jsonReaderIdent, fieldValueVar, loopLabel, stmts, i, false, isJsonb);
+            }
+
+            if (valueExpr == null) {
+                JCTree.JCIdent objectReaderIdent = ident(fieldObjectReader(i));
+                JCTree.JCMethodInvocation getObjectReaderMethod = method(fieldReaderField, "getObjectReader", jsonReaderIdent);
+                JCTree.JCAssign objectReaderAssign = assign(objectReaderIdent, getObjectReaderMethod);
+                stmts.append(defIf(eq(objectReaderIdent, defNull()), block(exec(objectReaderAssign))));
+                JCTree.JCMethodInvocation objectMethod = method(
+                        field(ident(names._this), fieldObjectReader(i)),
+                        isJsonb ? "readJSONBObject" : "readObject",
+                        jsonReaderIdent,
+                        field(fieldReaderField, "fieldType"),
+                        literal(attributeInfo.name),
+                        literal(0L)
+                );
+                stmts.append(exec(assign(fieldValueVar, cast(fieldValueType, objectMethod))));
+                valueExpr = ident(fieldValueVar);
+            }
+        }
+
+        stmts.append(exec(assign(ident(recordFieldVar(attributeInfo)), valueExpr)));
+        stmts.append(defContinue(loopLabel));
+        return stmts.toList();
+    }
+
+    private String recordFieldVar(AttributeInfo attributeInfo) {
+        return "_" + attributeInfo.name;
+    }
+
+    private String recordValueVar(AttributeInfo attributeInfo) {
+        return recordFieldVar(attributeInfo) + "_value";
+    }
+
+    private JCTree.JCExpression defaultValue(String type) {
+        switch (type) {
+            case "boolean":
+                return literal(false);
+            case "byte":
+                return literal((byte) 0);
+            case "short":
+                return literal(TypeTag.SHORT, 0);
+            case "int":
+                return literal(0);
+            case "long":
+                return literal(0L);
+            case "char":
+                return literal(TypeTag.CHAR, 0);
+            case "float":
+                return literal(TypeTag.FLOAT, 0F);
+            case "double":
+                return literal(TypeTag.DOUBLE, 0D);
+            default:
+                return defNull();
+        }
     }
 
     private JCTree.JCMethodDecl genWrite(
@@ -3169,7 +3373,7 @@ public class JSONCompiledAnnotationProcessor
         if (type.contains("<")) {
             return collectionIdent(type);
         }
-        return qualIdent(type);
+        return identType(type);
     }
 
     private String findConverterName(StructInfo structInfo, String suffix) {

--- a/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/StructInfo.java
+++ b/codegen/src/main/java/com/alibaba/fastjson2/internal/processor/StructInfo.java
@@ -16,6 +16,7 @@ public class StructInfo {
     final boolean disableJSONB;
     final boolean disableAutoType;
     final boolean disableArrayMapping;
+    final boolean record;
 
     String typeKey;
     int readerFeatures;
@@ -38,6 +39,7 @@ public class StructInfo {
         this.binaryName = binaryName;
 
         this.modifiers = Analysis.getModifiers(element.getModifiers());
+        this.record = "RECORD".equals(element.getKind().name());
 
         AnnotationMirror jsonType = null;
         for (AnnotationMirror mirror : element.getAnnotationMirrors()) {
@@ -122,6 +124,13 @@ public class StructInfo {
     }
 
     public List<AttributeInfo> getReaderAttributes() {
+        if (record) {
+            return attributes.values()
+                    .stream()
+                    .filter(AttributeInfo::supportSet)
+                    .collect(Collectors.toList());
+        }
+
         return attributes.values()
                 .stream()
                 .filter(AttributeInfo::supportSet)

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/JSONCompiledRecordTest.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/JSONCompiledRecordTest.java
@@ -1,9 +1,14 @@
 package com.alibaba.fastjson2.internal.processor;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.reader.ObjectReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
@@ -14,6 +19,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class JSONCompiledRecordTest {
     @TempDir
@@ -21,22 +28,80 @@ public class JSONCompiledRecordTest {
 
     @Test
     public void record() throws Exception {
-        Path sourceDir = tempDir.resolve("src");
-        Path classesDir = tempDir.resolve("classes");
-        Files.createDirectories(sourceDir);
-        Files.createDirectories(classesDir);
-
-        Path source = sourceDir.resolve("Person.java");
-        Files.write(source, Arrays.asList(
+        try (CompiledClass compiled = compile("Person",
                 "import com.alibaba.fastjson2.annotation.JSONCompiled;",
                 "",
                 "@JSONCompiled",
                 "public record Person(int id, String name) {",
                 "}"
-        ), StandardCharsets.UTF_8);
+        )) {
+            Class<?> personClass = compiled.clazz;
+            Object person = JSON.parseObject("{\"name\":\"DataWorks\",\"id\":101}", personClass);
+            assertEquals(101, personClass.getMethod("id").invoke(person));
+            assertEquals("DataWorks", personClass.getMethod("name").invoke(person));
+        }
+    }
+
+    @Test
+    public void recordCreateInstanceUsesDefaultValues() throws Exception {
+        try (CompiledClass compiled = compile("Person",
+                "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                "",
+                "@JSONCompiled",
+                "public record Person(int id, String name, boolean active, long score) {",
+                "}"
+        )) {
+            Class<?> personClass = compiled.clazz;
+            ObjectReader<?> objectReader = JSONFactory.getDefaultObjectReaderProvider().getObjectReader(personClass);
+            Object person = objectReader.createInstance(0L);
+            assertEquals(0, personClass.getMethod("id").invoke(person));
+            assertNull(personClass.getMethod("name").invoke(person));
+            assertEquals(false, personClass.getMethod("active").invoke(person));
+            assertEquals(0L, personClass.getMethod("score").invoke(person));
+        }
+    }
+
+    @Test
+    public void recordJsonbSerializationAndCollections() throws Exception {
+        try (CompiledClass compiled = compile("Person",
+                "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                "import java.util.List;",
+                "import java.util.Map;",
+                "",
+                "@JSONCompiled",
+                "public record Person(int id, String name, List<String> tags, Map<String, Integer> scores) {",
+                "}"
+        )) {
+            Class<?> personClass = compiled.clazz;
+            Object person = JSON.parseObject(
+                    "{\"id\":7,\"name\":\"Flink\",\"tags\":[\"stream\",\"sql\"],\"scores\":{\"core\":99}}",
+                    personClass
+            );
+            assertEquals("{\"id\":7,\"name\":\"Flink\",\"tags\":[\"stream\",\"sql\"],\"scores\":{\"core\":99}}",
+                    JSON.toJSONString(person));
+
+            byte[] jsonbBytes = JSONB.toBytes(person);
+            Object jsonbPerson = JSONB.parseObject(jsonbBytes, personClass);
+            assertEquals(7, personClass.getMethod("id").invoke(jsonbPerson));
+            assertEquals("Flink", personClass.getMethod("name").invoke(jsonbPerson));
+            assertEquals(Arrays.asList("stream", "sql"), personClass.getMethod("tags").invoke(jsonbPerson));
+            assertEquals(Integer.valueOf(99), ((java.util.Map<?, ?>) personClass.getMethod("scores").invoke(jsonbPerson)).get("core"));
+        }
+    }
+
+    private CompiledClass compile(String className, String... sourceLines) throws Exception {
+        assumeTrue(isJdk17OrLater());
+
+        Path sourceDir = tempDir.resolve(className + "-src-" + System.nanoTime());
+        Path classesDir = tempDir.resolve(className + "-classes-" + System.nanoTime());
+        Files.createDirectories(sourceDir);
+        Files.createDirectories(classesDir);
+
+        Path source = sourceDir.resolve(className + ".java");
+        Files.write(source, Arrays.asList(sourceLines), StandardCharsets.UTF_8);
 
         List<String> command = new ArrayList<>();
-        command.add(Path.of(System.getProperty("java.home"), "bin", "javac").toString());
+        command.add(javacExecutable());
         command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED");
         command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED");
         command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED");
@@ -57,19 +122,64 @@ public class JSONCompiledRecordTest {
         command.add(classesDir.toString());
         command.add(source.toString());
 
+        ProcessResult result = run(command);
+        assertEquals(0, result.exitCode, result.output);
+
+        URLClassLoader classLoader = new URLClassLoader(
+                new URL[]{classesDir.toUri().toURL()},
+                Thread.currentThread().getContextClassLoader()
+        );
+        return new CompiledClass(classLoader, Class.forName(className, true, classLoader));
+    }
+
+    private static boolean isJdk17OrLater() {
+        String version = System.getProperty("java.specification.version");
+        if (version.startsWith("1.")) {
+            version = version.substring(2);
+        }
+        return Integer.parseInt(version) >= 17;
+    }
+
+    private static String javacExecutable() {
+        return new File(new File(System.getProperty("java.home"), "bin"), "javac").toString();
+    }
+
+    private static ProcessResult run(List<String> command) throws Exception {
         Process process = new ProcessBuilder(command)
                 .redirectErrorStream(true)
                 .start();
-        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
-        assertEquals(0, process.waitFor(), output);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[4096];
+        int n;
+        while ((n = process.getInputStream().read(buffer)) != -1) {
+            baos.write(buffer, 0, n);
+        }
+        return new ProcessResult(process.waitFor(), baos.toString(StandardCharsets.UTF_8.name()));
+    }
 
-        try (URLClassLoader classLoader = new URLClassLoader(
-                new URL[]{classesDir.toUri().toURL()},
-                Thread.currentThread().getContextClassLoader())) {
-            Class<?> personClass = Class.forName("Person", true, classLoader);
-            Object person = JSON.parseObject("{\"name\":\"DataWorks\",\"id\":101}", personClass);
-            assertEquals(101, personClass.getMethod("id").invoke(person));
-            assertEquals("DataWorks", personClass.getMethod("name").invoke(person));
+    private static final class CompiledClass
+            implements AutoCloseable {
+        private final URLClassLoader classLoader;
+        private final Class<?> clazz;
+
+        private CompiledClass(URLClassLoader classLoader, Class<?> clazz) {
+            this.classLoader = classLoader;
+            this.clazz = clazz;
+        }
+
+        @Override
+        public void close() throws Exception {
+            classLoader.close();
+        }
+    }
+
+    private static final class ProcessResult {
+        private final int exitCode;
+        private final String output;
+
+        private ProcessResult(int exitCode, String output) {
+            this.exitCode = exitCode;
+            this.output = output;
         }
     }
 }

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/JSONCompiledRecordTest.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/JSONCompiledRecordTest.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson2.internal.processor;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.reader.ObjectReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -20,6 +21,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class JSONCompiledRecordTest {
@@ -86,6 +88,54 @@ public class JSONCompiledRecordTest {
             assertEquals("Flink", personClass.getMethod("name").invoke(jsonbPerson));
             assertEquals(Arrays.asList("stream", "sql"), personClass.getMethod("tags").invoke(jsonbPerson));
             assertEquals(Integer.valueOf(99), ((java.util.Map<?, ?>) personClass.getMethod("scores").invoke(jsonbPerson)).get("core"));
+        }
+    }
+
+    @Test
+    public void recordJsonbNullListFieldDoesNotCorruptFollowingFields() throws Exception {
+        try (CompiledClass compiled = compile("Person",
+                "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                "import java.util.List;",
+                "",
+                "@JSONCompiled",
+                "public record Person(int id, List<String> tags, String name) {",
+                "}"
+        )) {
+            Class<?> personClass = compiled.clazz;
+            byte[] jsonbBytes = JSONB.toBytes(
+                    JSON.parseObject("{\"id\":7,\"tags\":null,\"name\":\"Flink\"}"),
+                    JSONWriter.Feature.WriteNulls
+            );
+            Object person = JSONB.parseObject(jsonbBytes, personClass);
+
+            assertEquals(7, personClass.getMethod("id").invoke(person));
+            assertNull(personClass.getMethod("tags").invoke(person));
+            assertEquals("Flink", personClass.getMethod("name").invoke(person));
+        }
+    }
+
+    @Test
+    public void recordListFieldResolvesReferences() throws Exception {
+        try (CompiledClass compiled = compile("Person",
+                "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                "import java.util.List;",
+                "",
+                "@JSONCompiled",
+                "public record Person(List<Item> first, List<Item> second) {",
+                "    public record Item(String name) {",
+                "    }",
+                "}"
+        )) {
+            Class<?> personClass = compiled.clazz;
+            Object person = JSON.parseObject(
+                    "{\"first\":[{\"name\":\"Flink\"}],\"second\":[{\"$ref\":\"$.first[0]\"}]}",
+                    personClass
+            );
+
+            List<?> first = (List<?>) personClass.getMethod("first").invoke(person);
+            List<?> second = (List<?>) personClass.getMethod("second").invoke(person);
+            assertEquals("Flink", first.get(0).getClass().getMethod("name").invoke(first.get(0)));
+            assertSame(first.get(0), second.get(0));
         }
     }
 

--- a/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/JSONCompiledRecordTest.java
+++ b/codegen/src/test/java/com/alibaba/fastjson2/internal/processor/JSONCompiledRecordTest.java
@@ -1,0 +1,75 @@
+package com.alibaba.fastjson2.internal.processor;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONCompiledRecordTest {
+    @TempDir
+    public Path tempDir;
+
+    @Test
+    public void record() throws Exception {
+        Path sourceDir = tempDir.resolve("src");
+        Path classesDir = tempDir.resolve("classes");
+        Files.createDirectories(sourceDir);
+        Files.createDirectories(classesDir);
+
+        Path source = sourceDir.resolve("Person.java");
+        Files.write(source, Arrays.asList(
+                "import com.alibaba.fastjson2.annotation.JSONCompiled;",
+                "",
+                "@JSONCompiled",
+                "public record Person(int id, String name) {",
+                "}"
+        ), StandardCharsets.UTF_8);
+
+        List<String> command = new ArrayList<>();
+        command.add(Path.of(System.getProperty("java.home"), "bin", "javac").toString());
+        command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED");
+        command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED");
+        command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED");
+        command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED");
+        command.add("-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED");
+        command.add("-J--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED");
+        command.add("-cp");
+        command.add(System.getProperty("java.class.path"));
+        command.add("-processor");
+        command.add(JSONCompiledAnnotationProcessor.class.getName());
+        command.add("-source");
+        command.add("17");
+        command.add("-target");
+        command.add("17");
+        command.add("-d");
+        command.add(classesDir.toString());
+        command.add("-s");
+        command.add(classesDir.toString());
+        command.add(source.toString());
+
+        Process process = new ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertEquals(0, process.waitFor(), output);
+
+        try (URLClassLoader classLoader = new URLClassLoader(
+                new URL[]{classesDir.toUri().toURL()},
+                Thread.currentThread().getContextClassLoader())) {
+            Class<?> personClass = Class.forName("Person", true, classLoader);
+            Object person = JSON.parseObject("{\"name\":\"DataWorks\",\"id\":101}", personClass);
+            assertEquals(101, personClass.getMethod("id").invoke(person));
+            assertEquals("DataWorks", personClass.getMethod("name").invoke(person));
+        }
+    }
+}


### PR DESCRIPTION
### What changed

This fixes `@JSONCompiled` on Java records. The generated reader path used to create a default instance and assign field values afterwards, which does not work for record components because the backing fields are final.

For records, the generated reader now collects component values into local variables and returns a new record instance through the canonical constructor. The normal bean path is unchanged.

### Details

- keep record reader attributes in declaration order so constructor arguments match record component order
- avoid generating field-writer lambdas that assign into final record fields
- skip the no-arg `createInstance()` override for records
- generate record-specific `readObject` / `readJSONBObject` methods that construct the record after field parsing
- reuse primitive-aware type generation for generated field class references

### Tests

```bash
./mvnw -s /tmp/fastjson2-empty-settings.xml -Penable-codegen -pl codegen -am -Dtest=JSONCompiledRecordTest -Dsurefire.failIfNoSpecifiedTests=false test
./mvnw -s /tmp/fastjson2-empty-settings.xml -pl core -DskipTests install
./mvnw -s /tmp/fastjson2-empty-settings.xml -N install
cd codegen && ../mvnw -s /tmp/fastjson2-empty-settings.xml test
```

The regression test compiles a `@JSONCompiled` record with `javac`, then loads it and verifies `JSON.parseObject` can construct the record values.

Fixes #7659
