### PR TITLE
docs: 修正兼容模式升级说明中的中文错别字

### DIFF
--- a/docs/fastjson_1_upgrade_cn.md
+++ b/docs/fastjson_1_upgrade_cn.md
@@ -20,7 +20,7 @@ FASTJSON v2项目目前处于活跃状态，会不定期发布新版本，你可
 * 使用fastjson v2新的API
 
 ### 2.2. 兼容模式升级
-升级可以通过兼容模式升级，兼容模式不需要改代码，但在深度使用的场景，不能做到完全兼容，通过这样的模式升级虽然省事，请认证测试，遇到问题反馈到 [https://github.com/alibaba/fastjson2/issues](https://github.com/alibaba/fastjson2/issues)
+升级可以通过兼容模式升级，兼容模式不需要改代码，但在深度使用的场景，不能做到完全兼容，通过这样的模式升级虽然省事，但请认真测试，遇到问题反馈到 [https://github.com/alibaba/fastjson2/issues](https://github.com/alibaba/fastjson2/issues)
 
 * 兼容模式Maven依赖
 ```xml


### PR DESCRIPTION
### What this PR does / why we need it?

修正 `docs/fastjson_1_upgrade_cn.md` 第 2.2 节「兼容模式升级」中的中文错别字，避免读者误解。

### Summary of your change

将「认证测试」改为「请认真测试」。

原文：
> 通过这样的模式升级虽然省事，认证测试，遇到问题反馈到 ...

修改后：
> 通过这样的模式升级虽然省事，请认真测试，遇到问题反馈到 ...

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
