### PR TITLE
fix: warn when Kotlin class loses field values due to missing kotlin-reflect

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBaseModule.java
@@ -340,7 +340,7 @@ public class ObjectReaderBaseModule
             if (beanInfo.creatorConstructor == null
                     && (beanInfo.readerFeatures & JSONReader.Feature.FieldBased.mask) == 0
                     && beanInfo.kotlin) {
-                KotlinUtils.getConstructor(objectClass, beanInfo);
+                KotlinUtils.getConstructor(objectClass, beanInfo, true);
             }
         }
 

--- a/core/src/main/java/com/alibaba/fastjson2/util/KotlinUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/KotlinUtils.java
@@ -102,6 +102,13 @@ public class KotlinUtils {
             } catch (Throwable e) {
                 // Ignore this exception
             }
+        } else if (creatorParams != 0 && beanInfo.createParameterNames == null) {
+            System.err.println("fastjson2 warning: class " + clazz.getName()
+                    + " is a Kotlin class with constructor parameters, "
+                    + "but kotlin-reflect is not on the classpath. "
+                    + "Constructor parameter names cannot be resolved, "
+                    + "which will cause deserialization to silently lose field values. "
+                    + "Add org.jetbrains.kotlin:kotlin-reflect to your dependencies.");
         }
 
         beanInfo.creatorConstructor = creatorConstructor;

--- a/core/src/main/java/com/alibaba/fastjson2/util/KotlinUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/KotlinUtils.java
@@ -10,6 +10,8 @@ import kotlin.reflect.KParameter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
 
 /**
  * @author kraity
@@ -27,6 +29,8 @@ public class KotlinUtils {
     private static volatile boolean kotlin_error;
     private static volatile Map<Class, String[]> kotlinIgnores;
     private static volatile boolean kotlinIgnores_error;
+    private static final Logger logger = Logger.getLogger("com.alibaba.fastjson2.util.KotlinUtils");
+    private static final Set<Class<?>> unresolvedParameterNamesWarned = ConcurrentHashMap.newKeySet();
 
     static {
         int state = 0;
@@ -52,6 +56,19 @@ public class KotlinUtils {
      * @param clazz the specified class for search
      */
     public static void getConstructor(Class<?> clazz, BeanInfo beanInfo) {
+        getConstructor(clazz, beanInfo, false);
+    }
+
+    /**
+     * Gets the target constructor and its
+     * parameter names of the specified {@code clazz}
+     *
+     * @param clazz the specified class for search
+     * @param warnUnresolvedParameterNames whether to log a warning when the
+     * constructor has parameters but their names could not be resolved,
+     * which makes deserialization silently fall back to default values
+     */
+    public static void getConstructor(Class<?> clazz, BeanInfo beanInfo, boolean warnUnresolvedParameterNames) {
         int creatorParams = 0;
         Constructor<?> creatorConstructor = null;
 
@@ -102,16 +119,36 @@ public class KotlinUtils {
             } catch (Throwable e) {
                 // Ignore this exception
             }
-        } else if (creatorParams != 0 && beanInfo.createParameterNames == null) {
-            System.err.println("fastjson2 warning: class " + clazz.getName()
-                    + " is a Kotlin class with constructor parameters, "
-                    + "but kotlin-reflect is not on the classpath. "
-                    + "Constructor parameter names cannot be resolved, "
-                    + "which will cause deserialization to silently lose field values. "
-                    + "Add org.jetbrains.kotlin:kotlin-reflect to your dependencies.");
+        }
+
+        if (warnUnresolvedParameterNames) {
+            warnParameterNamesUnresolved(clazz, STATE, creatorParams, beanInfo.createParameterNames);
         }
 
         beanInfo.creatorConstructor = creatorConstructor;
