### PR TITLE
fix: add serialVersionUID to JSONArray in fastjson1-compatible for Java serialization compatibility

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -27,6 +27,8 @@ public class JSONArray
     static ObjectReader<JSONArray> arrayReader;
     static ObjectReader<JSONObject> objectReader;
 
+    private static final long serialVersionUID = 1L;
+
     private List list = new com.alibaba.fastjson2.JSONArray();
 
     protected transient Object relatedArray;

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/JSONArrayTest_readObject.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/JSONArrayTest_readObject.java
@@ -1,0 +1,62 @@
+package com.alibaba.fastjson;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JSONArrayTest_readObject {
+    @Test
+    public void test_serialVersionUID() {
+        ObjectStreamClass desc = ObjectStreamClass.lookup(JSONArray.class);
+        assertEquals(1L, desc.getSerialVersionUID());
+    }
+
+    @Test
+    public void test_0() throws Exception {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(123);
+        jsonArray.add("hello");
+        jsonArray.add(new JSONObject());
+
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        ObjectOutputStream objOut = new ObjectOutputStream(bytesOut);
+        objOut.writeObject(jsonArray);
+        objOut.flush();
+
+        byte[] bytes = bytesOut.toByteArray();
+
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytes);
+        ObjectInputStream objIn = new ObjectInputStream(bytesIn);
+
+        Object obj = objIn.readObject();
+
+        assertEquals(JSONArray.class, obj.getClass());
+        assertEquals(jsonArray, obj);
+    }
+
+    @Test
+    public void test_1() throws Exception {
+        JSONArray jsonArray = JSON.parseArray("[1,2,3,{\"id\":123}]");
+
+        ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+        ObjectOutputStream objOut = new ObjectOutputStream(bytesOut);
+        objOut.writeObject(jsonArray);
+        objOut.flush();
+
+        byte[] bytes = bytesOut.toByteArray();
+
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytes);
+        ObjectInputStream objIn = new ObjectInputStream(bytesIn);
+
+        Object obj = objIn.readObject();
+
+        assertEquals(JSONArray.class, obj.getClass());
+        assertEquals(jsonArray, obj);
+    }
+}


### PR DESCRIPTION
## Issue

Fixes #7687

## Problem

`com.alibaba.fastjson.JSONArray` in the fastjson1-compatible module implements `Serializable` but was missing an explicit `serialVersionUID`. Java auto-computes a UID from the class structure, which doesn't match the original fastjson 1.x value (`1L`). This causes `InvalidClassException` when deserializing objects previously serialized with fastjson 1.x:

```
java.io.InvalidClassException: com.alibaba.fastjson.JSONArray; local class incompatible:
  stream classdesc serialVersionUID = 3642856726642946224,
  local class serialVersionUID = 1
```

## Fix

Added `private static final long serialVersionUID = 1L;` to `JSONArray`, matching:
- The original fastjson 1.x `JSONArray` value
- The sibling `JSONObject` class in the same module (which already declares `serialVersionUID = 1L`)

## Test

Added `JSONArrayTest_readObject` verifying:
- `serialVersionUID` equals `1L` (via `ObjectStreamClass.lookup`)
- Round-trip Java serialization/deserialization works correctly
