### PR TITLE
fix: strengthen autoType type name validation and whitelist verification

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -276,12 +276,6 @@ public class ContextAutoTypeBeforeHandler
                 if (clazz == null) {
                     clazz = loadClass(typeName);
                     if (clazz != null) {
-                        // matching an accept prefix is not an opt-in for gadget base types, only an
-                        // accept entry naming the type in full is; keep scanning for such an entry
-                        if (i + 1 < typeNameLength && JDKUtils.isAutoTypeDenyClass(clazz)) {
-                            continue;
-                        }
-
                         Class origin = putCacheIfAbsent(typeNameHash, clazz);
                         if (origin != null) {
                             clazz = origin;
@@ -290,6 +284,13 @@ public class ContextAutoTypeBeforeHandler
                 }
 
                 if (clazz != null) {
+                    // matching an accept prefix is not an opt-in for gadget base types, only an
+                    // accept entry naming the type in full is; keep scanning for such an entry.
+                    // checked after the cache read so that a cached class is checked too
+                    if (i + 1 < typeNameLength && JDKUtils.isAutoTypeDenyClass(clazz)) {
+                        continue;
+                    }
+
                     return clazz;
                 }
             }

--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -3,6 +3,7 @@ package com.alibaba.fastjson2.filter;
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.util.Fnv;
+import com.alibaba.fastjson2.util.JDKUtils;
 import com.alibaba.fastjson2.util.TypeUtils;
 
 import java.math.BigDecimal;
@@ -276,6 +277,12 @@ public class ContextAutoTypeBeforeHandler
                 if (clazz == null) {
                     clazz = loadClass(typeName);
                     if (clazz != null) {
+                        // matching an accept prefix is not an opt-in for gadget base types, only an
+                        // accept entry naming the type in full is; keep scanning for such an entry
+                        if (i + 1 < typeNameLength && JDKUtils.isAutoTypeDenyClass(clazz)) {
+                            continue;
+                        }
+
                         Class origin = putCacheIfAbsent(typeNameHash, clazz);
                         if (origin != null) {
                             clazz = origin;

--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -223,7 +223,7 @@ public class ContextAutoTypeBeforeHandler
             }
 
             array[index++] = hashCode;
-            normalizedNames.add(name.replace('$', '.'));
+            normalizedNames.add(normalizeAcceptName(name));
         }
 
         if (index != array.length) {
@@ -253,7 +253,7 @@ public class ContextAutoTypeBeforeHandler
             typeName = "Object";
         }
 
-        if (typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0) {
+        if (hasIllegalTypeNameChars(typeName)) {
             return null;
         }
 
@@ -267,8 +267,7 @@ public class ContextAutoTypeBeforeHandler
             hash *= MAGIC_PRIME;
 
             if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
-                String prefix = typeName.substring(0, i + 1).replace('$', '.');
-                if (!acceptNameSet.contains(prefix)) {
+                if (!acceptNameSet.contains(normalizeAcceptName(typeName.substring(0, i + 1)))) {
                     continue;
                 }
                 long typeNameHash = Fnv.hashCode64(typeName);

--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -24,6 +24,7 @@ import static com.alibaba.fastjson2.util.TypeUtils.*;
 public class ContextAutoTypeBeforeHandler
         implements JSONReader.AutoTypeBeforeHandler {
     final long[] acceptHashCodes;
+    final Set<String> acceptNameSet;
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, Class>> tclHashCaches = new ConcurrentHashMap<>();
     final Map<Long, Class> classCache = new ConcurrentHashMap<>(16, 0.75f, 1);
 
@@ -206,6 +207,7 @@ public class ContextAutoTypeBeforeHandler
         }
 
         long[] array = new long[nameSet.size()];
+        Set<String> normalizedNames = new HashSet<>(nameSet.size());
 
         int index = 0;
         for (String name : nameSet) {
@@ -220,6 +222,7 @@ public class ContextAutoTypeBeforeHandler
             }
 
             array[index++] = hashCode;
+            normalizedNames.add(name.replace('$', '.'));
         }
 
         if (index != array.length) {
@@ -227,6 +230,7 @@ public class ContextAutoTypeBeforeHandler
         }
         Arrays.sort(array);
         this.acceptHashCodes = array;
+        this.acceptNameSet = Collections.unmodifiableSet(normalizedNames);
     }
 
     public Class<?> apply(long typeNameHash, Class<?> expectClass, long features) {
@@ -248,6 +252,10 @@ public class ContextAutoTypeBeforeHandler
             typeName = "Object";
         }
 
+        if (typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0) {
+            return null;
+        }
+
         long hash = MAGIC_HASH_CODE;
         for (int i = 0, typeNameLength = typeName.length(); i < typeNameLength; ++i) {
             char ch = typeName.charAt(i);
@@ -258,6 +266,10 @@ public class ContextAutoTypeBeforeHandler
             hash *= MAGIC_PRIME;
 
             if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                String prefix = typeName.substring(0, i + 1).replace('$', '.');
+                if (!acceptNameSet.contains(prefix)) {
+                    continue;
+                }
                 long typeNameHash = Fnv.hashCode64(typeName);
                 Class clazz = apply(typeNameHash, expectClass, features);
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -196,7 +196,20 @@ public class ObjectReaderProvider
     boolean disableAutoType = JSONFactory.isDisableAutoType();
     boolean disableSmartMatch = JSONFactory.isDisableSmartMatch();
 
+    /**
+     * Always accepted, it is the map implementation fastjson 1.x substitutes for {@code HashMap}
+     * when hash collision protection is enabled.
+     */
+    static final String ANTI_COLLISION_HASH_MAP = "com.alibaba.fastjson.util.AntiCollisionHashMap";
+    static final long ANTI_COLLISION_HASH_MAP_HASH = -6293031534589903644L; // Fnv.hashCode64(ANTI_COLLISION_HASH_MAP)
+
     private volatile long[] acceptHashCodes;
+
+    /**
+     * The accept names behind {@link #acceptHashCodes}, normalized the same way the rolling hash in
+     * {@link #checkAutoType} normalizes a type name. A hash match is only honored when the matched
+     * prefix text is in this set, so a hash collision alone cannot whitelist a type name.
+     */
     private volatile Set<String> acceptNameSet = Collections.emptySet();
 
     private AutoTypeBeforeHandler autoTypeBeforeHandler = DEFAULT_AUTO_TYPE_BEFORE_HANDLER;
@@ -211,13 +224,14 @@ public class ObjectReaderProvider
         } else {
             hashCodes = new long[AUTO_TYPE_ACCEPT_LIST.length + 1];
             for (int i = 0; i < AUTO_TYPE_ACCEPT_LIST.length; i++) {
-                String name = AUTO_TYPE_ACCEPT_LIST[i].replace('$', '.');
-                hashCodes[i] = Fnv.hashCode64(AUTO_TYPE_ACCEPT_LIST[i]);
+                String name = normalizeAcceptName(AUTO_TYPE_ACCEPT_LIST[i]);
+                hashCodes[i] = Fnv.hashCode64(name);
                 names.add(name);
             }
         }
 
-        hashCodes[hashCodes.length - 1] = -6293031534589903644L;
+        hashCodes[hashCodes.length - 1] = ANTI_COLLISION_HASH_MAP_HASH;
+        names.add(ANTI_COLLISION_HASH_MAP);
 
         Arrays.sort(hashCodes);
         acceptHashCodes = hashCodes;
@@ -260,7 +274,8 @@ public class ObjectReaderProvider
      */
     public synchronized void addAutoTypeAccept(String name) {
         if (name != null && name.length() != 0) {
-            long hash = Fnv.hashCode64(name);
+            String acceptName = normalizeAcceptName(name);
+            long hash = Fnv.hashCode64(acceptName);
             long[] current = this.acceptHashCodes;
             if (Arrays.binarySearch(current, hash) < 0) {
                 long[] hashCodes = new long[current.length + 1];
@@ -269,10 +284,25 @@ public class ObjectReaderProvider
                 Arrays.sort(hashCodes);
                 this.acceptHashCodes = hashCodes;
             }
-            Set<String> names = new HashSet<>(this.acceptNameSet);
-            names.add(name.replace('$', '.'));
-            this.acceptNameSet = Collections.unmodifiableSet(names);
+            if (!this.acceptNameSet.contains(acceptName)) {
+                Set<String> names = new HashSet<>(this.acceptNameSet);
+                names.add(acceptName);
+                this.acceptNameSet = Collections.unmodifiableSet(names);
+            }
         }
+    }
+
+    /**
+     * Normalizes an accept name the same way {@link #checkAutoType} normalizes the type name it
+     * hashes, so that an accept entry written with the binary name of a nested class
+     * ({@code a.b.Outer$Inner}) matches as well as one written with its canonical name
+     * ({@code a.b.Outer.Inner}).
+     *
+     * @param name the accept name to normalize
+     * @return the normalized accept name
+     */
+    private static String normalizeAcceptName(String name) {
+        return name.indexOf('$') >= 0 ? name.replace('$', '.') : name;
     }
 
     @Deprecated
@@ -844,12 +874,17 @@ public class ObjectReaderProvider
                 hash ^= ch;
                 hash *= MAGIC_PRIME;
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
-                    String prefix = typeName.substring(0, i + 1).replace('$', '.');
-                    if (!acceptNameSet.contains(prefix)) {
+                    if (!acceptNameSet.contains(normalizeAcceptName(typeName.substring(0, i + 1)))) {
                         continue;
                     }
                     clazz = loadClass(typeName);
                     if (clazz != null) {
+                        // matching an accept prefix is not an opt-in for gadget base types, only an
+                        // accept entry naming the type in full is; keep scanning for such an entry
+                        if (i + 1 < typeNameLength && JDKUtils.isAutoTypeDenyClass(clazz)) {
+                            continue;
+                        }
+
                         if (expectClass != null && !expectClass.isAssignableFrom(clazz)) {
                             throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());
                         }
@@ -873,16 +908,14 @@ public class ObjectReaderProvider
 
                 // white list
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
-                    String prefix = typeName.substring(0, i + 1).replace('$', '.');
-                    if (!acceptNameSet.contains(prefix)) {
+                    if (!acceptNameSet.contains(normalizeAcceptName(typeName.substring(0, i + 1)))) {
                         continue;
                     }
                     clazz = loadClass(typeName);
 
-                    if (clazz != null) {
-                        if (ClassLoader.class.isAssignableFrom(clazz) || JDKUtils.isSQLDataSourceOrRowSet(clazz)) {
-                            throw new JSONException("autoType is not support. " + typeName);
-                        }
+                    // see the SupportAutoType branch above
+                    if (clazz != null && i + 1 < typeNameLength && JDKUtils.isAutoTypeDenyClass(clazz)) {
+                        continue;
                     }
 
                     if (clazz != null && expectClass != null && !expectClass.isAssignableFrom(clazz)) {
@@ -919,7 +952,7 @@ public class ObjectReaderProvider
         clazz = loadClass(typeName);
 
         if (clazz != null) {
-            if (ClassLoader.class.isAssignableFrom(clazz) || JDKUtils.isSQLDataSourceOrRowSet(clazz)) {
+            if (JDKUtils.isAutoTypeDenyClass(clazz)) {
                 throw new JSONException("autoType is not support. " + typeName);
             }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -28,7 +28,9 @@ import java.util.function.Supplier;
 import static com.alibaba.fastjson2.JSONFactory.*;
 import static com.alibaba.fastjson2.util.Fnv.MAGIC_HASH_CODE;
 import static com.alibaba.fastjson2.util.Fnv.MAGIC_PRIME;
+import static com.alibaba.fastjson2.util.TypeUtils.hasIllegalTypeNameChars;
 import static com.alibaba.fastjson2.util.TypeUtils.loadClass;
+import static com.alibaba.fastjson2.util.TypeUtils.normalizeAcceptName;
 
 /**
  * ObjectReaderProvider is responsible for providing and managing ObjectReader instances
@@ -234,8 +236,9 @@ public class ObjectReaderProvider
         names.add(ANTI_COLLISION_HASH_MAP);
 
         Arrays.sort(hashCodes);
-        acceptHashCodes = hashCodes;
+        // see addAutoTypeAccept, the name set is published before the hash array
         acceptNameSet = Collections.unmodifiableSet(names);
+        acceptHashCodes = hashCodes;
 
         hashCache.put(ObjectArrayReader.TYPE_HASH_CODE, ObjectArrayReader.INSTANCE);
         final long STRING_CLASS_NAME_HASH = -4834614249632438472L; // Fnv.hashCode64(String.class.getName());
@@ -275,6 +278,15 @@ public class ObjectReaderProvider
     public synchronized void addAutoTypeAccept(String name) {
         if (name != null && name.length() != 0) {
             String acceptName = normalizeAcceptName(name);
+
+            // publish the name before the hash, so that a reader seeing the new hash array is
+            // guaranteed to see the name it verifies against rather than transiently rejecting
+            if (!this.acceptNameSet.contains(acceptName)) {
+                Set<String> names = new HashSet<>(this.acceptNameSet);
+                names.add(acceptName);
+                this.acceptNameSet = Collections.unmodifiableSet(names);
+            }
+
             long hash = Fnv.hashCode64(acceptName);
             long[] current = this.acceptHashCodes;
             if (Arrays.binarySearch(current, hash) < 0) {
@@ -284,25 +296,7 @@ public class ObjectReaderProvider
                 Arrays.sort(hashCodes);
                 this.acceptHashCodes = hashCodes;
             }
-            if (!this.acceptNameSet.contains(acceptName)) {
-                Set<String> names = new HashSet<>(this.acceptNameSet);
-                names.add(acceptName);
-                this.acceptNameSet = Collections.unmodifiableSet(names);
-            }
         }
-    }
-
-    /**
-     * Normalizes an accept name the same way {@link #checkAutoType} normalizes the type name it
-     * hashes, so that an accept entry written with the binary name of a nested class
-     * ({@code a.b.Outer$Inner}) matches as well as one written with its canonical name
-     * ({@code a.b.Outer.Inner}).
-     *
-     * @param name the accept name to normalize
-     * @return the normalized accept name
-     */
-    private static String normalizeAcceptName(String name) {
-        return name.indexOf('$') >= 0 ? name.replace('$', '.') : name;
     }
 
     @Deprecated
@@ -847,8 +841,8 @@ public class ObjectReaderProvider
             throw new JSONException("autoType is not support. " + typeName);
         }
 
-        if (typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0) {
-            throw new JSONException("autoType is not support. " + typeName);
+        if (hasIllegalTypeNameChars(typeName)) {
+            throw new JSONException("autoType is not support, illegal type name. " + typeName);
         }
 
         if (typeName.charAt(0) == '[') {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -197,6 +197,7 @@ public class ObjectReaderProvider
     boolean disableSmartMatch = JSONFactory.isDisableSmartMatch();
 
     private volatile long[] acceptHashCodes;
+    private volatile Set<String> acceptNameSet = Collections.emptySet();
 
     private AutoTypeBeforeHandler autoTypeBeforeHandler = DEFAULT_AUTO_TYPE_BEFORE_HANDLER;
     private Consumer<Class> autoTypeHandler = DEFAULT_AUTO_TYPE_HANDLER;
@@ -204,12 +205,15 @@ public class ObjectReaderProvider
 
     {
         long[] hashCodes;
+        Set<String> names = new HashSet<>();
         if (AUTO_TYPE_ACCEPT_LIST == null) {
             hashCodes = new long[1];
         } else {
             hashCodes = new long[AUTO_TYPE_ACCEPT_LIST.length + 1];
             for (int i = 0; i < AUTO_TYPE_ACCEPT_LIST.length; i++) {
+                String name = AUTO_TYPE_ACCEPT_LIST[i].replace('$', '.');
                 hashCodes[i] = Fnv.hashCode64(AUTO_TYPE_ACCEPT_LIST[i]);
+                names.add(name);
             }
         }
 
@@ -217,6 +221,7 @@ public class ObjectReaderProvider
 
         Arrays.sort(hashCodes);
         acceptHashCodes = hashCodes;
+        acceptNameSet = Collections.unmodifiableSet(names);
 
         hashCache.put(ObjectArrayReader.TYPE_HASH_CODE, ObjectArrayReader.INSTANCE);
         final long STRING_CLASS_NAME_HASH = -4834614249632438472L; // Fnv.hashCode64(String.class.getName());
@@ -264,6 +269,9 @@ public class ObjectReaderProvider
                 Arrays.sort(hashCodes);
                 this.acceptHashCodes = hashCodes;
             }
+            Set<String> names = new HashSet<>(this.acceptNameSet);
+            names.add(name.replace('$', '.'));
+            this.acceptNameSet = Collections.unmodifiableSet(names);
         }
     }
 
@@ -809,6 +817,10 @@ public class ObjectReaderProvider
             throw new JSONException("autoType is not support. " + typeName);
         }
 
+        if (typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0) {
+            throw new JSONException("autoType is not support. " + typeName);
+        }
+
         if (typeName.charAt(0) == '[') {
             String componentTypeName = typeName.substring(1);
             checkAutoType(componentTypeName, null, features); // blacklist check for componentType
@@ -832,6 +844,10 @@ public class ObjectReaderProvider
                 hash ^= ch;
                 hash *= MAGIC_PRIME;
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                    String prefix = typeName.substring(0, i + 1).replace('$', '.');
+                    if (!acceptNameSet.contains(prefix)) {
+                        continue;
+                    }
                     clazz = loadClass(typeName);
                     if (clazz != null) {
                         if (expectClass != null && !expectClass.isAssignableFrom(clazz)) {
@@ -857,7 +873,17 @@ public class ObjectReaderProvider
 
                 // white list
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                    String prefix = typeName.substring(0, i + 1).replace('$', '.');
+                    if (!acceptNameSet.contains(prefix)) {
+                        continue;
+                    }
                     clazz = loadClass(typeName);
+
+                    if (clazz != null) {
+                        if (ClassLoader.class.isAssignableFrom(clazz) || JDKUtils.isSQLDataSourceOrRowSet(clazz)) {
+                            throw new JSONException("autoType is not support. " + typeName);
+                        }
+                    }
 
                     if (clazz != null && expectClass != null && !expectClass.isAssignableFrom(clazz)) {
                         throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -841,8 +841,11 @@ public class ObjectReaderProvider
             throw new JSONException("autoType is not support. " + typeName);
         }
 
+        // treat it as unresolvable rather than an error, the same as a type name that fails to
+        // load: JSON-LD uses @type for an IRI, and reporting that as unresolved leaves the
+        // ErrorOnNotSupportAutoType feature in charge of whether the caller sees an exception
         if (hasIllegalTypeNameChars(typeName)) {
-            throw new JSONException("autoType is not support, illegal type name. " + typeName);
+            return null;
         }
 
         if (typeName.charAt(0) == '[') {
@@ -857,6 +860,10 @@ public class ObjectReaderProvider
 
         boolean autoTypeSupport = (features & JSONReader.Feature.SupportAutoType.mask) != 0;
         Class<?> clazz;
+
+        // set when an accept prefix matched a deny class, so that the rejection below can tell a
+        // misconfigured accept list apart from a type name that was never accepted at all
+        boolean denyPrefixOnly = false;
 
         if (autoTypeSupport) {
             long hash = MAGIC_HASH_CODE;
@@ -876,6 +883,7 @@ public class ObjectReaderProvider
                         // matching an accept prefix is not an opt-in for gadget base types, only an
                         // accept entry naming the type in full is; keep scanning for such an entry
                         if (i + 1 < typeNameLength && JDKUtils.isAutoTypeDenyClass(clazz)) {
+                            denyPrefixOnly = true;
                             continue;
                         }
 
@@ -947,7 +955,10 @@ public class ObjectReaderProvider
 
         if (clazz != null) {
             if (JDKUtils.isAutoTypeDenyClass(clazz)) {
-                throw new JSONException("autoType is not support. " + typeName);
+                throw new JSONException(denyPrefixOnly
+                        ? "autoType is not support, an accept prefix does not cover it, "
+                        + "add the type name in full to accept. " + typeName
+                        : "autoType is not support. " + typeName);
             }
 
             if (expectClass != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/util/JDKUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/JDKUtils.java
@@ -450,6 +450,19 @@ public class JDKUtils {
                 || (CLASS_SQL_ROW_SET != null && CLASS_SQL_ROW_SET.isAssignableFrom(type));
     }
 
+    /**
+     * Tests whether a class is a well known deserialization gadget entry point, namely a
+     * {@link ClassLoader} subclass or a JDK SQL {@code DataSource}/{@code RowSet} implementation.
+     * Such types must not be resolved by matching an autoType whitelist prefix; only an accept
+     * entry naming the type in full is treated as an explicit opt-in.
+     *
+     * @param type the class to test
+     * @return true if the class must not be resolved through a whitelist prefix match
+     */
+    public static boolean isAutoTypeDenyClass(Class<?> type) {
+        return ClassLoader.class.isAssignableFrom(type) || isSQLDataSourceOrRowSet(type);
+    }
+
     public static void setReflectErrorLast(Throwable error) {
         reflectErrorCount.incrementAndGet();
         reflectErrorLast = error;

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -2835,6 +2835,8 @@ public class TypeUtils {
      * <p>Every autoType entry point shares this predicate; validating in only some of them is the
      * asymmetry that lets a type name reach a class loader through the unchecked path.
      *
+     * <p>Internal, public only because the autoType entry points live in different packages.
+     *
      * @param typeName the type name to test
      * @return true if the type name must be rejected without being resolved
      */
@@ -2845,7 +2847,10 @@ public class TypeUtils {
     /**
      * Normalizes a type name the way the autoType accept-list rolling hash normalizes it, so that a
      * nested class matches whether it is written with its binary name ({@code a.b.Outer$Inner}) or
-     * its canonical name ({@code a.b.Outer.Inner}).
+     * its canonical name ({@code a.b.Outer.Inner}). Following that existing rolling-hash rule means
+     * the two spellings are equivalent as accept entries.
+     *
+     * <p>Internal, public only because the autoType entry points live in different packages.
      *
      * @param typeName the type name to normalize
      * @return the normalized type name

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -2832,6 +2832,10 @@ public class TypeUtils {
             return null;
         }
 
+        if (className.indexOf(':') >= 0 || className.indexOf('!') >= 0) {
+            return null;
+        }
+
         switch (className) {
             case "O":
             case "Object":

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -2827,12 +2827,39 @@ public class TypeUtils {
         return null;
     }
 
+    /**
+     * Tests whether a type name carries a character that cannot appear in a Java binary class name
+     * but is meaningful in a URL. A nested jar URL such as {@code jar:http://host/x.jar!/} is
+     * resolvable by some class loaders, so a type name carrying one must never reach one.
+     *
+     * <p>Every autoType entry point shares this predicate; validating in only some of them is the
+     * asymmetry that lets a type name reach a class loader through the unchecked path.
+     *
+     * @param typeName the type name to test
+     * @return true if the type name must be rejected without being resolved
+     */
+    public static boolean hasIllegalTypeNameChars(String typeName) {
+        return typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0;
+    }
+
+    /**
+     * Normalizes a type name the way the autoType accept-list rolling hash normalizes it, so that a
+     * nested class matches whether it is written with its binary name ({@code a.b.Outer$Inner}) or
+     * its canonical name ({@code a.b.Outer.Inner}).
+     *
+     * @param typeName the type name to normalize
+     * @return the normalized type name
+     */
+    public static String normalizeAcceptName(String typeName) {
+        return typeName.indexOf('$') >= 0 ? typeName.replace('$', '.') : typeName;
+    }
+
     public static Class loadClass(String className) {
         if (className.length() >= 192) {
             return null;
         }
 
-        if (className.indexOf(':') >= 0 || className.indexOf('!') >= 0) {
+        if (hasIllegalTypeNameChars(className)) {
             return null;
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -10,6 +10,8 @@ import com.alibaba.fastjson2.util.TypeUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import javax.sql.DataSource;
+
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Set;
@@ -22,6 +24,7 @@ public class AutoTypeValidationTest {
     static final String PACKAGE_PREFIX = "com.alibaba.fastjson2.autoType.";
     static final String TEST_BEAN = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean";
     static final String TEST_CLASS_LOADER = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestClassLoader";
+    static final String TEST_DATA_SOURCE = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestDataSource";
 
     // =========================================================================
     // type name format validation
@@ -262,10 +265,26 @@ public class AutoTypeValidationTest {
     }
 
     @Test
+    public void testAcceptPrefixDoesNotAllowDataSource() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+
+        assertNull(provider.checkAutoType(TEST_DATA_SOURCE, null, 0));
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_DATA_SOURCE, null, JSONReader.Feature.SupportAutoType.mask));
+    }
+
+    @Test
     public void testContextHandlerAcceptPrefixDoesNotAllowClassLoader() {
         ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
         assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
         assertEquals(TestBean.class, handler.apply(TEST_BEAN, null, 0));
+    }
+
+    @Test
+    public void testContextHandlerAcceptPrefixDoesNotAllowDataSource() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
+        assertNull(handler.apply(TEST_DATA_SOURCE, null, 0));
     }
 
     @Test
@@ -311,5 +330,12 @@ public class AutoTypeValidationTest {
 
     public static class TestClassLoader
             extends ClassLoader {
+    }
+
+    /**
+     * Abstract is enough, {@code checkAutoType} resolves the class without instantiating it.
+     */
+    public abstract static class TestDataSource
+            implements DataSource {
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -14,6 +14,8 @@ import javax.sql.DataSource;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -30,26 +32,45 @@ public class AutoTypeValidationTest {
     // type name format validation
     // =========================================================================
 
+    /**
+     * Unresolvable rather than an error, matching a type name that simply fails to load. Whether the
+     * caller sees an exception is left to {@code ErrorOnNotSupportAutoType}.
+     */
     @Test
     public void testRejectColonInTypeName() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
-        assertThrows(JSONException.class, () ->
-                provider.checkAutoType("com.example.Bean:invalid", null, 0));
+        assertNull(provider.checkAutoType("com.example.Bean:invalid", null, 0));
     }
 
     @Test
     public void testRejectExclamationInTypeName() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
-        assertThrows(JSONException.class, () ->
-                provider.checkAutoType("com.example.Bean!invalid", null, 0));
+        assertNull(provider.checkAutoType("com.example.Bean!invalid", null, 0));
     }
 
     @Test
     public void testRejectColonWithSupportAutoType() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
         long features = JSONReader.Feature.SupportAutoType.mask;
-        assertThrows(JSONException.class, () ->
-                provider.checkAutoType("com.example.Bean:invalid", null, features));
+        assertNull(provider.checkAutoType("com.example.Bean:invalid", null, features));
+    }
+
+    /**
+     * {@code @type} is a JSON-LD keyword whose value is an IRI, so it always carries {@code :}.
+     * Rejecting the type name must leave the existing fall-back-to-map behaviour intact.
+     */
+    @Test
+    public void testParseJsonLdFallsBackToMap() {
+        String jsonLd = "{\"@type\":\"http://schema.org/Person\",\"name\":\"x\"}";
+
+        Object object = JSON.parseObject(jsonLd, Object.class);
+        assertInstanceOf(Map.class, object);
+        assertEquals("x", ((Map<?, ?>) object).get("name"));
+
+        assertInstanceOf(Map.class, JSON.parseArray("[" + jsonLd + "]", Object.class).get(0));
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(
+                jsonLd, Object.class, JSONReader.Feature.ErrorOnNotSupportAutoType));
     }
 
     /**
@@ -287,6 +308,23 @@ public class AutoTypeValidationTest {
         assertNull(handler.apply(TEST_DATA_SOURCE, null, 0));
     }
 
+    /**
+     * The blacklist runs after the class cache is consulted, so a cached class is checked too rather
+     * than the check resting on nothing but a deny class never being cached.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testContextHandlerChecksCachedClass() throws Exception {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
+
+        Field field = ContextAutoTypeBeforeHandler.class.getDeclaredField("classCache");
+        field.setAccessible(true);
+        ((Map<Long, Class>) field.get(handler))
+                .put(Fnv.hashCode64(TEST_CLASS_LOADER), TestClassLoader.class);
+
+        assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
+    }
+
     @Test
     public void testContextHandlerExactAcceptNameAllowsClassLoader() {
         ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(
@@ -321,7 +359,25 @@ public class AutoTypeValidationTest {
         String json = "{\"@type\":\"java.util.HashMap\",\"value\":1}";
         Object obj = JSON.parseObject(json, Object.class,
                 JSONReader.autoTypeFilter("java.util.HashMap"));
-        assertNotNull(obj);
+        // not merely non-null, falling back to a JSONObject would satisfy that too
+        assertEquals(HashMap.class, obj.getClass());
+    }
+
+    @Test
+    public void testDenyPrefixOnlyRejectionIsDistinguishable() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        long features = JSONReader.Feature.SupportAutoType.mask;
+
+        // no accept entry covers it, the generic rejection
+        JSONException plain = assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, features));
+        assertFalse(plain.getMessage().contains("accept"));
+
+        // an accept prefix covers it but not in full, the actionable rejection
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+        JSONException prefixOnly = assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, features));
+        assertTrue(prefixOnly.getMessage().contains("add the type name in full to accept"));
     }
 
     public static class TestBean {

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -5,14 +5,28 @@ import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
 import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.util.Fnv;
 import com.alibaba.fastjson2.util.TypeUtils;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("autotype")
 public class AutoTypeValidationTest {
+    static final String PACKAGE_PREFIX = "com.alibaba.fastjson2.autoType.";
+    static final String TEST_BEAN = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean";
+    static final String TEST_CLASS_LOADER = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestClassLoader";
+
+    // =========================================================================
+    // type name format validation
+    // =========================================================================
+
     @Test
     public void testRejectColonInTypeName() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
@@ -35,14 +49,38 @@ public class AutoTypeValidationTest {
                 provider.checkAutoType("com.example.Bean:invalid", null, features));
     }
 
+    /**
+     * A type name carrying {@code :} or {@code !} must not reach the class loader at all: a nested
+     * jar URL such as {@code jar:http://host/x.jar!/} is resolvable by some class loaders and would
+     * turn a type name into a remote class load. Uses a class loader that resolves any name, so the
+     * assertion fails if the format check is removed.
+     */
     @Test
-    public void testLoadClassRejectsColon() {
-        assertNull(TypeUtils.loadClass("com.example.Bean:invalid"));
-    }
+    public void testLoadClassDoesNotReachClassLoader() {
+        AtomicReference<String> requested = new AtomicReference<>();
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader recording = new ClassLoader(contextClassLoader) {
+            @Override
+            public Class<?> loadClass(String name) {
+                requested.set(name);
+                return Integer.class;
+            }
+        };
 
-    @Test
-    public void testLoadClassRejectsExclamation() {
-        assertNull(TypeUtils.loadClass("com.example.Bean!invalid"));
+        try {
+            Thread.currentThread().setContextClassLoader(recording);
+
+            assertNull(TypeUtils.loadClass("jar:http://127.0.0.1/evil.jar!/Evil"));
+            assertNull(TypeUtils.loadClass("com.example.Bean:invalid"));
+            assertNull(TypeUtils.loadClass("com.example.Bean!invalid"));
+            assertNull(requested.get(), "type name must not reach the class loader");
+
+            // control: an ordinary type name does reach the class loader
+            assertEquals(Integer.class, TypeUtils.loadClass("com.example.Bean"));
+            assertEquals("com.example.Bean", requested.get());
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
     }
 
     @Test
@@ -65,8 +103,7 @@ public class AutoTypeValidationTest {
     @Test
     public void testContextHandlerAcceptsWhitelisted() {
         ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
-        Class<?> clazz = handler.apply("java.lang.String", null, 0);
-        assertEquals(String.class, clazz);
+        assertEquals(String.class, handler.apply("java.lang.String", null, 0));
     }
 
     @Test
@@ -75,33 +112,189 @@ public class AutoTypeValidationTest {
         assertNull(handler.apply("com.example.NotWhitelisted", null, 0));
     }
 
-    @Test
-    public void testWhitelistWithAddAccept() {
-        ObjectReaderProvider provider = new ObjectReaderProvider();
-        provider.addAutoTypeAccept("com.alibaba.fastjson2.autoType.AutoTypeValidationTest$");
+    // =========================================================================
+    // whitelist text verification
+    // =========================================================================
 
-        long features = JSONReader.Feature.SupportAutoType.mask;
-        Class<?> clazz = provider.checkAutoType(
-                "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean", null, features);
-        assertEquals(TestBean.class, clazz);
+    /**
+     * Without {@code SupportAutoType} the whitelist is the only way a type name resolves, so these
+     * assertions can only pass through the rolling-hash accept path.
+     */
+    @Test
+    public void testWhitelistPrefixAccept() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertNull(provider.checkAutoType(TEST_BEAN, null, 0));
+
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+        assertEquals(TestBean.class, provider.checkAutoType(TEST_BEAN, null, 0));
+    }
+
+    /**
+     * The rolling hash in {@code checkAutoType} normalizes {@code $} to {@code .}, so an accept
+     * entry written with the binary name of a nested class has to be normalized the same way to
+     * match.
+     */
+    @Test
+    public void testWhitelistAcceptNestedClassBinaryName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(TEST_BEAN);
+        assertEquals(TestBean.class, provider.checkAutoType(TEST_BEAN, null, 0));
+
+        ObjectReaderProvider canonical = new ObjectReaderProvider();
+        canonical.addAutoTypeAccept(TEST_BEAN.replace('$', '.'));
+        assertEquals(TestBean.class, canonical.checkAutoType(TEST_BEAN, null, 0));
+    }
+
+    /**
+     * A hash match alone must not whitelist a type name. Injects the hash of a {@code java.lang.}
+     * prefix into {@code acceptHashCodes} without registering the text, which is what a rolling-hash
+     * collision would look like, and asserts the type name is still rejected.
+     */
+    @Test
+    public void testWhitelistHashMatchWithoutTextRejected() throws Exception {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+
+        Field field = ObjectReaderProvider.class.getDeclaredField("acceptHashCodes");
+        field.setAccessible(true);
+        long[] hashCodes = (long[]) field.get(provider);
+        long[] injected = Arrays.copyOf(hashCodes, hashCodes.length + 1);
+        injected[injected.length - 1] = Fnv.hashCode64("java.lang.");
+        Arrays.sort(injected);
+        field.set(provider, injected);
+
+        assertNull(provider.checkAutoType("java.lang.Integer", null, 0));
+
+        // control: the same lookup succeeds once the accept text is registered
+        provider.addAutoTypeAccept("java.lang.");
+        assertEquals(Integer.class, provider.checkAutoType("java.lang.Integer", null, 0));
+    }
+
+    /**
+     * A collision on the full type name is the dangerous case: matching an accept entry in full is
+     * what exempts a type from the gadget blacklist, so it must be backed by the accept text.
+     */
+    @Test
+    public void testWhitelistFullNameHashMatchWithoutTextRejected() throws Exception {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+
+        Field field = ObjectReaderProvider.class.getDeclaredField("acceptHashCodes");
+        field.setAccessible(true);
+        long[] hashCodes = (long[]) field.get(provider);
+        long[] injected = Arrays.copyOf(hashCodes, hashCodes.length + 1);
+        injected[injected.length - 1] = Fnv.hashCode64(TEST_CLASS_LOADER.replace('$', '.'));
+        Arrays.sort(injected);
+        field.set(provider, injected);
+
+        assertNull(provider.checkAutoType(TEST_CLASS_LOADER, null, 0));
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, JSONReader.Feature.SupportAutoType.mask));
     }
 
     @Test
-    public void testWhitelistTextVerification() {
+    public void testContextHandlerHashMatchWithoutTextRejected() throws Exception {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler("com.example.");
+
+        Field field = ContextAutoTypeBeforeHandler.class.getDeclaredField("acceptHashCodes");
+        field.setAccessible(true);
+        long[] hashCodes = (long[]) field.get(handler);
+        assertEquals(1, hashCodes.length);
+        hashCodes[0] = Fnv.hashCode64(TEST_CLASS_LOADER.replace('$', '.'));
+
+        assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
+    }
+
+    @Test
+    public void testWhitelistNonAcceptedPrefix() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
         provider.addAutoTypeAccept("com.example.");
 
         long features = JSONReader.Feature.SupportAutoType.mask;
-        Class<?> clazz = provider.checkAutoType("com.other.NotAccepted", null, features);
-        assertNull(clazz);
+        assertNull(provider.checkAutoType("com.other.NotAccepted", null, features));
+    }
+
+    /**
+     * {@code com.alibaba.fastjson.util.AntiCollisionHashMap} is always accepted through a hardcoded
+     * hash. Text verification would silently kill that entry if its name were missing from
+     * {@code acceptNameSet}.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAntiCollisionHashMapAlwaysAccepted() throws Exception {
+        String name = "com.alibaba.fastjson.util.AntiCollisionHashMap";
+        assertEquals(-6293031534589903644L, Fnv.hashCode64(name));
+
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        Field field = ObjectReaderProvider.class.getDeclaredField("acceptNameSet");
+        field.setAccessible(true);
+        assertTrue(((Set<String>) field.get(provider)).contains(name));
+    }
+
+    // =========================================================================
+    // blacklist enforcement on whitelist matches
+    // =========================================================================
+
+    @Test
+    public void testAcceptPrefixDoesNotAllowClassLoader() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+
+        assertNull(provider.checkAutoType(TEST_CLASS_LOADER, null, 0));
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, JSONReader.Feature.SupportAutoType.mask));
+
+        // the accept prefix still resolves types that are not gadget base types
+        assertEquals(TestBean.class, provider.checkAutoType(TEST_BEAN, null, 0));
+    }
+
+    /**
+     * An accept entry naming the type in full is an explicit opt-in, and a shorter prefix entry
+     * matching first must not preempt it.
+     */
+    @Test
+    public void testExactAcceptNameAllowsClassLoader() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+        provider.addAutoTypeAccept(TEST_CLASS_LOADER);
+
+        assertEquals(TestClassLoader.class, provider.checkAutoType(TEST_CLASS_LOADER, null, 0));
+        assertEquals(TestClassLoader.class, provider.checkAutoType(
+                TEST_CLASS_LOADER, null, JSONReader.Feature.SupportAutoType.mask));
     }
 
     @Test
-    public void testParseWithAutoTypeFilterRejectsColon() {
-        String json = "{\"@type\":\"com.example.Bean:invalid\",\"value\":1}";
-        assertThrows(JSONException.class, () ->
-                JSON.parseObject(json, Object.class,
-                        JSONReader.autoTypeFilter(String.class)));
+    public void testContextHandlerAcceptPrefixDoesNotAllowClassLoader() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
+        assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
+        assertEquals(TestBean.class, handler.apply(TEST_BEAN, null, 0));
+    }
+
+    @Test
+    public void testContextHandlerExactAcceptNameAllowsClassLoader() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(
+                PACKAGE_PREFIX,
+                TEST_CLASS_LOADER
+        );
+        assertEquals(TestClassLoader.class, handler.apply(TEST_CLASS_LOADER, null, 0));
+    }
+
+    /**
+     * An unresolved {@code @type} falls back to a map unless {@code ErrorOnNotSupportAutoType} is
+     * set, so what matters end to end is that no {@link ClassLoader} is ever instantiated.
+     */
+    @Test
+    public void testParseRejectsClassLoaderUnderAcceptPrefix() {
+        Object object = JSON.parseObject(
+                "{\"@type\":\"" + TEST_CLASS_LOADER + "\"}",
+                Object.class,
+                JSONReader.autoTypeFilter(PACKAGE_PREFIX));
+        assertFalse(object instanceof ClassLoader, "accept prefix must not resolve a ClassLoader");
+
+        // control: the same accept prefix still deserializes an ordinary bean
+        TestBean bean = (TestBean) JSON.parseObject(
+                "{\"@type\":\"" + TEST_BEAN + "\",\"id\":123}",
+                Object.class,
+                JSONReader.autoTypeFilter(PACKAGE_PREFIX));
+        assertEquals(123, bean.id);
     }
 
     @Test
@@ -114,5 +307,9 @@ public class AutoTypeValidationTest {
 
     public static class TestBean {
         public int id;
+    }
+
+    public static class TestClassLoader
+            extends ClassLoader {
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -1,0 +1,118 @@
+package com.alibaba.fastjson2.autoType;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.util.TypeUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("autotype")
+public class AutoTypeValidationTest {
+    @Test
+    public void testRejectColonInTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType("com.example.Bean:invalid", null, 0));
+    }
+
+    @Test
+    public void testRejectExclamationInTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType("com.example.Bean!invalid", null, 0));
+    }
+
+    @Test
+    public void testRejectColonWithSupportAutoType() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType("com.example.Bean:invalid", null, features));
+    }
+
+    @Test
+    public void testLoadClassRejectsColon() {
+        assertNull(TypeUtils.loadClass("com.example.Bean:invalid"));
+    }
+
+    @Test
+    public void testLoadClassRejectsExclamation() {
+        assertNull(TypeUtils.loadClass("com.example.Bean!invalid"));
+    }
+
+    @Test
+    public void testLoadClassNormalClass() {
+        assertEquals(String.class, TypeUtils.loadClass("java.lang.String"));
+    }
+
+    @Test
+    public void testContextHandlerRejectsColon() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(true);
+        assertNull(handler.apply("com.example.Bean:invalid", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerRejectsExclamation() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(true);
+        assertNull(handler.apply("com.example.Bean!invalid", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerAcceptsWhitelisted() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
+        Class<?> clazz = handler.apply("java.lang.String", null, 0);
+        assertEquals(String.class, clazz);
+    }
+
+    @Test
+    public void testContextHandlerRejectsNonWhitelisted() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
+        assertNull(handler.apply("com.example.NotWhitelisted", null, 0));
+    }
+
+    @Test
+    public void testWhitelistWithAddAccept() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept("com.alibaba.fastjson2.autoType.AutoTypeValidationTest$");
+
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        Class<?> clazz = provider.checkAutoType(
+                "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean", null, features);
+        assertEquals(TestBean.class, clazz);
+    }
+
+    @Test
+    public void testWhitelistTextVerification() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept("com.example.");
+
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        Class<?> clazz = provider.checkAutoType("com.other.NotAccepted", null, features);
+        assertNull(clazz);
+    }
+
+    @Test
+    public void testParseWithAutoTypeFilterRejectsColon() {
+        String json = "{\"@type\":\"com.example.Bean:invalid\",\"value\":1}";
+        assertThrows(JSONException.class, () ->
+                JSON.parseObject(json, Object.class,
+                        JSONReader.autoTypeFilter(String.class)));
+    }
+
+    @Test
+    public void testParseWithAutoTypeFilterNormal() {
+        String json = "{\"@type\":\"java.util.HashMap\",\"value\":1}";
+        Object obj = JSON.parseObject(json, Object.class,
+                JSONReader.autoTypeFilter("java.util.HashMap"));
+        assertNotNull(obj);
+    }
+
+    public static class TestBean {
+        public int id;
+    }
+}

--- a/docs/autotype_cn.md
+++ b/docs/autotype_cn.md
@@ -8,6 +8,20 @@ FASTJSON支持AutoType功能，这个功能会在序列化的JSON字符串中带
 * 支持配置safeMode，在safeMode打开后，显式传入AutoType参数也不起作用。
 * 显式打开后，会经过内置黑名单过滤。该黑名单能拦截大部分常见风险，这个机制不能保证绝对安全，打开AutoType不应该在暴露在公网的场景下使用。
 
+### 2.1 accept前缀不覆盖黑名单类型（2.0.62 起）
+`ClassLoader`子类和JDK SQL的`DataSource`/`RowSet`实现是反序列化利用链的常见入口，**用前缀注册accept不再放行这些类型**，必须写全类名才算显式授权。适用于`addAutoTypeAccept`、`-Dfastjson2.autoTypeAccept`、`JSONReader.autoTypeFilter`，以及fastjson 1.x兼容模式的`ParserConfig.addAccept`。
+
+```java
+// 2.0.62 之前：前缀accept会放行 DruidDataSource
+// 2.0.62 起：被拒绝
+ParserConfig.getGlobalInstance().addAccept("com.alibaba.druid.pool.");
+
+// 确实需要时，写全类名
+ParserConfig.getGlobalInstance().addAccept("com.alibaba.druid.pool.DruidDataSource");
+```
+
+在此之前，注册了accept前缀的类型比完全没有注册的类型检查更松：同一个类型名在没有accept前缀时会被黑名单拦下，加了前缀反而能加载出来。
+
 
 ## 3. AutoType功能使用介绍
 

--- a/docs/autotype_en.md
+++ b/docs/autotype_en.md
@@ -8,6 +8,20 @@ FASTJSON supports the AutoType feature, which includes type information in the s
 *   **Supports `safeMode` configuration.** When `safeMode` is enabled, explicitly passing AutoType parameters will have no effect.
 *   **Filtered by a built-in blacklist when explicitly enabled.** This blacklist can intercept most common risks, but this mechanism cannot guarantee absolute security. Enabling AutoType should not be done in scenarios exposed to the public internet.
 
+### 2.1 Accept prefixes do not cover blacklisted types (since 2.0.62)
+`ClassLoader` subclasses and JDK SQL `DataSource`/`RowSet` implementations are common deserialization gadget entry points, and **registering an accept entry by prefix no longer allows them**. Only an accept entry naming the type in full counts as an explicit opt-in. This applies to `addAutoTypeAccept`, `-Dfastjson2.autoTypeAccept`, `JSONReader.autoTypeFilter`, and `ParserConfig.addAccept` in fastjson 1.x compatibility mode.
+
+```java
+// before 2.0.62: the accept prefix allowed DruidDataSource
+// since 2.0.62: rejected
+ParserConfig.getGlobalInstance().addAccept("com.alibaba.druid.pool.");
+
+// name the type in full where it is genuinely needed
+ParserConfig.getGlobalInstance().addAccept("com.alibaba.druid.pool.DruidDataSource");
+```
+
+Before this change, a type covered by an accept prefix was checked *less* strictly than one that was never registered at all: the same type name was stopped by the blacklist without the accept prefix, and loaded successfully with it.
+
 ## 3. How to Use the AutoType Feature
 
 ### 3.1 Including Type Information During Serialization


### PR DESCRIPTION
## Summary

Hardens the autoType deserialization path with three layers of defense:

1. **Type name format validation** — Type names containing `:` or `!` are reported as unresolvable in `checkAutoType()`, `ContextAutoTypeBeforeHandler.apply()`, and `TypeUtils.loadClass()`. These characters never appear in valid Java binary class names, and a nested jar URL (`jar:http://host/x.jar!/`) is resolvable by some class loaders, so a type name carrying them must never reach one. Shared as `TypeUtils.hasIllegalTypeNameChars` — validating in only some entry points is the asymmetry this PR exists to fix.

   Unresolvable, not an error: fastjson2 falls back to a map for an `@type` it cannot resolve, and `@type` is also a JSON-LD keyword whose value is an IRI, so throwing here would break every JSON-LD document. `ErrorOnNotSupportAutoType` still turns it into an exception for callers that want one.

2. **Whitelist text verification** — After a rolling-hash match against `acceptHashCodes`, verify the actual prefix text against a parallel `acceptNameSet` rather than trusting the hash value alone.

3. **Consistent blacklist enforcement** — Apply the `ClassLoader` and `DataSource/RowSet` blacklist in *both* whitelist branches of `checkAutoType` and in `ContextAutoTypeBeforeHandler`. Previously only the general `SupportAutoType` fallback had it, so a whitelisted prefix gave *weaker* checking than no whitelist entry at all: `{"@type":"com.example.EvilClassLoader"}` was rejected without an accept entry and accepted with `addAutoTypeAccept("com.example.")`.

   Matching an accept entry that names the type **in full** stays an explicit opt-in and skips the blacklist, so `addAutoTypeAccept("com.example.MyDataSource")` keeps working. A prefix match on a blacklisted type continues scanning rather than failing outright, so a shorter prefix entry cannot preempt a full-name entry appearing later in the type name.

## Two things text verification surfaced

- The hardcoded accept hash `-6293031534589903644L` is `Fnv.hashCode64("com.alibaba.fastjson.util.AntiCollisionHashMap")`. It has no accept name behind it, so text verification would have silently killed that always-accepted entry. The name is now registered alongside the hash, and a test pins the two together.

- `ObjectReaderProvider` hashed accept names with a literal `$` while the rolling hash in `checkAutoType` normalizes `$` to `.`, so an accept entry written with the binary name of a nested class (`a.b.Outer$Inner`) never matched. Accept names are now normalized through a shared `TypeUtils.normalizeAcceptName`, matching what `ContextAutoTypeBeforeHandler` already did.

## Breaking change

Registering a `ClassLoader` or `DataSource`/`RowSet` type **by prefix** no longer allows it — the type must be named in full. This breaks the fastjson 1.x style `ParserConfig.getGlobalInstance().addAccept("com.alibaba.druid.pool.")`, and the equivalent with `addAutoTypeAccept`, `-Dfastjson2.autoTypeAccept` and `JSONReader.autoTypeFilter`. Documented in `docs/autotype_{cn,en}.md` §2.1; worth a line in the 2.0.62 release notes.

When a rejection is caused by exactly this, the message says so (`an accept prefix does not cover it, add the type name in full to accept`) rather than the generic text — the hint is raised only when an accept prefix actually matched, so an error triggered by untrusted input naming a gadget does not carry instructions for whitelisting it.

## Also

- `addAutoTypeAccept` publishes `acceptNameSet` **before** `acceptHashCodes`. Readers consult the hash array first, so volatile happens-before transitivity guarantees a reader that sees a new hash also sees the name it verifies against, instead of transiently rejecting an accepted type.
- `ContextAutoTypeBeforeHandler` checks the blacklist after its class cache is consulted, so a cached class is checked too rather than the check resting on a deny class never being cached.

## Changes

| File | Change |
|------|--------|
| `ObjectReaderProvider.java` | `acceptNameSet`, format validation, text verification, blacklist in both whitelist branches, `$` normalization of accept names, publication order |
| `ContextAutoTypeBeforeHandler.java` | `acceptNameSet`, format validation, text verification, blacklist on prefix matches |
| `TypeUtils.java` | `hasIllegalTypeNameChars`, `normalizeAcceptName`, format validation in `loadClass()` |
| `JDKUtils.java` | `isAutoTypeDenyClass()` — single definition of the blacklist |
| `AutoTypeValidationTest.java` | Regression tests covering all three layers |
| `docs/autotype_{cn,en}.md` | Document the accept-prefix behaviour change |

## Testing

- `AutoTypeValidationTest` — 27 cases, mutation-checked. Removing any of these fails at least one test:
  - either character in `hasIllegalTypeNameChars`, and its call in `TypeUtils.loadClass` and in `checkAutoType`
  - text verification in both `checkAutoType` branches and in `ContextAutoTypeBeforeHandler`
  - the blacklist in both `checkAutoType` branches, the fallback, and `ContextAutoTypeBeforeHandler`, and **either arm** of `isAutoTypeDenyClass`
  - the full-name-accept exemption, the `AntiCollisionHashMap` accept name, `normalizeAcceptName`, and the `denyPrefixOnly` message
  - The one guard not independently pinned is the `hasIllegalTypeNameChars` call in `ContextAutoTypeBeforeHandler.apply` — it is redundant with the identical check in `TypeUtils.loadClass`, kept as defense in depth so the public entry point does not depend on `loadClass` internals.
- `core` — 7933 tests pass, 413 of them `@Tag("autotype")`
- `fastjson1-compatible` (1346) and `safemode-test` (2) pass
- checkstyle passes
