### PR TITLE
fix: preserve runtime subtype fields in JSON.toJSON, for issue #7655

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
@@ -611,7 +611,17 @@ public class ObjectWriterAdapter<T>
     }
 
     public JSONObject toJSONObject(T object, long features) {
+        return toJSONObject(object, features, new IdentityHashMap<Object, JSONObject>());
+    }
+
+    private JSONObject toJSONObject(T object, long features, IdentityHashMap refs) {
+        JSONObject existing = (JSONObject) refs.get(object);
+        if (existing != null) {
+            return existing;
+        }
+
         JSONObject jsonObject = new JSONObject();
+        refs.put(object, jsonObject);
 
         for (int i = 0, size = fieldWriters.size(); i < size; i++) {
             FieldWriter fieldWriter = fieldWriters.get(i);
@@ -681,16 +691,19 @@ public class ObjectWriterAdapter<T>
                 }
             }
             if (fieldWriter instanceof FieldWriterObject && fieldValue != null && !(fieldValue instanceof Map)) {
-                ObjectWriter valueWriter = fieldWriter.getInitWriter();
-                if (fieldValue.getClass() != fieldWriter.fieldClass) {
-                    valueWriter = JSONFactory.getObjectWriter(fieldValue.getClass(), this.features | features);
+                FieldWriterObject fieldWriterObject = (FieldWriterObject) fieldWriter;
+                Class<?> fieldValueClass = fieldValue.getClass();
+                ObjectWriter valueWriter = fieldWriterObject.getInitWriter();
+                if (fieldValueClass != fieldWriter.fieldClass
+                        && !fieldWriterObjectWriteUsing(fieldWriterObject, valueWriter, fieldValueClass)) {
+                    valueWriter = JSONFactory.getObjectWriter(fieldValueClass, this.features | features);
                 } else if (valueWriter == null) {
                     valueWriter = JSONFactory.getObjectWriter(fieldWriter.fieldType, this.features | features);
                 }
                 if (valueWriter instanceof ObjectWriterAdapter) {
                     ObjectWriterAdapter objectWriterAdapter = (ObjectWriterAdapter) valueWriter;
                     if (!objectWriterAdapter.getFieldWriters().isEmpty()) {
-                        fieldValue = objectWriterAdapter.toJSONObject(fieldValue);
+                        fieldValue = objectWriterAdapter.toJSONObject(fieldValue, features, refs);
                     } else {
                         fieldValue = JSON.toJSON(fieldValue);
                     }
@@ -698,8 +711,20 @@ public class ObjectWriterAdapter<T>
             }
             jsonObject.put(fieldWriter.fieldName, fieldValue);
         }
-
+        refs.remove(object);
         return jsonObject;
+    }
+
+    private static boolean fieldWriterObjectWriteUsing(
+            FieldWriterObject fieldWriterObject,
+            ObjectWriter valueWriter,
+            Class<?> fieldValueClass
+    ) {
+        Class<?> initValueClass = fieldWriterObject.initValueClass;
+        return valueWriter != null
+                && fieldWriterObject.writeUsing
+                && initValueClass != null
+                && initValueClass.isAssignableFrom(fieldValueClass);
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
@@ -682,7 +682,9 @@ public class ObjectWriterAdapter<T>
             }
             if (fieldWriter instanceof FieldWriterObject && fieldValue != null && !(fieldValue instanceof Map)) {
                 ObjectWriter valueWriter = fieldWriter.getInitWriter();
-                if (valueWriter == null) {
+                if (fieldValue.getClass() != fieldWriter.fieldClass) {
+                    valueWriter = JSONFactory.getObjectWriter(fieldValue.getClass(), this.features | features);
+                } else if (valueWriter == null) {
                     valueWriter = JSONFactory.getObjectWriter(fieldWriter.fieldType, this.features | features);
                 }
                 if (valueWriter instanceof ObjectWriterAdapter) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2286.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_2200/Issue2286.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.issues_2200;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.annotation.JSONField;
 import com.alibaba.fastjson2.writer.ObjectWriter;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Type;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 @Tag("regression")
 @Tag("annotation")
@@ -19,6 +21,18 @@ public class Issue2286 {
         Bean bean = new Bean();
         bean.animal = new Cat();
         assertEquals("{\"animal\":{\"type\":\"Cat\"}}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void toJSONShouldNotBypassSerializeUsingForSubtype() {
+        Bean bean = new Bean();
+        Cat cat = new Cat();
+        cat.color = "black";
+        bean.animal = cat;
+
+        JSONObject jsonObject = (JSONObject) JSON.toJSON(bean);
+
+        assertSame(cat, jsonObject.get("animal"));
     }
 
     public static class Bean {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
@@ -2315,27 +2315,41 @@ public abstract class JSON
     }
 
     public static Object adaptResult(Object result) {
-        return adaptResult(result, 0);
+        return adaptResult(result, 0, new IdentityHashMap<>());
     }
 
-    private static Object adaptResult(Object result, int level) {
+    private static Object adaptResult(Object result, int level, IdentityHashMap<Object, Object> refs) {
         if (level > MAX_LEVEL) {
             throw new JSONException("level too large : " + level);
         }
         if (result instanceof com.alibaba.fastjson2.JSONObject) {
+            Object existing = refs.get(result);
+            if (existing != null) {
+                return existing;
+            }
+
             JSONObject jsonObject = new JSONObject();
+            refs.put(result, jsonObject);
             com.alibaba.fastjson2.JSONObject object = (com.alibaba.fastjson2.JSONObject) result;
             for (Map.Entry<?, Object> entry : object.entrySet()) {
                 String key = (entry.getKey() == null) ? null : entry.getKey().toString();
-                jsonObject.put(key, adaptResult(entry.getValue(), level + 1));
+                jsonObject.put(key, adaptResult(entry.getValue(), level + 1, refs));
             }
+            refs.remove(result);
             return jsonObject;
         } else if (result instanceof com.alibaba.fastjson2.JSONArray) {
+            Object existing = refs.get(result);
+            if (existing != null) {
+                return existing;
+            }
+
             JSONArray jsonArray = new JSONArray();
+            refs.put(result, jsonArray);
             com.alibaba.fastjson2.JSONArray array = (com.alibaba.fastjson2.JSONArray) result;
             for (int i = 0; i < array.size(); ++i) {
-                jsonArray.set(i, adaptResult(array.get(i), level + 1));
+                jsonArray.set(i, adaptResult(array.get(i), level + 1, refs));
             }
+            refs.remove(result);
             return jsonArray;
         }
         return result;

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_7600/Issue7655.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_7600/Issue7655.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson.JSONObject;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Issue7655 {
     @Test
@@ -25,6 +26,25 @@ public class Issue7655 {
         assertEquals("value2", fieldClassA.getString("field2"));
         assertEquals("value3", fieldClassA.getString("field3"));
         assertEquals("value4", fieldClassA.getString("field4"));
+    }
+
+    @Test
+    public void toJSONShouldKeepRuntimeSubclassCycleSafe() {
+        ClassB classB = new ClassB();
+        classB.setField1("value1");
+        classB.setField2("value2");
+        classB.setField3("value3");
+        classB.setField4("value4");
+
+        ClassC classC = new ClassC();
+        classC.setFieldClassA(classB);
+        classB.setOwner(classC);
+
+        JSONObject jsonObject = (JSONObject) JSON.toJSON(classC);
+        JSONObject fieldClassA = jsonObject.getJSONObject("fieldClassA");
+
+        assertEquals("value3", fieldClassA.getString("field3"));
+        assertSame(jsonObject, fieldClassA.get("owner"));
     }
 
     public static class ClassA {
@@ -51,6 +71,7 @@ public class Issue7655 {
     public static class ClassB extends ClassA {
         private String field3;
         private String field4;
+        private ClassC owner;
 
         public String getField3() {
             return field3;
@@ -66,6 +87,14 @@ public class Issue7655 {
 
         public void setField4(String field4) {
             this.field4 = field4;
+        }
+
+        public ClassC getOwner() {
+            return owner;
+        }
+
+        public void setOwner(ClassC owner) {
+            this.owner = owner;
         }
     }
 

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_7600/Issue7655.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_7600/Issue7655.java
@@ -1,0 +1,83 @@
+package com.alibaba.fastjson.issue_7600;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7655 {
+    @Test
+    public void toJSONShouldKeepRuntimeSubclassProperties() {
+        ClassB classB = new ClassB();
+        classB.setField1("value1");
+        classB.setField2("value2");
+        classB.setField3("value3");
+        classB.setField4("value4");
+
+        ClassC classC = new ClassC();
+        classC.setFieldClassA(classB);
+
+        JSONObject jsonObject = (JSONObject) JSON.toJSON(classC);
+        JSONObject fieldClassA = jsonObject.getJSONObject("fieldClassA");
+
+        assertEquals("value1", fieldClassA.getString("field1"));
+        assertEquals("value2", fieldClassA.getString("field2"));
+        assertEquals("value3", fieldClassA.getString("field3"));
+        assertEquals("value4", fieldClassA.getString("field4"));
+    }
+
+    public static class ClassA {
+        private String field1;
+        private String field2;
+
+        public String getField1() {
+            return field1;
+        }
+
+        public void setField1(String field1) {
+            this.field1 = field1;
+        }
+
+        public String getField2() {
+            return field2;
+        }
+
+        public void setField2(String field2) {
+            this.field2 = field2;
+        }
+    }
+
+    public static class ClassB extends ClassA {
+        private String field3;
+        private String field4;
+
+        public String getField3() {
+            return field3;
+        }
+
+        public void setField3(String field3) {
+            this.field3 = field3;
+        }
+
+        public String getField4() {
+            return field4;
+        }
+
+        public void setField4(String field4) {
+            this.field4 = field4;
+        }
+    }
+
+    public static class ClassC {
+        private ClassA fieldClassA;
+
+        public ClassA getFieldClassA() {
+            return fieldClassA;
+        }
+
+        public void setFieldClassA(ClassA fieldClassA) {
+            this.fieldClassA = fieldClassA;
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #7655.

When `com.alibaba.fastjson.JSON.toJSON` converts a bean whose field is declared as a parent type but currently holds a subclass instance, `ObjectWriterAdapter#toJSONObject` used the declared field type writer. As a result, subclass-only properties were omitted from the nested `JSONObject`.

### Summary of your change

Use the runtime value class writer for non-null object fields when the runtime class differs from the declared field class, so `toJSON` keeps the same subtype fields that normal serialization can see.

Added a fastjson1-compatible regression test covering a `ClassA` field that holds a `ClassB extends ClassA` instance and verifies all parent and child fields are present.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of Conventional Commits specification.
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Tests run:

- `./mvnw -s /tmp/codex-empty-maven-settings.xml -pl fastjson1-compatible -am -Dtest=com.alibaba.fastjson.issue_7600.Issue7655 -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -Dcheckstyle.skip -Drat.skip=true`
- `./mvnw -s /tmp/codex-empty-maven-settings.xml -pl fastjson1-compatible -am -Dtest=com.alibaba.fastjson.JSONFromObjectTest,com.alibaba.fastjson.issue_7600.Issue7655 -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -Dcheckstyle.skip -Drat.skip=true`
- `./mvnw -s /tmp/codex-empty-maven-settings.xml -pl fastjson1-compatible -am test -DskipITs -Dcheckstyle.skip -Drat.skip=true`