### PR TITLE
fix: validate additionalItems for Java arrays

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/schema/ArraySchema.java
+++ b/core/src/main/java/com/alibaba/fastjson2/schema/ArraySchema.java
@@ -206,7 +206,7 @@ public final class ArraySchema
                     return result;
                 }
                 prefixMatch = true;
-            } else if (isCollection && itemSchema == null && additionalItem != null) { // 只有 Collection 才会执行这部分校验
+            } else if (itemSchema == null && additionalItem != null) {
                 ValidateResult result = additionalItem.validate(item);
                 if (!result.isSuccess()) {
                     return result;

--- a/core/src/test/java/com/alibaba/fastjson2/schema/JSONSchemaTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/schema/JSONSchemaTest.java
@@ -1900,6 +1900,17 @@ public class JSONSchemaTest {
     }
 
     @Test
+    public void testAdditionalItemsSchemaWithObjectArray() {
+        JSONSchema jsonSchema = JSONSchema.parseSchema("{\n" +
+                "  \"items\": [{\"type\": \"integer\"}],\n" +
+                "  \"additionalItems\": {\"type\": \"boolean\"}\n" +
+                "}");
+
+        assertTrue(jsonSchema.isValid(new Object[]{1, true}));
+        assertFalse(jsonSchema.isValid(new Object[]{1, "invalid"}));
+    }
+
+    @Test
     public void test_items_0() {
         JSONSchema jsonSchema = JSONSchema.parseSchema("{\n" +
                 "            \"definitions\": {\n" +


### PR DESCRIPTION
### What this PR does / why we need it?

When a tuple schema uses an array-valued `items` together with a schema-valued `additionalItems`, `ArraySchema` applies the additional-item schema to `Collection` inputs but skips it for Java arrays. As a result, an `Object[]` can pass validation even when an element after the tuple prefix violates `additionalItems`.

Draft-07 requires every array element after the tuple prefix to validate against `additionalItems`, independent of the Java representation used by the validator.

### Summary of your change

- Apply the `additionalItems` schema to Java arrays as well as collections.
- Add a regression test covering both a valid and invalid trailing element in an `Object[]`.

Validation:

- `./mvnw -q -pl core -Dtest=JSONSchemaTest#testAdditionalItemsSchemaWithObjectArray test`
- `./mvnw -q -pl core clean package` (7,934 tests, 0 failures/errors)
- `./mvnw -q -pl core -Dfastjson2.creator=reflect clean package` (7,934 tests, 0 failures/errors)

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. No documentation change is needed because this restores the documented JSON Schema behavior.