### PR TITLE
fix: JSONB BC_BIGINT declared-length OOM (#7669)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -580,6 +580,9 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BIGINT length out of range: " + len);
+                }
                 byte[] buf = new byte[len];
                 System.arraycopy(bytes, offset, buf, 0, len);
                 offset += len;
@@ -3253,6 +3256,9 @@ final class JSONReaderJSONB
                 return Long.toString(int64Value);
             case BC_BIGINT: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BIGINT length out of range: " + len);
+                }
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4180,6 +4186,9 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BIGINT length out of range: " + len);
+                }
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4409,6 +4418,9 @@ final class JSONReaderJSONB
             );
         } else if (type == BC_BIGINT) {
             int len = readInt32Value();
+            if (len < 0 || len > end - offset) {
+                throw new JSONException("BC_BIGINT length out of range: " + len);
+            }
             byte[] bytes = new byte[len];
             System.arraycopy(this.bytes, offset, bytes, 0, len);
             offset += len;

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -1,0 +1,43 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("regression")
+@Tag("jsonb")
+public class Issue7669 {
+    @Test
+    public void testBigIntDeclaredLengthOOM() {
+        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+        byte[] payload = {
+                (byte) 0xBB,
+                (byte) 0x48,
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+    }
+
+    @Test
+    public void testBigIntNegativeLength() {
+        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+        byte[] payload = {
+                (byte) 0xBB,
+                (byte) 0x48,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+    }
+
+    @Test
+    public void testBigIntValidPayloadStillWorks() {
+        // Verify legitimate BigInteger values still round-trip correctly
+        java.math.BigInteger value = java.math.BigInteger.valueOf(Long.MAX_VALUE).multiply(java.math.BigInteger.TEN);
+        byte[] jsonbBytes = JSONB.toBytes(value);
+        java.math.BigInteger result = (java.math.BigInteger) JSONB.parse(jsonbBytes);
+        org.junit.jupiter.api.Assertions.assertEquals(value, result);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7669

JSONB `BC_BIGINT` deserialization read a 32-bit length via `readInt32Value()` and immediately called `new byte[len]` without bounds validation. A crafted 6-byte payload declaring `Integer.MAX_VALUE` (~2GB) triggers `OutOfMemoryError`, crashing the JVM process.

## Changes

Added bounds check in all 4 `BC_BIGINT` code paths in `JSONReaderJSONB.java`:

```java
if (len < 0 || len > end - offset) {
    throw new JSONException("BC_BIGINT length out of range: " + len);
}
```

- `readAny()` — general-purpose deserialization
- `readString()` — string coercion path
- `readNumber()` — number coercion path
- `readBigInteger()` — direct BigInteger read

The check uses `len > end - offset` (not `offset + len > end`) to avoid integer overflow when `len` is near `Integer.MAX_VALUE`.

## Test

Added `Issue7669.java` with 3 tests:
- Malicious payload (Integer.MAX_VALUE declared length) → `JSONException`
- Negative length → `JSONException`
- Valid BigInteger round-trip still works