### PR TITLE
fix: grow strBuf when reading long escaped strings, for issue #7671

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3254,12 +3254,10 @@ final class JSONReaderUTF16
             char[] strBuf = this.strBuf;
             if (strBuf == null) {
                 strBuf = new char[stroff + 512];
-                this.strBuf = strBuf;
             } else if (stroff > strBuf.length) {
-                int newCapacity = newCapacity(stroff, strBuf.length);
-                strBuf = new char[newCapacity];
-                this.strBuf = strBuf;
+                strBuf = new char[newCapacity(stroff, strBuf.length)];
             }
+            this.strBuf = strBuf;
             System.arraycopy(chars, start, strBuf, 0, stroff);
 
             while (true) {
@@ -3272,6 +3270,7 @@ final class JSONReaderUTF16
 
                     if (stroff + 4 >= strBuf.length) {
                         strBuf = Arrays.copyOf(strBuf, newCapacity(stroff + 4, strBuf.length));
+                        this.strBuf = strBuf;
                     }
 
                     IOUtils.putLongLE(strBuf, stroff, v);
@@ -3300,6 +3299,7 @@ final class JSONReaderUTF16
                 }
                 if (stroff == strBuf.length) {
                     strBuf = Arrays.copyOf(strBuf, newCapacity(stroff + 1, strBuf.length));
+                    this.strBuf = strBuf;
                 }
                 strBuf[stroff++] = c;
                 offset++;


### PR DESCRIPTION
### What this PR does / why we need it?

Keep `JSONReaderUTF16.strBuf` in sync when the local buffer is grown mid-loop while reading escaped strings.

Issue #7671 reported `ArrayIndexOutOfBoundsException` on 2.0.61 when a long escaped string followed a shorter one that had already initialized `strBuf` (e.g. `char[512]`). The live crash path is already fixed on main by #3989 (`else if (stroff > strBuf.length)` before the initial `arraycopy`, released in 2.0.62). This change is a **buffer-reuse / consistency follow-up**: when `strBuf` is resized inside the escape loop, write the grown array back to `this.strBuf` so later reads reuse the larger buffer instead of re-growing from the stale smaller one.

### Summary of your change

- Always assign `this.strBuf` after initial allocate/grow, and after mid-loop growth in `JSONReaderUTF16.readString`.
- No dedicated regression test: #3989 / `Issue3989` already covers the AIOOBE case; a black-box parse test would not fail if these mid-loop assignments were reverted.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.