### PR TITLE
fix: JSONB BC_BINARY declared-length OOM (#7669)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -697,6 +697,9 @@ final class JSONReaderJSONB
             }
             case BC_BINARY: {
                 int len = readLength();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BINARY length out of range: " + len);
+                }
                 byte[] binary = Arrays.copyOfRange(this.bytes, offset, offset + len);
                 offset += len;
                 return binary;
@@ -3708,6 +3711,9 @@ final class JSONReaderJSONB
         }
 
         int len = readLength();
+        if (len < 0 || len > end - offset) {
+            throw new JSONException("BC_BINARY length out of range: " + len);
+        }
         byte[] bytes = new byte[len];
         System.arraycopy(this.bytes, offset, bytes, 0, len);
         offset += len;
@@ -4483,6 +4489,9 @@ final class JSONReaderJSONB
             }
             case BC_BINARY: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BINARY length out of range: " + len);
+                }
                 byte[] buf = new byte[len];
                 System.arraycopy(this.bytes, offset, buf, 0, len);
                 offset += len;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -580,9 +580,7 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BIGINT length out of range: " + len);
-                }
+                checkBigintLen(len, offset, end);
                 byte[] buf = new byte[len];
                 System.arraycopy(bytes, offset, buf, 0, len);
                 offset += len;
@@ -3259,9 +3257,7 @@ final class JSONReaderJSONB
                 return Long.toString(int64Value);
             case BC_BIGINT: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BIGINT length out of range: " + len);
-                }
+                checkBigintLen(len, offset, end);
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4192,9 +4188,7 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BIGINT length out of range: " + len);
-                }
+                checkBigintLen(len, offset, end);
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4424,9 +4418,7 @@ final class JSONReaderJSONB
             );
         } else if (type == BC_BIGINT) {
             int len = readInt32Value();
-            if (len < 0 || len > end - offset) {
-                throw new JSONException("BC_BIGINT length out of range: " + len);
-            }
+            checkBigintLen(len, offset, end);
             byte[] bytes = new byte[len];
             System.arraycopy(this.bytes, offset, bytes, 0, len);
             offset += len;
@@ -6309,6 +6301,12 @@ final class JSONReaderJSONB
             throw outOfBoundsCheckFromToIndex(off, end);
         }
         return off;
+    }
+
+    static void checkBigintLen(int len, int offset, int end) {
+        if (len < 0 || len > end - offset) {
+            throw new JSONException("BC_BIGINT length out of range: " + len + ", available: " + (end - offset));
+        }
     }
 
     static JSONException outOfBoundsCheckFromToIndex(int offset, int end) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -2,9 +2,12 @@ package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("regression")
