### PR TITLE
fix: limit number literal digits to prevent BigInteger O(n²) DoS (#7668)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -54,6 +54,7 @@ import static com.alibaba.fastjson2.util.TypeUtils.*;
 public abstract class JSONReader
         implements Closeable {
     static final int MAX_EXP = 2047;
+    static final int MAX_NUMBER_DIGITS = 10_000;
 
     static final byte
             JSON_TYPE_INT = 1,

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3990,6 +3990,9 @@ final class JSONReaderUTF16
         if (intOverflow) {
             int numStart = negative ? start : start - 1;
             int numDigits = scale > 0 ? offset - 2 - numStart : offset - 1 - numStart;
+            if (numDigits > MAX_NUMBER_DIGITS) {
+                throw new JSONException("Number literal too long: " + numDigits + " digits (max " + MAX_NUMBER_DIGITS + ")");
+            }
             if (numDigits > 38) {
                 valueType = JSON_TYPE_BIG_DEC;
             } else {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -5469,6 +5469,9 @@ class JSONReaderUTF8
         if (intOverflow) {
             int numStart = negative ? start : start - 1;
             int numDigits = scale > 0 ? offset - 2 - numStart : offset - 1 - numStart;
+            if (numDigits > MAX_NUMBER_DIGITS) {
+                throw new JSONException("Number literal too long: " + numDigits + " digits (max " + MAX_NUMBER_DIGITS + ")");
+            }
             if (numDigits > 38) {
                 valueType = JSON_TYPE_BIG_DEC;
             } else {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7668.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7668.java
@@ -1,0 +1,85 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Issue7668 {
+    @Test
+    public void testExceedsMaxDigits() {
+        int n = 10_001;
+        StringBuilder sb = new StringBuilder("{\"x\":");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertThrows(JSONException.class, () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testWithinMaxDigits() {
+        int n = 100;
+        StringBuilder sb = new StringBuilder("{\"x\":");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        Object val = JSON.parseObject(json).get("x");
+        assertInstanceOf(BigInteger.class, val);
+
+        Object val2 = JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)).get("x");
+        assertInstanceOf(BigInteger.class, val2);
+    }
+
+    @Test
+    public void testErrorMessage() {
+        int n = 20_000;
+        StringBuilder sb = new StringBuilder("{\"x\":");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        JSONException ex = assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertTrue(ex.getMessage().contains("Number literal too long"));
+    }
+
+    @Test
+    public void testNegativeNumber() {
+        int n = 10_001;
+        StringBuilder sb = new StringBuilder("{\"x\":-");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertThrows(JSONException.class, () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testDecimalExceedsMaxDigits() {
+        int n = 10_001;
+        StringBuilder sb = new StringBuilder("{\"x\":0.");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertThrows(JSONException.class, () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)));
+    }
+}


### PR DESCRIPTION
## Problem

Parsing JSON number literals with >38 significant digits stores the full numeric string and constructs `BigInteger`/`BigDecimal` via `new BigInteger(stringValue)`, which has **O(n²) time complexity**. An attacker can send a single JSON field with hundreds of thousands of digits to block a server CPU core — a denial-of-service attack.

Fixes #7668

## Fix

Added `MAX_NUMBER_DIGITS = 10_000` constant in `JSONReader` and a digit-count check in `readNumber0()` for both `JSONReaderUTF8` and `JSONReaderUTF16`, throwing `JSONException` before the expensive construction occurs.

This follows the same approach as Jackson's `MAX_DIGITS_IN_DECIMAL` fix for CVE-2020-36518.

## Changes

- `JSONReader.java` — added `MAX_NUMBER_DIGITS` constant
- `JSONReaderUTF8.java` — digit-limit check in `readNumber0()` (also covers `JSONReaderASCII`)
- `JSONReaderUTF16.java` — digit-limit check in `readNumber0()`
- `Issue7668.java` — test covering: exceeds limit, within limit, error message, negative numbers, decimals

## Verification

- All new tests pass
- BigInteger/BigDecimal/Number regression tests pass
- `mvn validate` (checkstyle) passes
