### PR TITLE
test: cover both strBuf sizing paths in readString (#7685)

### DIFF
--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7685.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7685.java
@@ -1,0 +1,41 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Issue7685 {
+    @Test
+    public void test() {
+        String str = "{\"Test\":[{\"message\":\"中\\n\"},{\"message\":\"s Howard), dedicated to dinosaur conservation, was invited by Benjamin Lockwood. Benjamin and his subordinate Eli Mills (played by Rafi Spo) hope that she and relevant technicians will go to Isla Nublar to save the dinosaurs there and relocate them to a new habitat. Claire, who is infected, manages to bring Owen (played by Chris Pratt) along to go, while Owen hopes to rescue the velociraptor Blue that he has personally tamed. When they set foot on this isolated island, they found that things were not that simple.\\nVolcanoes are restless and ready to erupt, while ugly conspiracies are quietly brewing amidst chaos.\"}]}";
+        JSONObject result = JSON.parseObject(str);
+        assertNotNull(result);
+        assertEquals(2, result.getJSONArray("Test").size());
+    }
+
+    @Test
+    public void testVariousLengths() {
+        for (int len = 1; len <= 600; len++) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("{\"Test\":[{\"message\":\"中\\n\"},{\"message\":\"");
+            for (int i = 0; i < len; i++) {
+                sb.append('a');
+            }
+            sb.append("\\n");
+            for (int i = 0; i < len; i++) {
+                sb.append('b');
+            }
+            sb.append("\"}]}");
+
+            JSONObject result = JSON.parseObject(sb.toString());
+            assertNotNull(result);
+            String message = result.getJSONArray("Test")
+                    .getJSONObject(1)
+                    .getString("message");
+            assertEquals(len * 2 + 1, message.length());
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7685.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7685.java
@@ -1,8 +1,11 @@
 package com.alibaba.fastjson2.issues_7000;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONObject;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -36,6 +39,64 @@ public class Issue7685 {
                     .getJSONObject(1)
                     .getString("message");
             assertEquals(len * 2 + 1, message.length());
+        }
+    }
+
+    /**
+     * Same payloads as {@link #testVariousLengths()}, but parsed from UTF-8 bytes so the
+     * escape handling in JSONReaderUTF8.readString is exercised as well — that reader got
+     * the same strBuf growth fix and is not reached through the String entry point, which
+     * routes multi-byte input to JSONReaderUTF16.
+     */
+    @Test
+    public void testVariousLengthsUTF8() {
+        for (int len = 1; len <= 600; len++) {
+            assertMessageRoundTripUTF8(len);
+        }
+        // strBuf is pooled process-wide, so a preceding test may leave a buffer that already
+        // covers the lengths above; this one is past any capacity another test can have grown it to.
+        assertMessageRoundTripUTF8(100_000);
+    }
+
+    private void assertMessageRoundTripUTF8(int len) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"Test\":[{\"message\":\"中\\n\"},{\"message\":\"");
+        for (int i = 0; i < len; i++) {
+            sb.append('a');
+        }
+        sb.append("\\n");
+        for (int i = 0; i < len; i++) {
+            sb.append('b');
+        }
+        sb.append("\"}]}");
+
+        byte[] utf8 = sb.toString().getBytes(StandardCharsets.UTF_8);
+        JSONObject result = JSON.parseObject(utf8);
+        assertNotNull(result);
+        String message = result.getJSONArray("Test")
+                .getJSONObject(1)
+                .getString("message");
+        assertEquals(len * 2 + 1, message.length());
+    }
+
+    @Test
+    public void testVariousLengthsJSONB() {
+        for (int len = 1; len <= 600; len++) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("中\n");
+            for (int i = 0; i < len; i++) {
+                sb.append('a');
+            }
+            sb.append('\n');
+            for (int i = 0; i < len; i++) {
+                sb.append('b');
+            }
+            String message = sb.toString();
+
+            JSONObject object = new JSONObject().fluentPut("message", message);
+            JSONObject parsed = (JSONObject) JSONB.parse(JSONB.toBytes(object));
+            assertNotNull(parsed);
+            assertEquals(message, parsed.getString("message"));
         }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7685.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7685.java