@@ -38,6 +41,49 @@ public class Issue7669 {
         java.math.BigInteger value = java.math.BigInteger.valueOf(Long.MAX_VALUE).multiply(java.math.BigInteger.TEN);
         byte[] jsonbBytes = JSONB.toBytes(value);
         java.math.BigInteger result = (java.math.BigInteger) JSONB.parse(jsonbBytes);
-        org.junit.jupiter.api.Assertions.assertEquals(value, result);
+        assertEquals(value, result);
+    }
+
+    @Test
+    public void testBinaryDeclaredLengthOOM() {
+        // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0x0FFFFFFF = 256MB-1 (passes readLength cap, exceeds buffer)
+        byte[] payload = {
+                (byte) 0x91,
+                (byte) 0x48,
+                (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+    }
+
+    @Test
+    public void testBinaryNegativeLength() {
+        // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+        byte[] payload = {
+                (byte) 0x91,
+                (byte) 0x48,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+    }
+
+    @Test
+    public void testReadBinaryDeclaredLengthOOM() {
+        // Explicit readBinary() path
+        byte[] payload = {
+                (byte) 0x91,
+                (byte) 0x48,
+                (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        try (JSONReader reader = JSONReader.ofJSONB(payload)) {
+            assertThrows(JSONException.class, reader::readBinary);
+        }
+    }
+
+    @Test
+    public void testBinaryValidPayloadStillWorks() {
+        byte[] value = {1, 2, 3, 4, 5};
+        byte[] jsonbBytes = JSONB.toBytes(value);
+        byte[] result = (byte[]) JSONB.parse(jsonbBytes);
+        assertArrayEquals(value, result);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -6,6 +6,8 @@ import com.alibaba.fastjson2.JSONReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,68 +15,81 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Tag("regression")
 @Tag("jsonb")
 public class Issue7669 {
+    // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] PAYLOAD_MAX_LEN = {
+            (byte) 0xBB,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+    static final byte[] PAYLOAD_NEG_LEN = {
+            (byte) 0xBB,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0x0FFFFFFF = 256MB-1 (passes readLength cap, exceeds buffer)
+    static final byte[] BINARY_PAYLOAD_MAX_LEN = {
+            (byte) 0x91,
+            (byte) 0x48,
+            (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+    static final byte[] BINARY_PAYLOAD_NEG_LEN = {
+            (byte) 0x91,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
     @Test
     public void testBigIntDeclaredLengthOOM() {
-        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
-        byte[] payload = {
-                (byte) 0xBB,
-                (byte) 0x48,
-                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+        assertThrows(JSONException.class, () -> JSONB.parse(PAYLOAD_MAX_LEN));
     }
 
     @Test
     public void testBigIntNegativeLength() {
-        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0xFFFFFFFF = -1
-        byte[] payload = {
-                (byte) 0xBB,
-                (byte) 0x48,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+        assertThrows(JSONException.class, () -> JSONB.parse(PAYLOAD_NEG_LEN));
+    }
+
+    @Test
+    public void testBigIntDeclaredLengthOOM_readBigInteger() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(PAYLOAD_MAX_LEN, BigInteger.class));
+    }
+
+    @Test
+    public void testBigIntDeclaredLengthOOM_readString() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(PAYLOAD_MAX_LEN, String.class));
+    }
+
+    @Test
+    public void testBigIntDeclaredLengthOOM_readNumber() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(PAYLOAD_MAX_LEN, Number.class));
     }
 
     @Test
     public void testBigIntValidPayloadStillWorks() {
-        // Verify legitimate BigInteger values still round-trip correctly
-        java.math.BigInteger value = java.math.BigInteger.valueOf(Long.MAX_VALUE).multiply(java.math.BigInteger.TEN);
+        BigInteger value = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN);
         byte[] jsonbBytes = JSONB.toBytes(value);
-        java.math.BigInteger result = (java.math.BigInteger) JSONB.parse(jsonbBytes);
+        BigInteger result = (BigInteger) JSONB.parse(jsonbBytes);
         assertEquals(value, result);
     }
 
     @Test
     public void testBinaryDeclaredLengthOOM() {
-        // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0x0FFFFFFF = 256MB-1 (passes readLength cap, exceeds buffer)
-        byte[] payload = {
-                (byte) 0x91,
-                (byte) 0x48,
-                (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+        assertThrows(JSONException.class, () -> JSONB.parse(BINARY_PAYLOAD_MAX_LEN));
     }
 
     @Test
     public void testBinaryNegativeLength() {
-        // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0xFFFFFFFF = -1
-        byte[] payload = {
-                (byte) 0x91,
-                (byte) 0x48,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+        assertThrows(JSONException.class, () -> JSONB.parse(BINARY_PAYLOAD_NEG_LEN));
     }
 
     @Test
     public void testReadBinaryDeclaredLengthOOM() {
         // Explicit readBinary() path
-        byte[] payload = {
-                (byte) 0x91,
-                (byte) 0x48,
-                (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        try (JSONReader reader = JSONReader.ofJSONB(payload)) {
+        try (JSONReader reader = JSONReader.ofJSONB(BINARY_PAYLOAD_MAX_LEN)) {
             assertThrows(JSONException.class, reader::readBinary);
         }
     }


### PR DESCRIPTION
## Summary

Add bounds checks before allocating byte arrays from JSONB-declared lengths, covering the `BC_BINARY` sites left over after #7696.

## Problem

`JSONReaderJSONB` reads a declared length from the JSONB stream and immediately allocates a byte array without validating that the length fits within the remaining buffer. A crafted payload declaring a huge length triggers an `OutOfMemoryError`.

#7696 fixed this for `BC_BIGINT`. The same pattern remained at three `BC_BINARY` allocation sites:

- `readAny()` → `case BC_BINARY`
- `readBinary()`
- `readBigInteger0()` → `case BC_BINARY`

## Fix

- Added `if (len < 0 || len > end - offset)` guards at the three `BC_BINARY` sites.
- Extracted the existing `BC_BIGINT` guard (4 sites) into a `checkBigintLen` helper, and included the available byte count in the exception message for easier diagnosis.

## Tests

`Issue7669` — 10 tests:

- `BC_BIGINT` with `Integer.MAX_VALUE` and negative declared lengths, via `JSONB.parse` and the `readBigInteger` / `readString` / `readNumber` paths
- `BC_BINARY` with 256MB-1 and negative declared lengths, via `JSONB.parse` and explicit `readBinary()`
- Valid round-trip for both `BigInteger` and `byte[]`
