### PR TITLE
fix: 修复 fastjson1 兼容层 JSONPath 连续写入失效问题

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
@@ -2318,7 +2318,12 @@ public abstract class JSON
         return adaptResult(result, 0);
     }
 
-    // Return live wrappers for #7690 so changes propagate to the underlying fastjson2 container.
+    /**
+     * Returns a live wrapper sharing state with the underlying fastjson2 container;
+     * mutations propagate to the parent. Use in {@code get()}-family accessors where
+     * JSONPath navigation must see writes. Use {@link #adaptResult(Object)} for
+     * independent snapshots.
+     */
     static Object adaptResultLive(Object result) {
         if (result instanceof com.alibaba.fastjson2.JSONObject) {
             return new JSONObject((com.alibaba.fastjson2.JSONObject) result);

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
@@ -2318,6 +2318,17 @@ public abstract class JSON
         return adaptResult(result, 0);
     }
 
+    // Return live wrappers for #7690 so changes propagate to the underlying fastjson2 container.
+    static Object adaptResultLive(Object result) {
+        if (result instanceof com.alibaba.fastjson2.JSONObject) {
+            return new JSONObject((com.alibaba.fastjson2.JSONObject) result);
+        }
+        if (result instanceof com.alibaba.fastjson2.JSONArray) {
+            return new JSONArray((com.alibaba.fastjson2.JSONArray) result);
+        }
+        return result;
+    }
+
     private static Object adaptResult(Object result, int level) {
         if (level > MAX_LEVEL) {
             throw new JSONException("level too large : " + level);

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -593,13 +593,7 @@ public class JSONArray
     @Override
     public Object get(int index) {
         Object value = list.get(index);
-        if (value instanceof com.alibaba.fastjson2.JSONObject) {
-            return new JSONObject((com.alibaba.fastjson2.JSONObject) value);
-        }
-        if (value instanceof com.alibaba.fastjson2.JSONArray) {
-            return new JSONArray((com.alibaba.fastjson2.JSONArray) value);
-        }
-        return value;
+        return adaptResultLive(value);
     }
 
     /**

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -592,7 +592,14 @@ public class JSONArray
 
     @Override
     public Object get(int index) {
-        return adaptResult(list.get(index));
+        Object value = list.get(index);
+        if (value instanceof com.alibaba.fastjson2.JSONObject) {
+            return new JSONObject((com.alibaba.fastjson2.JSONObject) value);
+        }
+        if (value instanceof com.alibaba.fastjson2.JSONArray) {
+            return new JSONArray((com.alibaba.fastjson2.JSONArray) value);
+        }
+        return value;
     }
 
     /**

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -127,7 +127,13 @@ public class JSONObject
             val = map.get(key.toString());
         }
 
-        return adaptResult(val);
+        if (val instanceof com.alibaba.fastjson2.JSONObject) {
+            return new JSONObject((com.alibaba.fastjson2.JSONObject) val);
+        }
+        if (val instanceof com.alibaba.fastjson2.JSONArray) {
+            return new JSONArray((com.alibaba.fastjson2.JSONArray) val);
+        }
+        return val;
     }
 
     public JSONObject getJSONObject(String key) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -127,13 +127,7 @@ public class JSONObject
             val = map.get(key.toString());
         }
 
-        if (val instanceof com.alibaba.fastjson2.JSONObject) {
-            return new JSONObject((com.alibaba.fastjson2.JSONObject) val);
-        }
-        if (val instanceof com.alibaba.fastjson2.JSONArray) {
-            return new JSONArray((com.alibaba.fastjson2.JSONArray) val);
-        }
-        return val;
+        return adaptResultLive(val);
     }
 
     public JSONObject getJSONObject(String key) {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
@@ -1,0 +1,40 @@
+package com.alibaba.fastjson.v2issues;
+
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7690 {
+    @Test
+    public void testSetFieldAfterAutoCreatingArrayElement() {
+        JSONObject root = new JSONObject();
+
+        JSONObject item = new JSONObject();
+        item.put("title", "1");
+        item.put("value", "110");
+
+        JSONArray testArray = new JSONArray();
+        testArray.add(item);
+        root.put("test", testArray);
+
+        JSONPath.set(root, "$.test[1].title", 2);
+        assertEquals(2, JSONPath.eval(root, "$.test[1].title"));
+
+        JSONPath.set(root, "$.test[1].value", 220);
+        assertEquals(220, JSONPath.eval(root, "$.test[1].value"));
+    }
+
+    @Test
+    public void testSetFieldAfterAutoCreatingObject() {
+        JSONObject root = new JSONObject();
+
+        JSONPath.set(root, "$.test.title", 2);
+        assertEquals(2, JSONPath.eval(root, "$.test.title"));
+
+        JSONPath.set(root, "$.test.value", 220);
+        assertEquals(220, JSONPath.eval(root, "$.test.value"));
+    }
+}

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
@@ -24,17 +24,20 @@ public class Issue7690 {
         assertEquals(2, JSONPath.eval(root, "$.test[1].title"));
 
         JSONPath.set(root, "$.test[1].value", 220);
+        assertEquals(2, JSONPath.eval(root, "$.test[1].title"));
         assertEquals(220, JSONPath.eval(root, "$.test[1].value"));
     }
 
     @Test
-    public void testSetFieldAfterAutoCreatingObject() {
+    public void testObjectGetReturnsLiveWrapperAfterAutoCreatingObject() {
         JSONObject root = new JSONObject();
 
         JSONPath.set(root, "$.test.title", 2);
-        assertEquals(2, JSONPath.eval(root, "$.test.title"));
 
-        JSONPath.set(root, "$.test.value", 220);
+        JSONObject test = (JSONObject) root.get("test");
+        test.put("value", 220);
+
+        assertEquals(2, JSONPath.eval(root, "$.test.title"));
         assertEquals(220, JSONPath.eval(root, "$.test.value"));
     }
 }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
@@ -5,7 +5,10 @@ import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.JSONPath;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class Issue7690 {
     @Test
@@ -29,15 +32,29 @@ public class Issue7690 {
     }
 
     @Test
-    public void testObjectGetReturnsLiveWrapperAfterAutoCreatingObject() {
+    public void testGetReturnsLiveWrapperForCoreJSONObject() {
         JSONObject root = new JSONObject();
-
-        JSONPath.set(root, "$.test.title", 2);
+        root.put("test", new com.alibaba.fastjson2.JSONObject());
 
         JSONObject test = (JSONObject) root.get("test");
         test.put("value", 220);
 
-        assertEquals(2, JSONPath.eval(root, "$.test.title"));
         assertEquals(220, JSONPath.eval(root, "$.test.value"));
+    }
+
+    @Test
+    public void testLiveWrapperIterationExposesUnderlyingCoreNestedContainers() {
+        JSONObject root = new JSONObject();
+        JSONPath.set(root, "$.a.b.c", 1);
+
+        JSONObject a = (JSONObject) root.get("a");
+        Object value = a.values().iterator().next();
+        Object entryValue = a.entrySet().iterator().next().getValue();
+        AtomicReference<Object> forEachValue = new AtomicReference<>();
+        a.forEach((key, item) -> forEachValue.set(item));
+
+        assertEquals(com.alibaba.fastjson2.JSONObject.class, value.getClass());
+        assertSame(value, entryValue);
+        assertSame(value, forEachValue.get());
     }
 }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
@@ -54,6 +54,18 @@ public class Issue7690 {
     }
 
     @Test
+    public void testArrayGetReturnsLiveWrapperForCoreJSONObject() {
+        JSONArray arr = new JSONArray();
+        arr.add(new com.alibaba.fastjson2.JSONObject());
+
+        JSONObject obj = (JSONObject) arr.get(0);
+        obj.put("value", 42);
+
+        JSONObject obj2 = (JSONObject) arr.get(0);
+        assertEquals(42, obj2.get("value"));
+    }
+
+    @Test
     public void testLiveWrapperIterationExposesUnderlyingCoreNestedContainers() {
         JSONObject root = new JSONObject();
         JSONPath.set(root, "$.a.b.c", 1);

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7690.java
@@ -43,6 +43,17 @@ public class Issue7690 {
     }
 
     @Test
+    public void testGetReturnsLiveWrapperForCoreJSONArray() {
+        JSONObject root = new JSONObject();
+        root.put("arr", new com.alibaba.fastjson2.JSONArray());
+
+        JSONArray arr = (JSONArray) root.get("arr");
+        arr.add(220);
+
+        assertEquals(220, JSONPath.eval(root, "$.arr[0]"));
+    }
+
+    @Test
     public void testLiveWrapperIterationExposesUnderlyingCoreNestedContainers() {
         JSONObject root = new JSONObject();
         JSONPath.set(root, "$.a.b.c", 1);


### PR DESCRIPTION
## 问题

在 fastjson1 兼容层中，`JSONPath.set` 越界扩展数组并自动创建元素后，再次对同一元素写入其他字段时，修改不会持久化。

Fixes #7690

## 根因

`JSONPathMulti` 自动创建的中间容器可能是 fastjson2 core 的 `JSONObject` 或 `JSONArray`。

兼容层的 `JSONObject#get(Object)` 和 `JSONArray#get(int)` 原本通过 `JSON.adaptResult` 将 core 容器递归转换为新的兼容层对象。转换后的对象与原容器不再共享底层数据，导致后续 `JSONPath` 或直接调用方修改的是独立对象，写入无法传播回父容器。

## 修改

* 新增 `JSON.adaptResultLive(Object)`，集中处理 fastjson2 core 容器到兼容层 live-wrapper 的转换。
* core `JSONObject` 返回共享底层状态的兼容层 `JSONObject`。
* core `JSONArray` 返回共享底层状态的兼容层 `JSONArray`。
* `JSONObject#get(Object)` 和 `JSONArray#get(int)` 统一调用 `adaptResultLive`，避免两处包装逻辑分叉。
* 为 `adaptResultLive` 添加 Javadoc，明确其共享状态和写入传播语义，并与 `adaptResult` 的递归独立转换语义区分。
* 保持现有 `JSON.adaptResult` 的实现及递归转换行为不变。

## 回归测试

新增 `Issue7690` 测试，覆盖以下场景：

* 数组越界扩展并自动创建元素后，连续写入不同字段，验证第一次写入不会丢失。
* core `JSONObject` 经 `JSONObject#get` 返回兼容层 live-wrapper 后，写入能够传播回原始父容器。
* core `JSONArray` 经 `JSONObject#get` 返回兼容层 live-wrapper 后，新增元素能够传播回原始父容器。
* core `JSONObject` 经 `JSONArray#get(int)` 返回兼容层 live-wrapper 后，字段写入能够传播回原数组元素。
* 固定 live-wrapper 的 `values()`、`entrySet()` 和 `forEach()` 迭代视图保留底层 core 嵌套容器类型的行为契约。

## 验证

* `Issue7690` 与 `Issue3185`：6 个测试全部通过。
* `mvnw.cmd -pl fastjson1-compatible clean test`：1351 个测试全部通过。
* `mvnw.cmd -pl fastjson1-compatible -Dfastjson2.creator=reflect clean test`：1351 个测试全部通过。
* `mvnw.cmd -pl fastjson1-compatible validate`：构建成功，0 个 Checkstyle 问题。
* `git diff --check`：通过。