@@ -22,23 +22,9 @@ public class Issue7685 {
     @Test
     public void testVariousLengths() {
         for (int len = 1; len <= 600; len++) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("{\"Test\":[{\"message\":\"中\\n\"},{\"message\":\"");
-            for (int i = 0; i < len; i++) {
-                sb.append('a');
-            }
-            sb.append("\\n");
-            for (int i = 0; i < len; i++) {
-                sb.append('b');
-            }
-            sb.append("\"}]}");
-
-            JSONObject result = JSON.parseObject(sb.toString());
+            JSONObject result = JSON.parseObject(payload(len));
             assertNotNull(result);
-            String message = result.getJSONArray("Test")
-                    .getJSONObject(1)
-                    .getString("message");
-            assertEquals(len * 2 + 1, message.length());
+            assertEquals(expectedMessage(len), messageOf(result));
         }
     }
 
@@ -58,45 +44,89 @@ public class Issue7685 {
         assertMessageRoundTripUTF8(100_000);
     }
 
-    private void assertMessageRoundTripUTF8(int len) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("{\"Test\":[{\"message\":\"中\\n\"},{\"message\":\"");
-        for (int i = 0; i < len; i++) {
-            sb.append('a');
-        }
-        sb.append("\\n");
-        for (int i = 0; i < len; i++) {
-            sb.append('b');
-        }
-        sb.append("\"}]}");
+    /**
+     * Covers the initial {@code strBuf} allocation, {@code new char[stroff + 512]}: the escape is
+     * preceded by more than 512 characters that have already been scanned into {@code stroff}, so
+     * a plain {@code new char[512]} is too small for the pre-copy into the fresh buffer.
+     *
+     * <p>Unlike {@link #testVariousLengths()}, the escape must be in the <em>first</em> string
+     * value of the document — once {@code strBuf} has been allocated, later strings take the
+     * growth path instead. JSONReaderUTF16 keeps strBuf per reader instance, so every parse
+     * starts from null; the leading multi-byte character is what routes the String entry point
+     * to that reader rather than to the ASCII/UTF-8 one.
+     */
+    @Test
+    public void testLongPrefixBeforeFirstEscape() {
+        for (int len : new int[]{500, 511, 512, 513, 600, 4096}) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("{\"message\":\"中");
+            repeat(sb, 'a', len);
+            sb.append("\\n\"}");
 
-        byte[] utf8 = sb.toString().getBytes(StandardCharsets.UTF_8);
-        JSONObject result = JSON.parseObject(utf8);
-        assertNotNull(result);
-        String message = result.getJSONArray("Test")
-                .getJSONObject(1)
-                .getString("message");
-        assertEquals(len * 2 + 1, message.length());
+            String expected = repeat(new StringBuilder(len + 2).append('中'), 'a', len)
+                    .append('\n')
+                    .toString();
+            assertEquals(expected, JSON.parseObject(sb.toString()).getString("message"));
+        }
     }
 
+    /**
+     * Round-trip sanity check for the JSONB reader. It does <em>not</em> cover the strBuf fix:
+     * JSONReaderJSONB has no strBuf and reads string values by length prefix rather than by
+     * scanning for escapes, so it cannot reach the code path issue #7685 is about.
+     */
     @Test
     public void testVariousLengthsJSONB() {
         for (int len = 1; len <= 600; len++) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("中\n");
-            for (int i = 0; i < len; i++) {
-                sb.append('a');
-            }
-            sb.append('\n');
-            for (int i = 0; i < len; i++) {
-                sb.append('b');
-            }
-            String message = sb.toString();
+            String message = "中\n" + expectedMessage(len);
 
             JSONObject object = new JSONObject().fluentPut("message", message);
             JSONObject parsed = (JSONObject) JSONB.parse(JSONB.toBytes(object));
             assertNotNull(parsed);
             assertEquals(message, parsed.getString("message"));
         }