+    }
+
+    /**
+     * Logs a warning, at most once per class, when a Kotlin class has constructor
+     * parameters whose names could not be resolved — either because kotlin-reflect
+     * is not on the classpath or because it failed at runtime. Without the names,
+     * deserialization silently loses field values.
+     *
+     * @return true if a warning was logged for this call
+     */
+    static boolean warnParameterNamesUnresolved(Class<?> clazz, int state, int creatorParams, String[] createParameterNames) {
+        if (creatorParams == 0 || createParameterNames != null) {
+            return false;
+        }
+        if (!unresolvedParameterNamesWarned.add(clazz)) {
+            return false;
+        }
+        String reason = state == 2
+                ? "kotlin-reflect failed to resolve them."
+                : "kotlin-reflect is not on the classpath. Add org.jetbrains.kotlin:kotlin-reflect to your dependencies.";
+        logger.warning("fastjson2: constructor parameter names of Kotlin class " + clazz.getName()
+                + " cannot be resolved, deserialization may silently lose field values: " + reason);
+        return true;
     }
 
     public static boolean isKotlin(Class clazz) {

--- a/core/src/test/java/com/alibaba/fastjson2/util/KotlinUtilsWarningTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/util/KotlinUtilsWarningTest.java
@@ -1,0 +1,103 @@
+package com.alibaba.fastjson2.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KotlinUtilsWarningTest {
+    static List<LogRecord> capture(Runnable action) {
+        Logger logger = Logger.getLogger("com.alibaba.fastjson2.util.KotlinUtils");
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        boolean useParentHandlers = logger.getUseParentHandlers();
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
+        try {
+            action.run();
+        } finally {
+            logger.removeHandler(handler);
+            logger.setUseParentHandlers(useParentHandlers);
+        }
+        return records;
+    }
+
+    @Test
+    public void warnsOncePerClassWhenParameterNamesUnresolved() {
+        List<LogRecord> records = capture(() -> {
+            assertTrue(KotlinUtils.warnParameterNamesUnresolved(WarnOnce.class, 1, 2, null));
+            assertFalse(KotlinUtils.warnParameterNamesUnresolved(WarnOnce.class, 1, 2, null));
+        });
+        assertEquals(1, records.size());
+        assertEquals(Level.WARNING, records.get(0).getLevel());
+        String message = records.get(0).getMessage();
+        assertTrue(message.contains(WarnOnce.class.getName()), message);
+        assertTrue(message.contains("kotlin-reflect"), message);
+    }
+
+    @Test
+    public void noWarningWhenParameterNamesResolved() {
+        List<LogRecord> records = capture(() ->
+                assertFalse(KotlinUtils.warnParameterNamesUnresolved(Resolved.class, 1, 2, new String[]{"a", "b"})));
+        assertTrue(records.isEmpty());
+    }
+
+    @Test
+    public void noWarningWhenConstructorHasNoParameters() {
+        List<LogRecord> records = capture(() ->
+                assertFalse(KotlinUtils.warnParameterNamesUnresolved(NoParams.class, 1, 0, null)));
+        assertTrue(records.isEmpty());
+    }
+
+    @Test
+    public void messageSuggestsDependencyWhenKotlinReflectAbsent() {
+        List<LogRecord> records = capture(() ->
+                assertTrue(KotlinUtils.warnParameterNamesUnresolved(StateAbsent.class, 1, 2, null)));
+        String message = records.get(0).getMessage();
+        assertTrue(message.contains("kotlin-reflect is not on the classpath"), message);
+        assertTrue(message.contains("org.jetbrains.kotlin:kotlin-reflect"), message);
+    }
+
+    @Test
+    public void messageReportsFailureWhenKotlinReflectPresent() {
+        List<LogRecord> records = capture(() ->
+                assertTrue(KotlinUtils.warnParameterNamesUnresolved(StatePresent.class, 2, 2, null)));
+        String message = records.get(0).getMessage();
+        assertTrue(message.contains("kotlin-reflect failed"), message);
+        assertFalse(message.contains("Add org.jetbrains.kotlin:kotlin-reflect"), message);
+    }
+
+    private static class WarnOnce {
+    }
+
+    private static class Resolved {
+    }
+
+    private static class NoParams {
+    }
+
+    private static class StateAbsent {
+    }
+
+    private static class StatePresent {
+    }
+}

--- a/kotlin/src/test/kotlin/com/alibaba/fastjson2/KotlinReflectWarningTest.kt
+++ b/kotlin/src/test/kotlin/com/alibaba/fastjson2/KotlinReflectWarningTest.kt
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson2
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+import java.util.logging.Logger
+
+class KotlinReflectWarningTest {
+    data class Order(val id: Int, val title: String)
+
+    @Test
+    fun no_warning_when_kotlin_reflect_resolves_parameter_names() {
+        val logger = Logger.getLogger("com.alibaba.fastjson2.util.KotlinUtils")
+        val records = mutableListOf<LogRecord>()
+        val handler = object : Handler() {
+            override fun publish(record: LogRecord) {
+                records.add(record)
+            }
+
+            override fun flush() {
+            }
+
+            override fun close() {
+            }
+        }
+        logger.addHandler(handler)
+        try {
+            val json = JSON.toJSONString(Order(1, "kraity"))
+            val order = json.to<Order>()
+            assertEquals(1, order.id)
+            assertEquals("kraity", order.title)
+        } finally {
+            logger.removeHandler(handler)
+        }
+        assertTrue(records.isEmpty()) {
+            "expected no kotlin-reflect warning, got: " + records.joinToString { it.message }
+        }
+    }
+}


### PR DESCRIPTION

## What / Why

When a Kotlin class with constructor parameters (e.g. any `data class`) is
deserialized and `kotlin-reflect` is **not** on the classpath, FastJSON2 cannot
resolve the constructor parameter names. The result is a **silent failure**: an
object is constructed, but its fields are left at their default/null values with
no error and no diagnostic. Users only discover the data loss downstream, and it
looks like a FastJSON2 bug rather than a missing dependency.

This is the worst kind of failure mode — wrong data, no signal.

## Root cause

`KotlinUtils.getConstructor(...)` only resolves parameter names when
`STATE == 2`, i.e. when `kotlin.reflect.jvm.ReflectJvmMapping` (shipped in
`kotlin-reflect`) is present:

```java
if (creatorParams != 0 && STATE == 2) {
    // ... resolve names via Reflection.getOrCreateKotlinClass(...)
}
```

When kotlin-reflect is absent, STATE == 1 (only kotlin-stdlib is present),
the block is skipped, beanInfo.createParameterNames stays null, and binding
falls back to defaults with no indication of why.


## Change

Adds a diagnostic warning when — and only when — this exact condition is hit:
the class is Kotlin (the call site in ObjectReaderBaseModule is already guarded
by beanInfo.kotlin), it has constructor parameters, kotlin-reflect is
unavailable, and parameter names were not resolved by any other means
(annotations / @JSONCreator):

```
} else if (creatorParams != 0 && beanInfo.createParameterNames == null) {
    System.err.println("fastjson2 warning: class " + clazz.getName()
        + " is a Kotlin class with constructor parameters, "
        + "but kotlin-reflect is not on the classpath. ...");
}
```

The message names the class and tells the user to add
org.jetbrains.kotlin:kotlin-reflect.

No behavior change beyond the warning; the fallback path is unchanged. Java
classes are unaffected (guarded by beanInfo.kotlin), and users who already
supply parameter names are not warned (guarded by createParameterNames == null).
