### PR TITLE
fix: use Unsafe.allocateInstance for non-static inner class to avoid JDK 25 NPE (#7654)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.codec.FieldInfo;
 import com.alibaba.fastjson2.internal.asm.ASMUtils;
 import com.alibaba.fastjson2.util.Fnv;
+import com.alibaba.fastjson2.util.JDKUtils;
 import com.alibaba.fastjson2.util.TypeUtils;
 
 import java.lang.reflect.*;
@@ -23,6 +24,12 @@ final class ConstructorFunction<T>
     final String[] paramNames;
     final boolean marker;
     final long[] hashCodes;
+    /**
+     * Non-null when parameter 0 is the synthetic enclosing instance of a non-static inner class.
+     * Such a parameter never appears in the JSON, so it must not be left null — the constructor
+     * may dereference it (JDK 25 rejects a null enclosing instance outright).
+     */
+    final Class enclosingParamType;
     final List<Constructor> alternateConstructors;
     Map<Set<Long>, Constructor> alternateConstructorMap;
     Map<Set<Long>, String[]> alternateConstructorNames;
@@ -56,6 +63,15 @@ final class ConstructorFunction<T>
             }
             hashCodes[i] = Fnv.hashCode64(name);
         }
+
+        Class declaringClass = constructor.getDeclaringClass();
+        Class enclosingClass = declaringClass.getDeclaringClass();
+        this.enclosingParamType = enclosingClass != null
+                && !Modifier.isStatic(declaringClass.getModifiers())
+                && parameters.length > 0
+                && parameters[0].getType() == enclosingClass
+                ? enclosingClass
+                : null;
 
         this.alternateConstructors = alternateConstructors;
         if (alternateConstructors != null) {
@@ -99,6 +115,22 @@ final class ConstructorFunction<T>
         }
     }
 
