### PR TITLE
fix: detect references for Collection elements (e.g. HashSet) (#7678)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplCollection.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplCollection.java
@@ -82,9 +82,6 @@ final class ObjectWriterImplCollection
 //        }
 
         boolean refDetect = jsonWriter.isRefDetect();
-        if (collection.size() > 1 && !(collection instanceof SortedSet) && !(collection instanceof LinkedHashSet)) {
-            refDetect = false;
-        }
 
         jsonWriter.startArray(collection.size());
 
@@ -149,8 +146,10 @@ final class ObjectWriterImplCollection
 
         Iterable iterable = (Iterable) object;
 
+        boolean refDetect = jsonWriter.isRefDetect();
         Class previousClass = null;
         ObjectWriter previousObjectWriter = null;
+        boolean previousRefDetect = false;
         jsonWriter.startArray();
         int i = 0;
         for (Object o : iterable) {
@@ -165,15 +164,33 @@ final class ObjectWriterImplCollection
             }
             Class<?> itemClass = o.getClass();
             ObjectWriter itemObjectWriter;
+            boolean itemRefDetect;
             if (itemClass == previousClass) {
                 itemObjectWriter = previousObjectWriter;
+                itemRefDetect = previousRefDetect;
             } else {
                 itemObjectWriter = jsonWriter.getObjectWriter(itemClass);
+                itemRefDetect = refDetect && !ObjectWriterProvider.isNotReferenceDetect(itemClass);
                 previousClass = itemClass;
                 previousObjectWriter = itemObjectWriter;
+                previousRefDetect = itemRefDetect;
+            }
+
+            if (itemRefDetect) {
+                String refPath = jsonWriter.setPath(i, o);
+                if (refPath != null) {
+                    jsonWriter.writeReference(refPath);
+                    jsonWriter.popPath(o);
+                    i++;
+                    continue;
+                }
             }
 
             itemObjectWriter.write(jsonWriter, o, i, this.itemType, this.features);
+
+            if (itemRefDetect) {
+                jsonWriter.popPath(o);
+            }
 
             ++i;
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7678.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7678.java
@@ -1,0 +1,132 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Issue7678 {
+    public static class Person {
+        public Set<Bean> testSet;
+    }
+
+    public static class Bean {
+        public String xxx1;
+        public String xxx2;
+        public String xxx3;
+    }
+
+    public static class Root {
+        public List<Object> data;
+        public Person person;
+    }
+
+    @Test
+    public void testHashSetRefDetectJSON() {
+        Bean bean = new Bean();
+        bean.xxx1 = "123";
+        bean.xxx2 = "123";
+        bean.xxx3 = "123";
+
+        Person person = new Person();
+        person.testSet = new HashSet<>();
+        person.testSet.add(bean);
+
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("Person", person);
+
+        Root root = new Root();
+        root.data = new ArrayList<>();
+        root.data.add(item);
+        root.person = person;
+
+        String json = JSON.toJSONString(root, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+
+        Object parsed = JSON.parse(json);
+        assertNotNull(parsed);
+    }
+
+    @Test
+    public void testHashSetRefDetectJSONB() {
+        Bean bean = new Bean();
+        bean.xxx1 = "123";
+        bean.xxx2 = "123";
+        bean.xxx3 = "123";
+
+        Person person = new Person();
+        person.testSet = new HashSet<>();
+        person.testSet.add(bean);
+
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("Person", person);
+
+        Root root = new Root();
+        root.data = new ArrayList<>();
+        root.data.add(item);
+        root.person = person;
+
+        byte[] bytes = JSONB.toBytes(root, JSONWriter.Feature.ReferenceDetection);
+        Root parsed = JSONB.parseObject(bytes, Root.class);
+        assertNotNull(parsed);
+        assertNotNull(parsed.person);
+        assertEquals(1, parsed.person.testSet.size());
+        Bean parsedBean = parsed.person.testSet.iterator().next();
+        assertEquals("123", parsedBean.xxx1);
+    }
+
+    @Test
+    public void testHashSetMultiElementRefDetect() {
+        Bean bean1 = new Bean();
+        bean1.xxx1 = "a";
+
+        Bean bean2 = new Bean();
+        bean2.xxx1 = "b";
+
+        Set<Bean> set = new HashSet<>();
+        set.add(bean1);
+        set.add(bean2);
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("set1", set);
+        map.put("set2", set);
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+
+    @Test
+    public void testLinkedHashSetRefDetect() {
+        Bean bean = new Bean();
+        bean.xxx1 = "123";
+
+        Person person = new Person();
+        person.testSet = new LinkedHashSet<>();
+        person.testSet.add(bean);
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("p1", person);
+        map.put("p2", person);
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+
+    @Test
+    public void testTreeSetRefDetect() {
+        Set<String> set = new TreeSet<>();
+        set.add("a");
+        set.add("b");
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("s1", set);
+        map.put("s2", set);
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7678.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7678.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson2.issues_7000;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TypeReference;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -128,5 +129,42 @@ public class Issue7678 {
 
         String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
         assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+
+    /**
+     * The same instance twice inside a single collection: the $ref can only come from the
+     * per-item setPath/popPath in ObjectWriterImplCollection, not from a parent-level writer.
+     * ArrayDeque is used because it is a Collection (so it routes to ObjectWriterImplCollection
+     * rather than ObjectWriterImplList) and, unlike a Set, it keeps duplicate elements.
+     */
+    @Test
+    public void testDuplicateItemWithinCollection() {
+        Bean bean = new Bean();
+        bean.xxx1 = "shared";
+
+        Collection<Bean> collection = new ArrayDeque<>();
+        collection.add(bean);
+        collection.add(bean);
+
+        String json = JSON.toJSONString(collection, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref for duplicate item within collection: " + json);
+    }
+
+    @Test
+    public void testDuplicateItemWithinCollectionJSONB() {
+        Bean bean = new Bean();
+        bean.xxx1 = "shared";
+
+        Collection<Bean> collection = new ArrayDeque<>();
+        collection.add(bean);
+        collection.add(bean);
+
+        byte[] bytes = JSONB.toBytes(collection, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(JSONB.toJSONString(bytes).contains("$ref"), "Expected $ref for duplicate item within collection: " + JSONB.toJSONString(bytes));
+
+        List<Bean> parsed = JSONB.parseObject(bytes, new TypeReference<List<Bean>>() {}.getType());
+        assertEquals(2, parsed.size());
+        assertSame(parsed.get(0), parsed.get(1));
+        assertEquals("shared", parsed.get(0).xxx1);
     }
 }


### PR DESCRIPTION
## Problem

When `JSONWriter.Feature.ReferenceDetection` is enabled, `ObjectWriterImplCollection` did not detect references among collection elements. A `HashSet` (or any `Collection` that is not a `List`) containing a duplicate object would serialize the object in full both times instead of emitting a `$ref` for the second occurrence. fastjson1 handled this correctly.

Two gaps existed in `ObjectWriterImplCollection`:

1. **`write` (JSON path):** no reference detection at all — elements were written directly without `setPath`/`writeReference`/`popPath`.
2. **`writeJSONB` (JSONB path):** reference detection was explicitly disabled for any non-`SortedSet`, non-`LinkedHashSet` collection with size > 1.

## Fix

- **JSON path:** added per-element reference detection following the same pattern as `ObjectWriterImplList.write` — checks `jsonWriter.isRefDetect()`, filters via `ObjectWriterProvider.isNotReferenceDetect(itemClass)`, then calls `setPath`/`writeReference`/`popPath`.
- **JSONB path:** removed the restriction that disabled ref detection for unordered sets.

## Test

`Issue7678.java` — 5 test cases:
- HashSet ref detection in JSON (exact scenario from the issue)
- HashSet ref detection in JSONB (round-trip)
- Multi-element HashSet
- LinkedHashSet
- TreeSet

## Verification

- 5/5 new tests pass
- 431 regression tests pass (features, jsonb, issues_7000, Set-specific) — 0 failures
- `mvn validate` (checkstyle) clean