+    }
+
+    private void assertMessageRoundTripUTF8(int len) {
+        byte[] utf8 = payload(len).getBytes(StandardCharsets.UTF_8);
+        JSONObject result = JSON.parseObject(utf8);
+        assertNotNull(result);
+        assertEquals(expectedMessage(len), messageOf(result));
+    }
+
+    /**
+     * {@code {"Test":[{"message":"中\n"},{"message":"a*len \n b*len"}]}} — the leading multi-byte
+     * value forces the String entry point onto JSONReaderUTF16, and the second value is the one
+     * that has to grow strBuf.
+     */
+    private static String payload(int len) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"Test\":[{\"message\":\"中\\n\"},{\"message\":\"");
+        repeat(sb, 'a', len);
+        sb.append("\\n");
+        repeat(sb, 'b', len);
+        sb.append("\"}]}");
+        return sb.toString();
+    }
+
+    private static String expectedMessage(int len) {
+        StringBuilder sb = new StringBuilder(len * 2 + 1);
+        repeat(sb, 'a', len);
+        sb.append('\n');
+        repeat(sb, 'b', len);
+        return sb.toString();
+    }
+
+    private static String messageOf(JSONObject result) {
+        return result.getJSONArray("Test")
+                .getJSONObject(1)
+                .getString("message");
+    }
+
+    private static StringBuilder repeat(StringBuilder sb, char c, int count) {
+        for (int i = 0; i < count; i++) {
+            sb.append(c);
+        }
+        return sb;
     }
 }


### PR DESCRIPTION
## Summary

Regression tests for #7685 — `ArrayIndexOutOfBoundsException` in `readString` when a string containing a `\n` escape is long enough to outgrow `strBuf`.