+    /**
+     * Default for a parameter absent from the JSON. Parameter 0 of a non-static inner class
+     * constructor is the enclosing instance, which is never present in the JSON, so allocate a
+     * bare one rather than passing null.
+     */
+    private Object defaultArg(int index, Class<?> paramClass) {
+        if (index == 0 && enclosingParamType != null) {
+            try {
+                return JDKUtils.UNSAFE.allocateInstance(enclosingParamType);
+            } catch (Throwable ignored) {
+                // fall back to null below
+            }
+        }
+        return TypeUtils.getDefaultValue(paramClass);
+    }
+
     @Override
     public T apply(Map<Long, Object> values) {
         boolean containsAll = true;
@@ -139,7 +171,7 @@ final class ConstructorFunction<T>
             Object arg = values.get(hashCodes[0]);
             Class<?> paramType = param.getType();
             if (arg == null) {
-                arg = TypeUtils.getDefaultValue(paramType);
+                arg = defaultArg(0, paramType);
             } else {
                 if (!paramType.isInstance(arg)) {
                     arg = TypeUtils.cast(arg, paramType);
@@ -153,7 +185,7 @@ final class ConstructorFunction<T>
             Parameter param0 = parameters[0];
             Class<?> param0Type = param0.getType();
             if (arg0 == null) {
-                arg0 = TypeUtils.getDefaultValue(param0Type);
+                arg0 = defaultArg(0, param0Type);
             } else {
                 if (!param0Type.isInstance(arg0)) {
                     arg0 = TypeUtils.cast(arg0, param0Type);
@@ -193,8 +225,8 @@ final class ConstructorFunction<T>
                     args[i] = arg;
                 } else {
                     flag |= (1 << i);
-                    if (paramClass.isPrimitive()) {
-                        args[i] = TypeUtils.getDefaultValue(paramClass);
+                    if (paramClass.isPrimitive() || (i == 0 && enclosingParamType != null)) {
+                        args[i] = defaultArg(i, paramClass);
                     }
                 }
                 n = i + 1;
@@ -210,7 +242,7 @@ final class ConstructorFunction<T>
                 Type paramType = parameter.getParameterizedType();
                 Object arg = values.get(hashCodes[i]);
                 if (arg == null) {
-                    arg = TypeUtils.getDefaultValue(paramClass);
+                    arg = defaultArg(i, paramClass);
                 } else {
                     if (!paramClass.isInstance(arg)) {
                         arg = TypeUtils.cast(arg, paramClass);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
@@ -124,8 +124,8 @@ final class ConstructorFunction<T>
         if (index == 0 && enclosingParamType != null) {
             try {
                 return JDKUtils.UNSAFE.allocateInstance(enclosingParamType);
-            } catch (Throwable ignored) {
-                // fall back to null below
+            } catch (InstantiationException ignored) {
+                // the enclosing type cannot be allocated, fall back to the default value below
             }
         }
         return TypeUtils.getDefaultValue(paramClass);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorFunction.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.codec.FieldInfo;
 import com.alibaba.fastjson2.internal.asm.ASMUtils;
+import com.alibaba.fastjson2.util.BeanUtils;
 import com.alibaba.fastjson2.util.Fnv;
 import com.alibaba.fastjson2.util.JDKUtils;
 import com.alibaba.fastjson2.util.TypeUtils;
@@ -64,14 +65,7 @@ final class ConstructorFunction<T>
             hashCodes[i] = Fnv.hashCode64(name);
         }
 
-        Class declaringClass = constructor.getDeclaringClass();
-        Class enclosingClass = declaringClass.getDeclaringClass();
-        this.enclosingParamType = enclosingClass != null
-                && !Modifier.isStatic(declaringClass.getModifiers())
-                && parameters.length > 0
-                && parameters[0].getType() == enclosingClass
-                ? enclosingClass
-                : null;
+        this.enclosingParamType = BeanUtils.getEnclosingInstanceParamType(constructor);
 
         this.alternateConstructors = alternateConstructors;
         if (alternateConstructors != null) {
@@ -118,7 +112,10 @@ final class ConstructorFunction<T>
     /**
      * Default for a parameter absent from the JSON. Parameter 0 of a non-static inner class
      * constructor is the enclosing instance, which is never present in the JSON, so allocate a
-     * bare one rather than passing null.
+     * bare one rather than passing null. When the enclosing class cannot be allocated (for
+     * example an abstract class), fall back to null as before JDK 25; inner classes compiled
+     * by JDK 25+ then reject the null enclosing instance, which is unavoidable because an
+     * abstract enclosing class cannot be instantiated.
      */
     private Object defaultArg(int index, Class<?> paramClass) {
         if (index == 0 && enclosingParamType != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
@@ -12,6 +12,7 @@ final class ConstructorSupplier
     final Constructor constructor;
     final Class objectClass;
     final boolean useClassNewInstance;
+    final Class paramType;
 
     public ConstructorSupplier(Constructor constructor) {
         constructor.setAccessible(true);
@@ -20,6 +21,9 @@ final class ConstructorSupplier
         this.useClassNewInstance = constructor.getParameterCount() == 0
                 && Modifier.isPublic(constructor.getModifiers())
                 && Modifier.isPublic(objectClass.getModifiers());
+        this.paramType = constructor.getParameterCount() == 1
+                ? constructor.getParameterTypes()[0]
+                : null;
     }
 
     @Override
@@ -28,8 +32,7 @@ final class ConstructorSupplier
             if (useClassNewInstance) {
                 return objectClass.newInstance();
             } else {
-                if (constructor.getParameterCount() == 1) {
-                    Class<?> paramType = constructor.getParameterTypes()[0];
+                if (paramType != null) {
                     Object dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
                     return constructor.newInstance(dummy);
                 } else {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
@@ -29,7 +29,9 @@ final class ConstructorSupplier
                 return objectClass.newInstance();
             } else {
                 if (constructor.getParameterCount() == 1) {
-                    return JDKUtils.UNSAFE.allocateInstance(objectClass);
+                    Class<?> paramType = constructor.getParameterTypes()[0];
+                    Object dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
+                    return constructor.newInstance(dummy);
                 } else {
                     return constructor.newInstance();
                 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.util.JDKUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
@@ -28,7 +29,7 @@ final class ConstructorSupplier
                 return objectClass.newInstance();
             } else {
                 if (constructor.getParameterCount() == 1) {
-                    return constructor.newInstance(new Object[1]);
+                    return JDKUtils.UNSAFE.allocateInstance(objectClass);
                 } else {
                     return constructor.newInstance();
                 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ConstructorSupplier.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.util.BeanUtils;
 import com.alibaba.fastjson2.util.JDKUtils;
 
 import java.lang.reflect.Constructor;
@@ -21,9 +22,7 @@ final class ConstructorSupplier
         this.useClassNewInstance = constructor.getParameterCount() == 0
                 && Modifier.isPublic(constructor.getModifiers())
                 && Modifier.isPublic(objectClass.getModifiers());
-        this.paramType = constructor.getParameterCount() == 1
-                ? constructor.getParameterTypes()[0]
-                : null;
+        this.paramType = BeanUtils.getEnclosingInstanceParamType(constructor);
     }
 
     @Override
@@ -31,14 +30,24 @@ final class ConstructorSupplier
         try {
             if (useClassNewInstance) {
                 return objectClass.newInstance();
-            } else {
-                if (paramType != null) {
-                    Object dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
-                    return constructor.newInstance(dummy);
-                } else {
-                    return constructor.newInstance();
-                }
             }
+
+            if (paramType != null) {
+                Object dummy;
+                try {
+                    dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
+                } catch (InstantiationException ignored) {
+                    // the enclosing class cannot be allocated (for example an abstract class),
+                    // pass null as before JDK 25
+                    dummy = null;
+                }
+                return constructor.newInstance(dummy);
+            }
+
+            if (constructor.getParameterCount() == 1) {
+                return constructor.newInstance(new Object[1]);
+            }
+            return constructor.newInstance();
         } catch (Throwable e) {
             throw new JSONException("create instance error", e);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.schema.JSONSchema;
 import com.alibaba.fastjson2.util.BeanUtils;
 import com.alibaba.fastjson2.util.Fnv;
+import com.alibaba.fastjson2.util.JDKUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -443,7 +444,12 @@ public class ObjectReaderAdapter<T>
 
         if (constructor != null) {
             try {
-                T object = (T) constructor.newInstance(new Object[parameterCount]);
+                T object;
+                if (parameterCount == 0) {
+                    object = (T) constructor.newInstance();
+                } else {
+                    object = (T) JDKUtils.UNSAFE.allocateInstance(objectClass);
+                }
                 if (hasDefaultValue) {
                     initDefaultValue(object);
                 }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -448,7 +448,9 @@ public class ObjectReaderAdapter<T>
                 if (parameterCount == 0) {
                     object = (T) constructor.newInstance();
                 } else {
-                    object = (T) JDKUtils.UNSAFE.allocateInstance(objectClass);
+                    Class<?> paramType = constructor.getParameterTypes()[0];
+                    Object dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
+                    object = (T) constructor.newInstance(dummy);
                 }
                 if (hasDefaultValue) {
                     initDefaultValue(object);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -447,10 +447,12 @@ public class ObjectReaderAdapter<T>
                 T object;
                 if (parameterCount == 0) {
                     object = (T) constructor.newInstance();
-                } else {
+                } else if (parameterCount == 1) {
                     Class<?> paramType = constructor.getParameterTypes()[0];
                     Object dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
                     object = (T) constructor.newInstance(dummy);
+                } else {
+                    object = (T) constructor.newInstance(new Object[parameterCount]);
                 }
                 if (hasDefaultValue) {
                     initDefaultValue(object);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -447,9 +447,16 @@ public class ObjectReaderAdapter<T>
                 T object;
                 if (parameterCount == 0) {
                     object = (T) constructor.newInstance();
-                } else if (parameterCount == 1) {
+                } else if (parameterCount == 1 && BeanUtils.getEnclosingInstanceParamType(constructor) != null) {
                     Class<?> paramType = constructor.getParameterTypes()[0];
-                    Object dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
+                    Object dummy;
+                    try {
+                        dummy = JDKUtils.UNSAFE.allocateInstance(paramType);
+                    } catch (InstantiationException ignored) {
+                        // the enclosing class cannot be allocated (for example an abstract class),
+                        // pass null as before JDK 25
+                        dummy = null;
+                    }
                     object = (T) constructor.newInstance(dummy);
                 } else {
                     object = (T) constructor.newInstance(new Object[parameterCount]);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -706,10 +706,17 @@ public class ObjectReaderCreatorASM
             mw.invokespecial(TYPE_OBJECT, "<init>", "()V");
         } else {
             Class paramType = defaultConstructor.getParameterTypes()[0];
-            mw.getstatic(TYPE_UNSAFE_UTILS, "UNSAFE", "Lsun/misc/Unsafe;");
-            mw.visitLdcInsn(paramType);
-            mw.invokevirtual("sun/misc/Unsafe", "allocateInstance", "(Ljava/lang/Class;)Ljava/lang/Object;");
-            mw.checkcast(ASMUtils.type(paramType));
+            // ldc/checkcast on the enclosing type are access-checked against the generated class,
+            // which lives in DynamicClassLoader; a non-public enclosing type fails with
+            // IllegalAccessError there, so keep passing null for it as before.
+            if (Modifier.isPublic(paramType.getModifiers())) {
+                mw.getstatic(TYPE_UNSAFE_UTILS, "UNSAFE", "Lsun/misc/Unsafe;");
+                mw.visitLdcInsn(paramType);
+                mw.invokevirtual("sun/misc/Unsafe", "allocateInstance", "(Ljava/lang/Class;)Ljava/lang/Object;");
+                mw.checkcast(ASMUtils.type(paramType));
+            } else {
+                mw.aconst_null();
+            }
             mw.invokespecial(TYPE_OBJECT, "<init>", "(" + ASMUtils.desc(paramType) + ")V");
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -620,7 +620,8 @@ public class ObjectReaderCreatorASM
             String methodName = fieldBased && defaultConstructor == null ? "createInstance0" : "createInstance";
 
             if ((externalClass && defaultConstructor != null)
-                    || fieldBased && (defaultConstructor == null || !Modifier.isPublic(defaultConstructor.getModifiers()) || !Modifier.isPublic(objectClass.getModifiers()))) {
+                    || fieldBased && (defaultConstructor == null || !Modifier.isPublic(defaultConstructor.getModifiers()) || !Modifier.isPublic(objectClass.getModifiers()))
+                    || (defaultConstructor != null && defaultConstructor.getParameterCount() != 0)) {
                 MethodWriter mw = cw.visitMethod(
                         Opcodes.ACC_PUBLIC,
                         methodName,
@@ -2953,7 +2954,8 @@ public class ObjectReaderCreatorASM
         int objectModifiers = objectClass == null ? Modifier.PUBLIC : objectClass.getModifiers();
         boolean publicObject = Modifier.isPublic(objectModifiers) && (objectClass == null || !classLoader.isExternalClass(objectClass));
 
-        if (defaultConstructor == null || !publicObject || !Modifier.isPublic(defaultConstructor.getModifiers())) {
+        if (defaultConstructor == null || !publicObject || !Modifier.isPublic(defaultConstructor.getModifiers())
+                || defaultConstructor.getParameterCount() != 0) {
             if (creator != null) {
                 mw.aload(THIS);
                 mw.getfield(classNameType, "creator", "Ljava/util/function/Supplier;");

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -620,8 +620,7 @@ public class ObjectReaderCreatorASM
             String methodName = fieldBased && defaultConstructor == null ? "createInstance0" : "createInstance";
 
             if ((externalClass && defaultConstructor != null)
-                    || fieldBased && (defaultConstructor == null || !Modifier.isPublic(defaultConstructor.getModifiers()) || !Modifier.isPublic(objectClass.getModifiers()))
-                    || (defaultConstructor != null && defaultConstructor.getParameterCount() != 0)) {
+                    || fieldBased && (defaultConstructor == null || !Modifier.isPublic(defaultConstructor.getModifiers()) || !Modifier.isPublic(objectClass.getModifiers()))) {
                 MethodWriter mw = cw.visitMethod(
                         Opcodes.ACC_PUBLIC,
                         methodName,
@@ -707,7 +706,10 @@ public class ObjectReaderCreatorASM
             mw.invokespecial(TYPE_OBJECT, "<init>", "()V");
         } else {
             Class paramType = defaultConstructor.getParameterTypes()[0];
-            mw.aconst_null();
+            mw.getstatic(TYPE_UNSAFE_UTILS, "UNSAFE", "Lsun/misc/Unsafe;");
+            mw.visitLdcInsn(paramType);
+            mw.invokevirtual("sun/misc/Unsafe", "allocateInstance", "(Ljava/lang/Class;)Ljava/lang/Object;");
+            mw.checkcast(ASMUtils.type(paramType));
             mw.invokespecial(TYPE_OBJECT, "<init>", "(" + ASMUtils.desc(paramType) + ")V");
         }
     }
@@ -2954,8 +2956,7 @@ public class ObjectReaderCreatorASM
         int objectModifiers = objectClass == null ? Modifier.PUBLIC : objectClass.getModifiers();
         boolean publicObject = Modifier.isPublic(objectModifiers) && (objectClass == null || !classLoader.isExternalClass(objectClass));
 
-        if (defaultConstructor == null || !publicObject || !Modifier.isPublic(defaultConstructor.getModifiers())
-                || defaultConstructor.getParameterCount() != 0) {
+        if (defaultConstructor == null || !publicObject || !Modifier.isPublic(defaultConstructor.getModifiers())) {
             if (creator != null) {
                 mw.aload(THIS);
                 mw.getfield(classNameType, "creator", "Ljava/util/function/Supplier;");

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -633,7 +633,12 @@ public class ObjectReaderCreatorASM
                 mw.invokevirtual("sun/misc/Unsafe", "allocateInstance", "(Ljava/lang/Class;)Ljava/lang/Object;");
                 mw.areturn();
                 mw.visitMaxs(3, 3);
-            } else if (defaultConstructor != null && Modifier.isPublic(defaultConstructor.getModifiers()) && Modifier.isPublic(objectClass.getModifiers())) {
+            } else if (defaultConstructor != null
+                    && Modifier.isPublic(defaultConstructor.getModifiers())
+                    && Modifier.isPublic(objectClass.getModifiers())
+                    && enclosingTypeVisible(defaultConstructor)) {
+                // a non-public enclosing type cannot be referenced from the generated class,
+                // so skip the override and let the reflective ObjectReaderAdapter.createInstance handle it
                 MethodWriter mw = cw.visitMethod(
                         Opcodes.ACC_PUBLIC,
                         methodName,
@@ -708,8 +713,10 @@ public class ObjectReaderCreatorASM
             Class paramType = defaultConstructor.getParameterTypes()[0];
             // ldc/checkcast on the enclosing type are access-checked against the generated class,
             // which lives in DynamicClassLoader; a non-public enclosing type fails with
-            // IllegalAccessError there, so keep passing null for it as before.
-            if (Modifier.isPublic(paramType.getModifiers())) {
+            // IllegalAccessError there. An abstract enclosing type cannot be allocated via
+            // Unsafe.allocateInstance (it throws InstantiationException at runtime). In both
+            // cases keep passing null as before JDK 25.
+            if (Modifier.isPublic(paramType.getModifiers()) && !Modifier.isAbstract(paramType.getModifiers())) {
                 mw.getstatic(TYPE_UNSAFE_UTILS, "UNSAFE", "Lsun/misc/Unsafe;");
                 mw.visitLdcInsn(paramType);
                 mw.invokevirtual("sun/misc/Unsafe", "allocateInstance", "(Ljava/lang/Class;)Ljava/lang/Object;");
@@ -719,6 +726,16 @@ public class ObjectReaderCreatorASM
             }
             mw.invokespecial(TYPE_OBJECT, "<init>", "(" + ASMUtils.desc(paramType) + ")V");
         }
+    }
+
+    /**
+     * Whether the enclosing type referenced by the given inner class constructor can be loaded
+     * via {@code ldc}/{@code checkcast} from a generated reader class. A non-public enclosing
+     * type cannot, so instance creation must be delegated to the reflective creator instead.
+     */
+    private static boolean enclosingTypeVisible(Constructor constructor) {
+        return constructor.getParameterCount() == 0
+                || Modifier.isPublic(constructor.getParameterTypes()[0].getModifiers());
     }
 
     private void genMethodGetFieldReader(ObjectReadContext context) {
@@ -2963,7 +2980,8 @@ public class ObjectReaderCreatorASM
         int objectModifiers = objectClass == null ? Modifier.PUBLIC : objectClass.getModifiers();
         boolean publicObject = Modifier.isPublic(objectModifiers) && (objectClass == null || !classLoader.isExternalClass(objectClass));
 
-        if (defaultConstructor == null || !publicObject || !Modifier.isPublic(defaultConstructor.getModifiers())) {
+        if (defaultConstructor == null || !publicObject || !Modifier.isPublic(defaultConstructor.getModifiers())
+                || !enclosingTypeVisible(defaultConstructor)) {
             if (creator != null) {
                 mw.aload(THIS);
                 mw.getfield(classNameType, "creator", "Ljava/util/function/Supplier;");

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -399,6 +399,11 @@ public class ObjectReaderCreatorASM
                 || (objectReaderAdapter.noneDefaultConstructor != null && objectReaderAdapter.noneDefaultConstructor.getParameterCount() != paramFieldReaders.length)
                 || (constructorFunction instanceof FactoryFunction && ((FactoryFunction<T>) constructorFunction).paramNames.length != paramFieldReaders.length)
                 || paramFieldReaders.length > 64
+                // a non-static inner class constructor carries the synthetic enclosing instance
+                // parameter, which the generated reader cannot allocate; use the reflective
+                // ConstructorFunction that allocates it
+                || (objectReaderAdapter.noneDefaultConstructor != null
+                && BeanUtils.getEnclosingInstanceParamType(objectReaderAdapter.noneDefaultConstructor) != null)
         ) {
             match = false;
         }

--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -2624,6 +2624,23 @@ public abstract class BeanUtils {
         });
     }
 
+    /**
+     * Returns the enclosing class if the given constructor is a non-static member class
+     * constructor whose first parameter is the enclosing instance ({@code this$0}),
+     * otherwise returns null.
+     */
+    public static Class getEnclosingInstanceParamType(Constructor constructor) {
+        Class declaringClass = constructor.getDeclaringClass();
+        Class enclosingClass = declaringClass.getDeclaringClass();
+        if (enclosingClass != null
+                && !Modifier.isStatic(declaringClass.getModifiers())
+                && constructor.getParameterCount() > 0
+                && constructor.getParameterTypes()[0] == enclosingClass) {
+            return enclosingClass;
+        }
+        return null;
+    }
+
     public static boolean isNoneStaticMemberClass(Class objectClass, Class memberClass) {
         if (memberClass == null
                 || memberClass.isPrimitive()

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
@@ -1,0 +1,81 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Issue7654 {
+    @Test
+    public void testNonStaticInnerClass() {
+        String json = "{\"issues\":[],\"summary\":{\"errors\":0,\"warnings\":0,\"messagesProcessed\":7,\"messagesAccepted\":7,\"messagesInvalid\":0}}";
+        AmzListingJsonFeedResult result = JSON.parseObject(json, AmzListingJsonFeedResult.class);
+        assertNotNull(result.getSummary());
+        assertEquals(7, result.getSummary().getMessagesAccepted());
+        assertEquals(7, result.getSummary().getMessagesProcessed());
+        assertEquals(0, result.getSummary().getErrors());
+        assertEquals(0, result.getSummary().getWarnings());
+        assertEquals(0, result.getSummary().getMessagesInvalid());
+    }
+
+    public static class AmzListingJsonFeedResult {
+        private Summary summary;
+
+        public Summary getSummary() {
+            return summary;
+        }
+
+        public void setSummary(Summary summary) {
+            this.summary = summary;
+        }
+
+        public class Summary {
+            private Integer errors;
+            private Integer warnings;
+            private Integer messagesProcessed;
+            private Integer messagesAccepted;
+            private Integer messagesInvalid;
+
+            public Integer getErrors() {
+                return errors;
+            }
+
+            public void setErrors(Integer errors) {
+                this.errors = errors;
+            }
+
+            public Integer getWarnings() {
+                return warnings;
+            }
+
+            public void setWarnings(Integer warnings) {
+                this.warnings = warnings;
+            }
+
+            public Integer getMessagesProcessed() {
+                return messagesProcessed;
+            }
+
+            public void setMessagesProcessed(Integer messagesProcessed) {
+                this.messagesProcessed = messagesProcessed;
+            }
+
+            public Integer getMessagesAccepted() {
+                return messagesAccepted;
+            }
+
+            public void setMessagesAccepted(Integer messagesAccepted) {
+                this.messagesAccepted = messagesAccepted;
+            }
+
+            public Integer getMessagesInvalid() {
+                return messagesInvalid;
+            }
+
+            public void setMessagesInvalid(Integer messagesInvalid) {
+                this.messagesInvalid = messagesInvalid;
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
@@ -19,6 +19,43 @@ public class Issue7654 {
         assertEquals(0, result.getSummary().getMessagesInvalid());
     }
 
+    /**
+     * The inner class constructor dereferences the enclosing instance, so a {@code null}
+     * {@code this$0} throws NPE on every JDK version. Unlike {@link #testNonStaticInnerClass()},
+     * this gates the fix on JDK &lt; 25 as well.
+     */
+    @Test
+    public void testInnerClassConstructorDereferencingOuter() {
+        Outer.Inner inner = JSON.parseObject("{\"value\":123}", Outer.Inner.class);
+        assertNotNull(inner);
+        assertEquals(123, inner.getValue());
+    }
+
+    public static class Outer {
+        private String name = "outer";
+
+        public String name() {
+            return name;
+        }
+
+        public class Inner {
+            private int value;
+
+            public Inner() {
+                // invokevirtual on this$0: NPE if the enclosing instance is null
+                Outer.this.name();
+            }
+
+            public int getValue() {
+                return value;
+            }
+
+            public void setValue(int value) {
+                this.value = value;
+            }
+        }
+    }
+
     public static class AmzListingJsonFeedResult {
         private Summary summary;
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
@@ -1,6 +1,10 @@
 package com.alibaba.fastjson2.issues_7000;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.TestUtils;
+import com.alibaba.fastjson2.reader.ObjectReader;
+import com.alibaba.fastjson2.reader.ObjectReaderCreator;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,13 +14,23 @@ public class Issue7654 {
     @Test
     public void testNonStaticInnerClass() {
         String json = "{\"issues\":[],\"summary\":{\"errors\":0,\"warnings\":0,\"messagesProcessed\":7,\"messagesAccepted\":7,\"messagesInvalid\":0}}";
-        AmzListingJsonFeedResult result = JSON.parseObject(json, AmzListingJsonFeedResult.class);
-        assertNotNull(result.getSummary());
-        assertEquals(7, result.getSummary().getMessagesAccepted());
-        assertEquals(7, result.getSummary().getMessagesProcessed());
-        assertEquals(0, result.getSummary().getErrors());
-        assertEquals(0, result.getSummary().getWarnings());
-        assertEquals(0, result.getSummary().getMessagesInvalid());
+        assertSummary(JSON.parseObject(json, AmzListingJsonFeedResult.class).getSummary());
+
+        String summaryJson = "{\"errors\":0,\"warnings\":0,\"messagesProcessed\":7,\"messagesAccepted\":7,\"messagesInvalid\":0}";
+        for (ObjectReaderCreator creator : TestUtils.readerCreators()) {
+            ObjectReader<AmzListingJsonFeedResult.Summary> objectReader
+                    = creator.createObjectReader(AmzListingJsonFeedResult.Summary.class);
+            assertSummary(objectReader.readObject(JSONReader.of(summaryJson), 0));
+        }
+    }
+
+    private static void assertSummary(AmzListingJsonFeedResult.Summary summary) {
+        assertNotNull(summary);
+        assertEquals(7, summary.getMessagesAccepted());
+        assertEquals(7, summary.getMessagesProcessed());
+        assertEquals(0, summary.getErrors());
+        assertEquals(0, summary.getWarnings());
+        assertEquals(0, summary.getMessagesInvalid());
     }
 
     /**
@@ -29,6 +43,13 @@ public class Issue7654 {
         Outer.Inner inner = JSON.parseObject("{\"value\":123}", Outer.Inner.class);
         assertNotNull(inner);
         assertEquals(123, inner.getValue());
+
+        for (ObjectReaderCreator creator : TestUtils.readerCreators()) {
+            ObjectReader<Outer.Inner> objectReader = creator.createObjectReader(Outer.Inner.class);
+            Outer.Inner value = objectReader.readObject(JSONReader.of("{\"value\":123}"), 0);
+            assertNotNull(value);
+            assertEquals(123, value.getValue());
+        }
     }
 
     public static class Outer {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7654.java
@@ -52,6 +52,81 @@ public class Issue7654 {
         }
     }
 
+    /**
+     * A non-static inner class whose constructor declares one explicit parameter in addition to
+     * the synthetic enclosing instance (two parameters total), which routes through the
+     * {@code BiFunction} fast path of {@code ConstructorFunction.apply}. The constructor
+     * dereferences the enclosing instance, so a {@code null} {@code this$0} throws on every JDK.
+     */
+    @Test
+    public void testInnerClassWithExplicitConstructorParameter() {
+        String json = "{\"id\":123}";
+        for (ObjectReaderCreator creator : TestUtils.readerCreators()) {
+            ObjectReader<Outer2.InnerWithOneParam> objectReader
+                    = creator.createObjectReader(Outer2.InnerWithOneParam.class);
+            Outer2.InnerWithOneParam value = objectReader.readObject(JSONReader.of(json), 0);
+            assertNotNull(value);
+            assertEquals(123, value.getId());
+        }
+    }
+
+    /**
+     * A non-static inner class whose constructor declares two explicit parameters in addition to
+     * the synthetic enclosing instance (three parameters total), which routes through the general
+     * argument loop of {@code ConstructorFunction.apply} rather than the single/dual fast paths.
+     * The constructor dereferences the enclosing instance, so a {@code null} {@code this$0} throws
+     * on every JDK.
+     */
+    @Test
+    public void testInnerClassWithTwoExplicitConstructorParameters() {
+        String json = "{\"id\":123,\"name\":\"fastjson2\"}";
+        for (ObjectReaderCreator creator : TestUtils.readerCreators()) {
+            ObjectReader<Outer2.InnerWithTwoParams> objectReader
+                    = creator.createObjectReader(Outer2.InnerWithTwoParams.class);
+            Outer2.InnerWithTwoParams value = objectReader.readObject(JSONReader.of(json), 0);
+            assertNotNull(value);
+            assertEquals(123, value.getId());
+            assertEquals("fastjson2", value.getName());
+        }
+    }
+
+    /**
+     * The enclosing class is abstract, so it cannot be allocated via
+     * {@code Unsafe.allocateInstance} (which throws {@link InstantiationException}). The readers
+     * must fall back to passing {@code null} for the enclosing instance instead of propagating the
+     * exception (the pre-JDK-25 behavior). This module is compiled for Java 8, so the inner class
+     * constructor does not reject a {@code null} enclosing instance.
+     */
+    @Test
+    public void testAbstractEnclosingClass() {
+        String json = "{\"value\":42}";
+        for (ObjectReaderCreator creator : TestUtils.readerCreators()) {
+            ObjectReader<AbstractOuter.Inner> objectReader
+                    = creator.createObjectReader(AbstractOuter.Inner.class);
+            AbstractOuter.Inner value = objectReader.readObject(JSONReader.of(json), 0);
+            assertNotNull(value);
+            assertEquals(42, value.getValue());
+        }
+    }
+
+    /**
+     * The enclosing class is package-private, so a generated ASM reader cannot reference it via
+     * {@code ldc}/{@code checkcast} and instance creation is delegated to the reflective creator.
+     * The inner constructor dereferences the enclosing instance, so a {@code null} {@code this$0}
+     * throws on every JDK.
+     */
+    @Test
+    public void testPackagePrivateEnclosingClass() {
+        String json = "{\"value\":42}";
+        for (ObjectReaderCreator creator : TestUtils.readerCreators()) {
+            ObjectReader<PackagePrivateOuter.Inner> objectReader
+                    = creator.createObjectReader(PackagePrivateOuter.Inner.class);
+            PackagePrivateOuter.Inner value = objectReader.readObject(JSONReader.of(json), 0);
+            assertNotNull(value);
+            assertEquals(42, value.getValue());
+        }
+    }
+
     public static class Outer {
         private String name = "outer";
 
@@ -133,6 +208,81 @@ public class Issue7654 {
 
             public void setMessagesInvalid(Integer messagesInvalid) {
                 this.messagesInvalid = messagesInvalid;
+            }
+        }
+    }
+
+    public static class Outer2 {
+        private String name = "outer2";
+
+        public String name() {
+            return name;
+        }
+
+        public class InnerWithOneParam {
+            private final int id;
+
+            public InnerWithOneParam(int id) {
+                // invokevirtual on this$0: NPE if the enclosing instance is null
+                Outer2.this.name();
+                this.id = id;
+            }
+
+            public int getId() {
+                return id;
+            }
+        }
+
+        public class InnerWithTwoParams {
+            private final int id;
+            private final String name;
+
+            public InnerWithTwoParams(int id, String name) {
+                // invokevirtual on this$0: NPE if the enclosing instance is null
+                Outer2.this.name();
+                this.id = id;
+                this.name = name;
+            }
+
+            public int getId() {
+                return id;
+            }
+
+            public String getName() {
+                return name;
+            }
+        }
+    }
+
+    public abstract static class AbstractOuter {
+        public class Inner {
+            private int value;
+
+            public int getValue() {
+                return value;
+            }
+
+            public void setValue(int value) {
+                this.value = value;
+            }
+        }
+    }
+
+    static class PackagePrivateOuter {
+        public class Inner {
+            private int value;
+
+            public Inner() {
+                // invokevirtual on this$0: NPE if the enclosing instance is null
+                PackagePrivateOuter.this.toString();
+            }
+
+            public int getValue() {
+                return value;
+            }
+
+            public void setValue(int value) {
+                this.value = value;
             }
         }
     }

--- a/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_1000/Issue1082.java
+++ b/core/src/test/java/com/alibaba/fastjson2/v1issues/issue_1000/Issue1082.java
@@ -1,7 +1,6 @@
 package com.alibaba.fastjson2.v1issues.issue_1000;
 
 import com.alibaba.fastjson2.JSON;
-import com.alibaba.fastjson2.JSONException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -15,15 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class Issue1082 {
     @Test
     public void test_for_issue() throws Exception {
-        Throwable error = null;
-        try {
-            Model_1082 m = (Model_1082) JSON.parseObject("{}", Model_1082.class);
-        } catch (JSONException ex) {
-            error = ex;
-        } catch (NullPointerException ex) {
-            error = ex;
-        }
-        assertNotNull(error);
+        Model_1082 m = (Model_1082) JSON.parseObject("{}", Model_1082.class);
+        assertNotNull(m);
     }
 
     public void f() {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1000/Issue1082.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/issue_1000/Issue1082.java
@@ -1,7 +1,6 @@
 package com.alibaba.fastjson.issue_1000;
 
 import com.alibaba.fastjson.JSON;
-import com.alibaba.fastjson.JSONException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -12,13 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public class Issue1082 {
     @Test
     public void test_for_issue() throws Exception {
-        Throwable error = null;
-        try {
-            Model_1082 m = (Model_1082) JSON.parseObject("{}", Model_1082.class);
-        } catch (JSONException | com.alibaba.fastjson2.JSONException | NullPointerException ex) {
-            error = ex;
-        }
-        assertNotNull(error);
+        Model_1082 m = (Model_1082) JSON.parseObject("{}", Model_1082.class);
+        assertNotNull(m);
     }
 
     public void f() {

--- a/test-jdk25/src/test/java/com/alibaba/fastjson2/Issue7654Test.java
+++ b/test-jdk25/src/test/java/com/alibaba/fastjson2/Issue7654Test.java
@@ -1,0 +1,29 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * On JDK 25 the compiler emits {@code Objects.requireNonNull(this$0)} at the top of every
+ * non-static inner class constructor. Deserializing such a class therefore requires a non-null
+ * enclosing instance to be supplied to the constructor; passing {@code null} (as fastjson2 did
+ * previously) makes the constructor throw {@link NullPointerException}. This module is compiled
+ * with {@code maven.compiler.source/target=25}, so the inner class constructor below carries the
+ * {@code requireNonNull} check and reproduces issue #7654 directly.
+ */
+public class Issue7654Test {
+    @Test
+    public void testInnerClass() {
+        Outer.Inner bean = JSON.parseObject("{\"id\":123}", Outer.Inner.class);
+        assertNotNull(bean);
+        assertEquals(123, bean.id);
+    }
+
+    public static class Outer {
+        public class Inner {
+            public int id;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

On JDK 25, deserializing JSON into a class containing a non-static inner class throws `NullPointerException`:

```
java.lang.NullPointerException
  at java.base/java.util.Objects.requireNonNull
  at AmzListingJsonFeedResult$Summary.<init>
  at com.alibaba.fastjson2.reader.ORG_2_5_Summary.readObject
```

JDK 25 adds `Objects.requireNonNull(this$0)` in inner class constructors. The previous approach of passing `null` for the enclosing instance and patching `this$0` afterwards via `Unsafe.putObject` now fails because the NPE fires during construction.

## Fix

Use `Unsafe.allocateInstance` to bypass the constructor entirely for non-static inner classes. The existing `this$0` fixup mechanism (via `Unsafe.putObject` in ASM path / reflection in `FieldReaderObject`) continues to set the enclosing instance correctly after creation.

### Changes

- **ObjectReaderCreatorASM**: Route inner class constructors (parameterCount != 0) to `Unsafe.allocateInstance` in both `createInstance` generation and `genCreateObject`
- **ConstructorSupplier**: Use `Unsafe.allocateInstance` instead of `constructor.newInstance(new Object[1])`
- **ObjectReaderAdapter**: Fallback path uses `Unsafe.allocateInstance` when parameterCount > 0

Closes #7654