**Test-only, no production change.** The bug itself was already fixed on `main`: `bdfe92f76` (#3989) added the `stroff > strBuf.length` guard before the pre-copy, but that fix did not make it into the 2.0.61 release, which is what the reporter hit. What was missing was coverage — the tests here pin the behaviour of both `strBuf` sizing paths in `JSONReaderUTF16` / `JSONReaderUTF8`:

```java
char[] strBuf = this.strBuf;
if (strBuf == null) {
    strBuf = new char[stroff + 512];      // initial allocation
    this.strBuf = strBuf;
} else if (stroff > strBuf.length) {      // growth on reuse
    ...
}
System.arraycopy(chars, start, strBuf, 0, stroff);
```

## Tests

| Test | Covers |
|---|---|
| `test` | The exact payload from the issue report |
| `testVariousLengths` | Growth path via `JSONReaderUTF16`, sweeping lengths 1–600 around the 512 boundary |
| `testVariousLengthsUTF8` | Same payloads via `JSONReaderUTF8`, plus one at 100 000 to clear any buffer a preceding test left in the process-wide cache |
| `testLongPrefixBeforeFirstEscape` | Initial allocation — the escape sits in the first string value, behind 500–4096 already-scanned characters |
| `testVariousLengthsJSONB` | Round-trip sanity check only; documented as *not* covering `strBuf` |

Assertions compare full string content, not just length, so a substitution in the escape table cannot slip through.

## Verification

Each claim was revert-probed rather than assumed.

**Growth path** — restoring `new char[stroff + 512]` to `new char[512]` in both readers:

```
[ERROR] Issue7685.testLongPrefixBeforeFirstEscape:69
        java.lang.ArrayIndexOutOfBoundsException:
        arraycopy: last destination index 600 out of bounds for char[512]
  at com.alibaba.fastjson2.JSONReaderUTF16.readString(JSONReaderUTF16.java:3261)
```

**Content assertions** — mutating `'n', '\n'` to `'n', '\r'` in the `char1_escaped` table (`JSONReader.java:102`) fails 3 of the 5 tests. With length-only assertions the same mutation passed all of them.

## Notes

Two things worth recording, since they are what makes the tests work at all:

- A plain-ASCII payload never reaches `JSONReaderUTF16`. `JSON.parseObject(String)` routes a LATIN1-coded string to the ASCII/UTF-8 reader, so the value has to be prefixed with a multi-byte character to exercise the UTF-16 reader. `JSONReaderUTF16.strBuf` is a per-instance field and therefore null on every parse, which is what makes the initial-allocation path reachable from a test.
- `JSONReaderUTF8` takes `strBuf` from a process-wide cache, so its initial allocation cannot be forced from a test in a warm JVM. That branch stays uncovered; it is not claimed otherwise.

Full suites green locally on JDK 26 — core 7963, extension 56, fastjson1-compatible 1355, kotlin 36, safemode-test 2 — and core again with `-Dfastjson2.creator=reflect`.

Closes #7685

<details>
<summary>中文说明</summary>

## 概述

#7685 的回归测试 —— 含 `\n` 转义的字符串长到超出 `strBuf` 时，`readString` 抛 `ArrayIndexOutOfBoundsException`。

**纯测试，不改主代码。** 缺陷本身在 `main` 上已经修好：`bdfe92f76`（#3989）在 pre-copy 之前加了 `stroff > strBuf.length` 判断，但该修复没进 2.0.61 发布版，正是报告者踩到的。缺的是覆盖 —— 这里的测试固定住 `JSONReaderUTF16` / `JSONReaderUTF8` 中 `strBuf` 两条尺寸路径的行为：

```java
char[] strBuf = this.strBuf;
if (strBuf == null) {
    strBuf = new char[stroff + 512];      // 首次分配
    this.strBuf = strBuf;
} else if (stroff > strBuf.length) {      // 复用时扩容
    ...
}
System.arraycopy(chars, start, strBuf, 0, stroff);
```

## 测试

| 测试 | 覆盖 |
|---|---|
| `test` | issue 中原样的 payload |
| `testVariousLengths` | 经 `JSONReaderUTF16` 的扩容路径，长度 1–600 扫过 512 边界 |
| `testVariousLengthsUTF8` | 同样的 payload 经 `JSONReaderUTF8`，另加一个 100 000 的用例，越过前序测试可能留在进程级缓存里的 buffer |
| `testLongPrefixBeforeFirstEscape` | 首次分配 —— 转义位于第一个字符串值中，前面有 500–4096 个已扫描字符 |
| `testVariousLengthsJSONB` | 仅 round-trip sanity check；已注明**不**覆盖 `strBuf` |

断言比较字符串完整内容而非仅长度，转义表里的字符替换无法蒙混过关。

## 验证

每一条结论都做了 revert-probe，不是推断。

**扩容路径** —— 把两个 reader 的 `new char[stroff + 512]` 还原为 `new char[512]`：

```
[ERROR] Issue7685.testLongPrefixBeforeFirstEscape:69
        java.lang.ArrayIndexOutOfBoundsException:
        arraycopy: last destination index 600 out of bounds for char[512]
  at com.alibaba.fastjson2.JSONReaderUTF16.readString(JSONReaderUTF16.java:3261)
```

**内容断言** —— 把 `char1_escaped` 表（`JSONReader.java:102`）中的 `'n', '\n'` 改成 `'n', '\r'`，5 个测试挂 3 个。若只断言长度，同样的变异全部通过。

## 备注

两点值得记录，因为它们决定了测试能否成立：

- 纯 ASCII 的 payload 根本到不了 `JSONReaderUTF16`。`JSON.parseObject(String)` 对 LATIN1 编码的字符串走 ASCII/UTF-8 reader，因此值前面必须加多字节字符才能触发 UTF-16 reader。`JSONReaderUTF16.strBuf` 是实例字段，每次解析都为 null，这正是首次分配路径可被测试触达的原因。
- `JSONReaderUTF8` 的 `strBuf` 取自进程级缓存，在热 JVM 中无法从测试里强制其首次分配。该分支保持未覆盖，不作相反声明。

本地 JDK 26 全量通过 —— core 7963、extension 56、fastjson1-compatible 1355、kotlin 36、safemode-test 2；`-Dfastjson2.creator=reflect` 下 core 同样通过。

</details>
