### PR TITLE
2.0.63.android5: port security fixes from main

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.61.android5</version>
+        <version>2.0.63.android5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/codegen-test/pom.xml
+++ b/codegen-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.61.android5</version>
+        <version>2.0.63.android5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.61.android5</version>
+        <version>2.0.63.android5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -34,6 +34,7 @@ import static com.alibaba.fastjson2.util.TypeUtils.toDoubleValue;
 public abstract class JSONReader
         implements Closeable {
     static final int MAX_EXP = 2047;
+    static final int MAX_NUMBER_DIGITS = 10_000;
 
     static final byte JSON_TYPE_INT = 1;
     static final byte JSON_TYPE_DEC = 2;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -563,9 +563,7 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BIGINT length out of range: " + len);
-                }
+                checkBigintLen(len, offset, end);
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -656,6 +654,9 @@ final class JSONReaderJSONB
             }
             case BC_BINARY: {
                 int len = readLength();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BINARY length out of range: " + len);
+                }
                 byte[] binary = Arrays.copyOfRange(this.bytes, offset, offset + len);
                 offset += len;
                 return binary;
@@ -3257,9 +3258,7 @@ final class JSONReaderJSONB
                 return Long.toString(int64Value);
             case BC_BIGINT: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BIGINT length out of range: " + len);
-                }
+                checkBigintLen(len, offset, end);
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -3686,10 +3685,19 @@ final class JSONReaderJSONB
         }
 
         int len = readLength();
+        if (len < 0 || len > end - offset) {
+            throw new JSONException("BC_BINARY length out of range: " + len);
+        }
         byte[] bytes = new byte[len];
         System.arraycopy(this.bytes, offset, bytes, 0, len);
         offset += len;
         return bytes;
+    }
+
+    static void checkBigintLen(int len, int offset, int end) {
+        if (len < 0 || len > end - offset) {
+            throw new JSONException("BC_BIGINT length out of range: " + len + ", available: " + (end - offset));
+        }
     }
 
     @Override
@@ -4144,9 +4152,7 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BIGINT length out of range: " + len);
-                }
+                checkBigintLen(len, offset, end);
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4381,9 +4387,7 @@ final class JSONReaderJSONB
             );
         } else if (type == BC_BIGINT) {
             int len = readInt32Value();
-            if (len < 0 || len > end - offset) {
-                throw new JSONException("BC_BIGINT length out of range: " + len);
-            }
+            checkBigintLen(len, offset, end);
             byte[] bytes = new byte[len];
             System.arraycopy(this.bytes, offset, bytes, 0, len);
             offset += len;
@@ -4445,6 +4449,9 @@ final class JSONReaderJSONB
             }
             case BC_BINARY: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BINARY length out of range: " + len);
+                }
                 byte[] buf = new byte[len];
                 System.arraycopy(this.bytes, offset, buf, 0, len);
                 offset += len;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -563,6 +563,9 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BIGINT length out of range: " + len);
+                }
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -3254,6 +3257,9 @@ final class JSONReaderJSONB
                 return Long.toString(int64Value);
             case BC_BIGINT: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BIGINT length out of range: " + len);
+                }
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4138,6 +4144,9 @@ final class JSONReaderJSONB
             }
             case BC_BIGINT: {
                 int len = readInt32Value();
+                if (len < 0 || len > end - offset) {
+                    throw new JSONException("BC_BIGINT length out of range: " + len);
+                }
                 byte[] bytes = new byte[len];
                 System.arraycopy(this.bytes, offset, bytes, 0, len);
                 offset += len;
@@ -4372,6 +4381,9 @@ final class JSONReaderJSONB
             );
         } else if (type == BC_BIGINT) {
             int len = readInt32Value();
+            if (len < 0 || len > end - offset) {
+                throw new JSONException("BC_BIGINT length out of range: " + len);
+            }
             byte[] bytes = new byte[len];
             System.arraycopy(this.bytes, offset, bytes, 0, len);
             offset += len;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3630,6 +3630,9 @@ final class JSONReaderUTF16
         if (intOverflow) {
             int numStart = negative ? start : start - 1;
             int numDigits = scale > 0 ? offset - 2 - numStart : offset - 1 - numStart;
+            if (numDigits > MAX_NUMBER_DIGITS) {
+                throw new JSONException("Number literal too long: " + numDigits + " digits (max " + MAX_NUMBER_DIGITS + ")");
+            }
             if (numDigits > 38) {
                 valueType = JSON_TYPE_BIG_DEC;
                 if (negative) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -3328,6 +3328,9 @@ class JSONReaderUTF8
         if (intOverflow) {
             int numStart = negative ? start : start - 1;
             int numDigits = scale > 0 ? offset - 2 - numStart : offset - 1 - numStart;
+            if (numDigits > MAX_NUMBER_DIGITS) {
+                throw new JSONException("Number literal too long: " + numDigits + " digits (max " + MAX_NUMBER_DIGITS + ")");
+            }
             if (numDigits > 38) {
                 valueType = JSON_TYPE_BIG_DEC;
                 if (negative) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF16.java
@@ -2233,7 +2233,7 @@ final class JSONWriterUTF16
         boolean writeAsString = (context.features & Feature.WriteNonStringValueAsString.mask) != 0;
 
         int off = this.off;
-        int minCapacity = off + values.length * (writeAsString ? 16 : 18) + 1;
+        int minCapacity = off + values.length * 18 + 2;
         if (minCapacity >= chars.length) {
             ensureCapacity(minCapacity);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterUTF8.java
@@ -2257,7 +2257,7 @@ final class JSONWriterUTF8
         boolean writeAsString = (context.features & JSONWriter.Feature.WriteNonStringValueAsString.mask) != 0;
 
         int off = this.off;
-        int minCapacity = off + values.length * (writeAsString ? 16 : 18) + 1;
+        int minCapacity = off + values.length * 18 + 2;
         if (minCapacity >= bytes.length) {
             ensureCapacity(minCapacity);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
+++ b/core/src/main/java/com/alibaba/fastjson2/filter/ContextAutoTypeBeforeHandler.java
@@ -23,6 +23,7 @@ public class ContextAutoTypeBeforeHandler
     static final Class CLASS_UNMODIFIABLE_SET = Collections.unmodifiableSet(Collections.emptySet()).getClass();
     static final Class CLASS_UNMODIFIABLE_COLLECTION = Collections.unmodifiableCollection(Collections.emptyList()).getClass();
     final long[] acceptHashCodes;
+    final Set<String> acceptNameSet;
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, Class>> tclHashCaches = new ConcurrentHashMap<>();
     final Map<Long, Class> classCache = new ConcurrentHashMap<>(16, 0.75f, 1);
 
@@ -200,6 +201,7 @@ public class ContextAutoTypeBeforeHandler
         }
 
         long[] array = new long[nameSet.size()];
+        Set<String> normalizedNames = new HashSet<>(nameSet.size());
 
         int index = 0;
         for (String name : nameSet) {
@@ -214,6 +216,7 @@ public class ContextAutoTypeBeforeHandler
             }
 
             array[index++] = hashCode;
+            normalizedNames.add(normalizeAcceptName(name));
         }
 
         if (index != array.length) {
@@ -221,6 +224,7 @@ public class ContextAutoTypeBeforeHandler
         }
         Arrays.sort(array);
         this.acceptHashCodes = array;
+        this.acceptNameSet = Collections.unmodifiableSet(normalizedNames);
     }
 
     public Class<?> apply(long typeNameHash, Class<?> expectClass, long features) {
@@ -242,6 +246,10 @@ public class ContextAutoTypeBeforeHandler
             typeName = "Object";
         }
 
+        if (hasIllegalTypeNameChars(typeName)) {
+            return null;
+        }
+
         long hash = MAGIC_HASH_CODE;
         for (int i = 0, typeNameLength = typeName.length(); i < typeNameLength; ++i) {
             char ch = typeName.charAt(i);
@@ -252,6 +260,9 @@ public class ContextAutoTypeBeforeHandler
             hash *= MAGIC_PRIME;
 
             if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                if (!acceptNameSet.contains(normalizeAcceptName(typeName.substring(0, i + 1)))) {
+                    continue;
+                }
                 long typeNameHash = Fnv.hashCode64(typeName);
                 Class clazz = apply(typeNameHash, expectClass, features);
 
@@ -266,6 +277,13 @@ public class ContextAutoTypeBeforeHandler
                 }
 
                 if (clazz != null) {
+                    // matching an accept prefix is not an opt-in for gadget base types, only an
+                    // accept entry naming the type in full is; keep scanning for such an entry.
+                    // checked after the cache read so that a cached class is checked too
+                    if (i + 1 < typeNameLength && isAutoTypeDenyClass(clazz)) {
+                        continue;
+                    }
+
                     return clazz;
                 }
             }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -11,9 +11,6 @@ import com.alibaba.fastjson2.function.impl.*;
 import com.alibaba.fastjson2.time.ZoneId;
 import com.alibaba.fastjson2.util.*;
 
-import javax.sql.DataSource;
-import javax.sql.RowSet;
-
 import java.io.Closeable;
 import java.io.File;
 import java.io.Serializable;
@@ -32,9 +29,19 @@ import java.util.regex.Pattern;
 import static com.alibaba.fastjson2.util.BeanUtils.*;
 import static com.alibaba.fastjson2.util.Fnv.MAGIC_HASH_CODE;
 import static com.alibaba.fastjson2.util.Fnv.MAGIC_PRIME;
+import static com.alibaba.fastjson2.util.TypeUtils.hasIllegalTypeNameChars;
+import static com.alibaba.fastjson2.util.TypeUtils.isAutoTypeDenyClass;
 import static com.alibaba.fastjson2.util.TypeUtils.loadClass;
+import static com.alibaba.fastjson2.util.TypeUtils.normalizeAcceptName;
 
 public class ObjectReaderProvider {
+    /**
+     * Always accepted, it is the map implementation fastjson 1.x substitutes for {@code HashMap}
+     * when hash collision protection is enabled.
+     */
+    static final String ANTI_COLLISION_HASH_MAP = "com.alibaba.fastjson.util.AntiCollisionHashMap";
+    static final long ANTI_COLLISION_HASH_MAP_HASH = -6293031534589903644L; // Fnv.hashCode64(ANTI_COLLISION_HASH_MAP)
+
     static ObjectReaderCachePair readerCache;
 
     private static final class ObjectReaderCachePair {
@@ -61,6 +68,13 @@ public class ObjectReaderProvider {
 
     private long[] denyHashCodes;
     private long[] acceptHashCodes;
+
+    /**
+     * The accept names behind {@link #acceptHashCodes}, normalized the same way the rolling hash in
+     * {@link #checkAutoType} normalizes a type name. A hash match is only honored when the matched
+     * prefix text is in this set, so a hash collision alone cannot whitelist a type name.
+     */
+    private volatile Set<String> acceptNameSet = Collections.emptySet();
 
     private AutoTypeBeforeHandler autoTypeBeforeHandler;
     private Consumer<Class> autoTypeHandler;
@@ -231,7 +245,8 @@ public class ObjectReaderProvider {
                 9144212112462101475L
         };
 
-        acceptHashCodes = new long[]{-6293031534589903644L};
+        acceptHashCodes = new long[]{ANTI_COLLISION_HASH_MAP_HASH};
+        acceptNameSet = Collections.singleton(ANTI_COLLISION_HASH_MAP);
 
         hashCache.put(ObjectArrayReader.TYPE_HASH_CODE, ObjectArrayReader.INSTANCE);
         final long STRING_CLASS_NAME_HASH = -4834614249632438472L; // Fnv.hashCode64(String.class.getName());
@@ -246,7 +261,17 @@ public class ObjectReaderProvider {
 
     public void addAutoTypeAccept(String name) {
         if (name != null && name.length() != 0) {
-            long hash = Fnv.hashCode64(name);
+            String acceptName = normalizeAcceptName(name);
+
+            // publish the name before the hash, so that a reader seeing the new hash array is
+            // guaranteed to see the name it verifies against rather than transiently rejecting
+            if (!this.acceptNameSet.contains(acceptName)) {
+                Set<String> names = new HashSet<>(this.acceptNameSet);
+                names.add(acceptName);
+                this.acceptNameSet = Collections.unmodifiableSet(names);
+            }
+
+            long hash = Fnv.hashCode64(acceptName);
             if (Arrays.binarySearch(this.acceptHashCodes, hash) < 0) {
                 long[] hashCodes = new long[this.acceptHashCodes.length + 1];
                 hashCodes[hashCodes.length - 1] = hash;
@@ -673,6 +698,13 @@ public class ObjectReaderProvider {
             throw new JSONException("autoType is not support. " + typeName);
         }
 
+        // treat it as unresolvable rather than an error, the same as a type name that fails to
+        // load: JSON-LD uses @type for an IRI, and reporting that as unresolved leaves the
+        // ErrorOnNotSupportAutoType feature in charge of whether the caller sees an exception
+        if (hasIllegalTypeNameChars(typeName)) {
+            return null;
+        }
+
         if (typeName.charAt(0) == '[') {
             String componentTypeName = typeName.substring(1);
             checkAutoType(componentTypeName, null, features); // blacklist check for componentType
@@ -686,6 +718,10 @@ public class ObjectReaderProvider {
         boolean autoTypeSupport = (features & JSONReader.Feature.SupportAutoType.mask) != 0;
         Class<?> clazz;
 
+        // set when an accept prefix matched a deny class, so that the rejection below can tell a
+        // misconfigured accept list apart from a type name that was never accepted at all
+        boolean denyPrefixOnly = false;
+
         if (autoTypeSupport) {
             long hash = MAGIC_HASH_CODE;
             for (int i = 0; i < typeNameLength; ++i) {
@@ -696,8 +732,18 @@ public class ObjectReaderProvider {
                 hash ^= ch;
                 hash *= MAGIC_PRIME;
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                    if (!acceptNameSet.contains(normalizeAcceptName(typeName.substring(0, i + 1)))) {
+                        continue;
+                    }
                     clazz = loadClass(typeName);
                     if (clazz != null) {
+                        // matching an accept prefix is not an opt-in for gadget base types, only an
+                        // accept entry naming the type in full is; keep scanning for such an entry
+                        if (i + 1 < typeNameLength && isAutoTypeDenyClass(clazz)) {
+                            denyPrefixOnly = true;
+                            continue;
+                        }
+
                         if (expectClass != null && !expectClass.isAssignableFrom(clazz)) {
                             throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());
                         }
@@ -728,7 +774,15 @@ public class ObjectReaderProvider {
 
                 // white list
                 if (Arrays.binarySearch(acceptHashCodes, hash) >= 0) {
+                    if (!acceptNameSet.contains(normalizeAcceptName(typeName.substring(0, i + 1)))) {
+                        continue;
+                    }
                     clazz = loadClass(typeName);
+
+                    // see the SupportAutoType branch above
+                    if (clazz != null && i + 1 < typeNameLength && isAutoTypeDenyClass(clazz)) {
+                        continue;
+                    }
 
                     if (clazz != null && expectClass != null && !expectClass.isAssignableFrom(clazz)) {
                         throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());
@@ -762,8 +816,11 @@ public class ObjectReaderProvider {
         clazz = loadClass(typeName);
 
         if (clazz != null) {
-            if (ClassLoader.class.isAssignableFrom(clazz) || DataSource.class.isAssignableFrom(clazz) || RowSet.class.isAssignableFrom(clazz)) {
-                throw new JSONException("autoType is not support. " + typeName);
+            if (isAutoTypeDenyClass(clazz)) {
+                throw new JSONException(denyPrefixOnly
+                        ? "autoType is not support, an accept prefix does not cover it, "
+                        + "add the type name in full to accept. " + typeName
+                        : "autoType is not support. " + typeName);
             }
 
             if (expectClass != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/TypeUtils.java
@@ -7,6 +7,9 @@ import com.alibaba.fastjson2.time.*;
 import com.alibaba.fastjson2.writer.ObjectWriter;
 import com.alibaba.fastjson2.writer.ObjectWriterPrimitiveImpl;
 
+import javax.sql.DataSource;
+import javax.sql.RowSet;
+
 import java.lang.reflect.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -3077,8 +3080,59 @@ public class TypeUtils {
         return null;
     }
 
+    /**
+     * Tests whether a type name carries a character that cannot appear in a Java binary class name
+     * but is meaningful in a URL. A nested jar URL such as {@code jar:http://host/x.jar!/} is
+     * resolvable by some class loaders, so a type name carrying one must never reach one.
+     *
+     * <p>Every autoType entry point shares this predicate; validating in only some of them is the
+     * asymmetry that lets a type name reach a class loader through the unchecked path.
+     *
+     * <p>Internal, public only because the autoType entry points live in different packages.
+     *
+     * @param typeName the type name to test
+     * @return true if the type name must be rejected without being resolved
+     */
+    public static boolean hasIllegalTypeNameChars(String typeName) {
+        return typeName.indexOf(':') >= 0 || typeName.indexOf('!') >= 0;
+    }
+
+    /**
+     * Normalizes a type name the way the autoType accept-list rolling hash normalizes it, so that a
+     * nested class matches whether it is written with its binary name ({@code a.b.Outer$Inner}) or
+     * its canonical name ({@code a.b.Outer.Inner}). Following that existing rolling-hash rule means
+     * the two spellings are equivalent as accept entries.
+     *
+     * <p>Internal, public only because the autoType entry points live in different packages.
+     *
+     * @param typeName the type name to normalize
+     * @return the normalized type name
+     */
+    public static String normalizeAcceptName(String typeName) {
+        return typeName.indexOf('$') >= 0 ? typeName.replace('$', '.') : typeName;
+    }
+
+    /**
+     * Tests whether a class is a well known deserialization gadget entry point, namely a
+     * {@link ClassLoader} subclass or a JDK SQL {@code DataSource}/{@code RowSet} implementation.
+     * Such types must not be resolved by matching an autoType whitelist prefix; only an accept
+     * entry naming the type in full is treated as an explicit opt-in.
+     *
+     * @param type the class to test
+     * @return true if the class must not be resolved through a whitelist prefix match
+     */
+    public static boolean isAutoTypeDenyClass(Class<?> type) {
+        return ClassLoader.class.isAssignableFrom(type)
+                || DataSource.class.isAssignableFrom(type)
+                || RowSet.class.isAssignableFrom(type);
+    }
+
     public static Class loadClass(String className) {
         if (className.length() >= 192) {
+            return null;
+        }
+
+        if (hasIllegalTypeNameChars(className)) {
             return null;
         }
 

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplCollection.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplCollection.java
@@ -82,9 +82,6 @@ final class ObjectWriterImplCollection
 //        }
 
         boolean refDetect = jsonWriter.isRefDetect();
-        if (collection.size() > 1 && !(collection instanceof SortedSet) && !(collection instanceof LinkedHashSet)) {
-            refDetect = false;
-        }
 
         jsonWriter.startArray(collection.size());
 
@@ -144,8 +141,10 @@ final class ObjectWriterImplCollection
 
         Iterable iterable = (Iterable) object;
 
+        boolean refDetect = jsonWriter.isRefDetect();
         Class previousClass = null;
         ObjectWriter previousObjectWriter = null;
+        boolean previousRefDetect = false;
         jsonWriter.startArray();
         int i = 0;
         for (Iterator it = iterable.iterator(); it.hasNext(); ) {
@@ -161,15 +160,33 @@ final class ObjectWriterImplCollection
             }
             Class<?> itemClass = item.getClass();
             ObjectWriter itemObjectWriter;
+            boolean itemRefDetect;
             if (itemClass == previousClass) {
                 itemObjectWriter = previousObjectWriter;
+                itemRefDetect = previousRefDetect;
             } else {
                 itemObjectWriter = jsonWriter.getObjectWriter(itemClass);
+                itemRefDetect = refDetect && !ObjectWriterProvider.isNotReferenceDetect(itemClass);
                 previousClass = itemClass;
                 previousObjectWriter = itemObjectWriter;
+                previousRefDetect = itemRefDetect;
+            }
+
+            if (itemRefDetect) {
+                String refPath = jsonWriter.setPath(i, item);
+                if (refPath != null) {
+                    jsonWriter.writeReference(refPath);
+                    jsonWriter.popPath(item);
+                    i++;
+                    continue;
+                }
             }
 
             itemObjectWriter.write(jsonWriter, item, i, this.itemType, this.features);
+
+            if (itemRefDetect) {
+                jsonWriter.popPath(item);
+            }
 
             ++i;
         }

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -1,0 +1,397 @@
+package com.alibaba.fastjson2.autoType;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.util.Fnv;
+import com.alibaba.fastjson2.util.TypeUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("autotype")
+public class AutoTypeValidationTest {
+    static final String PACKAGE_PREFIX = "com.alibaba.fastjson2.autoType.";
+    static final String TEST_BEAN = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean";
+    static final String TEST_CLASS_LOADER = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestClassLoader";
+    static final String TEST_DATA_SOURCE = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestDataSource";
+
+    // =========================================================================
+    // type name format validation
+    // =========================================================================
+
+    /**
+     * Unresolvable rather than an error, matching a type name that simply fails to load. Whether the
+     * caller sees an exception is left to {@code ErrorOnNotSupportAutoType}.
+     */
+    @Test
+    public void testRejectColonInTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertNull(provider.checkAutoType("com.example.Bean:invalid", null, 0));
+    }
+
+    @Test
+    public void testRejectExclamationInTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertNull(provider.checkAutoType("com.example.Bean!invalid", null, 0));
+    }
+
+    @Test
+    public void testRejectColonWithSupportAutoType() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        assertNull(provider.checkAutoType("com.example.Bean:invalid", null, features));
+    }
+
+    /**
+     * {@code @type} is a JSON-LD keyword whose value is an IRI, so it always carries {@code :}.
+     * Rejecting the type name must leave the existing fall-back-to-map behaviour intact.
+     */
+    @Test
+    public void testParseJsonLdFallsBackToMap() {
+        String jsonLd = "{\"@type\":\"http://schema.org/Person\",\"name\":\"x\"}";
+
+        Object object = JSON.parseObject(jsonLd, Object.class);
+        assertInstanceOf(Map.class, object);
+        assertEquals("x", ((Map<?, ?>) object).get("name"));
+
+        assertInstanceOf(Map.class, JSON.parseArray("[" + jsonLd + "]", Object.class).get(0));
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(
+                jsonLd, Object.class, JSONReader.Feature.ErrorOnNotSupportAutoType));
+    }
+
+    /**
+     * A type name carrying {@code :} or {@code !} must not reach the class loader at all: a nested
+     * jar URL such as {@code jar:http://host/x.jar!/} is resolvable by some class loaders and would
+     * turn a type name into a remote class load. Uses a class loader that resolves any name, so the
+     * assertion fails if the format check is removed.
+     */
+    @Test
+    public void testLoadClassDoesNotReachClassLoader() {
+        AtomicReference<String> requested = new AtomicReference<>();
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader recording = new ClassLoader(contextClassLoader) {
+            @Override
+            public Class<?> loadClass(String name) {
+                requested.set(name);
+                return Integer.class;
+            }
+        };
+
+        try {
+            Thread.currentThread().setContextClassLoader(recording);
+
+            assertNull(TypeUtils.loadClass("jar:http://127.0.0.1/evil.jar!/Evil"));
+            assertNull(TypeUtils.loadClass("com.example.Bean:invalid"));
+            assertNull(TypeUtils.loadClass("com.example.Bean!invalid"));
+            assertNull(requested.get(), "type name must not reach the class loader");
+
+            // control: an ordinary type name does reach the class loader
+            assertEquals(Integer.class, TypeUtils.loadClass("com.example.Bean"));
+            assertEquals("com.example.Bean", requested.get());
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    @Test
+    public void testLoadClassNormalClass() {
+        assertEquals(String.class, TypeUtils.loadClass("java.lang.String"));
+    }
+
+    @Test
+    public void testContextHandlerRejectsColon() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(true);
+        assertNull(handler.apply("com.example.Bean:invalid", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerRejectsExclamation() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(true);
+        assertNull(handler.apply("com.example.Bean!invalid", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerAcceptsWhitelisted() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
+        assertEquals(String.class, handler.apply("java.lang.String", null, 0));
+    }
+
+    @Test
+    public void testContextHandlerRejectsNonWhitelisted() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(String.class);
+        assertNull(handler.apply("com.example.NotWhitelisted", null, 0));
+    }
+
+    // =========================================================================
+    // whitelist text verification
+    // =========================================================================
+
+    /**
+     * Without {@code SupportAutoType} the whitelist is the only way a type name resolves, so these
+     * assertions can only pass through the rolling-hash accept path.
+     */
+    @Test
+    public void testWhitelistPrefixAccept() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        assertNull(provider.checkAutoType(TEST_BEAN, null, 0));
+
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+        assertEquals(TestBean.class, provider.checkAutoType(TEST_BEAN, null, 0));
+    }
+
+    /**
+     * The rolling hash in {@code checkAutoType} normalizes {@code $} to {@code .}, so an accept
+     * entry written with the binary name of a nested class has to be normalized the same way to
+     * match.
+     */
+    @Test
+    public void testWhitelistAcceptNestedClassBinaryName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(TEST_BEAN);
+        assertEquals(TestBean.class, provider.checkAutoType(TEST_BEAN, null, 0));
+
+        ObjectReaderProvider canonical = new ObjectReaderProvider();
+        canonical.addAutoTypeAccept(TEST_BEAN.replace('$', '.'));
+        assertEquals(TestBean.class, canonical.checkAutoType(TEST_BEAN, null, 0));
+    }
+
+    /**
+     * A hash match alone must not whitelist a type name. Injects the hash of a {@code java.lang.}
+     * prefix into {@code acceptHashCodes} without registering the text, which is what a rolling-hash
+     * collision would look like, and asserts the type name is still rejected.
+     */
+    @Test
+    public void testWhitelistHashMatchWithoutTextRejected() throws Exception {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+
+        Field field = ObjectReaderProvider.class.getDeclaredField("acceptHashCodes");
+        field.setAccessible(true);
+        long[] hashCodes = (long[]) field.get(provider);
+        long[] injected = Arrays.copyOf(hashCodes, hashCodes.length + 1);
+        injected[injected.length - 1] = Fnv.hashCode64("java.lang.");
+        Arrays.sort(injected);
+        field.set(provider, injected);
+
+        assertNull(provider.checkAutoType("java.lang.Integer", null, 0));
+
+        // control: the same lookup succeeds once the accept text is registered
+        provider.addAutoTypeAccept("java.lang.");
+        assertEquals(Integer.class, provider.checkAutoType("java.lang.Integer", null, 0));
+    }
+
+    /**
+     * A collision on the full type name is the dangerous case: matching an accept entry in full is
+     * what exempts a type from the gadget blacklist, so it must be backed by the accept text.
+     */
+    @Test
+    public void testWhitelistFullNameHashMatchWithoutTextRejected() throws Exception {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+
+        Field field = ObjectReaderProvider.class.getDeclaredField("acceptHashCodes");
+        field.setAccessible(true);
+        long[] hashCodes = (long[]) field.get(provider);
+        long[] injected = Arrays.copyOf(hashCodes, hashCodes.length + 1);
+        injected[injected.length - 1] = Fnv.hashCode64(TEST_CLASS_LOADER.replace('$', '.'));
+        Arrays.sort(injected);
+        field.set(provider, injected);
+
+        assertNull(provider.checkAutoType(TEST_CLASS_LOADER, null, 0));
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, JSONReader.Feature.SupportAutoType.mask));
+    }
+
+    @Test
+    public void testContextHandlerHashMatchWithoutTextRejected() throws Exception {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler("com.example.");
+
+        Field field = ContextAutoTypeBeforeHandler.class.getDeclaredField("acceptHashCodes");
+        field.setAccessible(true);
+        long[] hashCodes = (long[]) field.get(handler);
+        assertEquals(1, hashCodes.length);
+        hashCodes[0] = Fnv.hashCode64(TEST_CLASS_LOADER.replace('$', '.'));
+
+        assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
+    }
+
+    @Test
+    public void testWhitelistNonAcceptedPrefix() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept("com.example.");
+
+        long features = JSONReader.Feature.SupportAutoType.mask;
+        assertNull(provider.checkAutoType("com.other.NotAccepted", null, features));
+    }
+
+    /**
+     * {@code com.alibaba.fastjson.util.AntiCollisionHashMap} is always accepted through a hardcoded
+     * hash. Text verification would silently kill that entry if its name were missing from
+     * {@code acceptNameSet}.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAntiCollisionHashMapAlwaysAccepted() throws Exception {
+        String name = "com.alibaba.fastjson.util.AntiCollisionHashMap";
+        assertEquals(-6293031534589903644L, Fnv.hashCode64(name));
+
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        Field field = ObjectReaderProvider.class.getDeclaredField("acceptNameSet");
+        field.setAccessible(true);
+        assertTrue(((Set<String>) field.get(provider)).contains(name));
+    }
+
+    // =========================================================================
+    // blacklist enforcement on whitelist matches
+    // =========================================================================
+
+    @Test
+    public void testAcceptPrefixDoesNotAllowClassLoader() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+
+        assertNull(provider.checkAutoType(TEST_CLASS_LOADER, null, 0));
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, JSONReader.Feature.SupportAutoType.mask));
+
+        // the accept prefix still resolves types that are not gadget base types
+        assertEquals(TestBean.class, provider.checkAutoType(TEST_BEAN, null, 0));
+    }
+
+    /**
+     * An accept entry naming the type in full is an explicit opt-in, and a shorter prefix entry
+     * matching first must not preempt it.
+     */
+    @Test
+    public void testExactAcceptNameAllowsClassLoader() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+        provider.addAutoTypeAccept(TEST_CLASS_LOADER);
+
+        assertEquals(TestClassLoader.class, provider.checkAutoType(TEST_CLASS_LOADER, null, 0));
+        assertEquals(TestClassLoader.class, provider.checkAutoType(
+                TEST_CLASS_LOADER, null, JSONReader.Feature.SupportAutoType.mask));
+    }
+
+    @Test
+    public void testAcceptPrefixDoesNotAllowDataSource() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+
+        assertNull(provider.checkAutoType(TEST_DATA_SOURCE, null, 0));
+        assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_DATA_SOURCE, null, JSONReader.Feature.SupportAutoType.mask));
+    }
+
+    @Test
+    public void testContextHandlerAcceptPrefixDoesNotAllowClassLoader() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
+        assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
+        assertEquals(TestBean.class, handler.apply(TEST_BEAN, null, 0));
+    }
+
+    @Test
+    public void testContextHandlerAcceptPrefixDoesNotAllowDataSource() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
+        assertNull(handler.apply(TEST_DATA_SOURCE, null, 0));
+    }
+
+    /**
+     * The blacklist runs after the class cache is consulted, so a cached class is checked too rather
+     * than the check resting on nothing but a deny class never being cached.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testContextHandlerChecksCachedClass() throws Exception {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(PACKAGE_PREFIX);
+
+        Field field = ContextAutoTypeBeforeHandler.class.getDeclaredField("classCache");
+        field.setAccessible(true);
+        ((Map<Long, Class>) field.get(handler))
+                .put(Fnv.hashCode64(TEST_CLASS_LOADER), TestClassLoader.class);
+
+        assertNull(handler.apply(TEST_CLASS_LOADER, null, 0));
+    }
+
+    @Test
+    public void testContextHandlerExactAcceptNameAllowsClassLoader() {
+        ContextAutoTypeBeforeHandler handler = new ContextAutoTypeBeforeHandler(
+                PACKAGE_PREFIX,
+                TEST_CLASS_LOADER
+        );
+        assertEquals(TestClassLoader.class, handler.apply(TEST_CLASS_LOADER, null, 0));
+    }
+
+    /**
+     * An unresolved {@code @type} falls back to a map unless {@code ErrorOnNotSupportAutoType} is
+     * set, so what matters end to end is that no {@link ClassLoader} is ever instantiated.
+     */
+    @Test
+    public void testParseRejectsClassLoaderUnderAcceptPrefix() {
+        Object object = JSON.parseObject(
+                "{\"@type\":\"" + TEST_CLASS_LOADER + "\"}",
+                Object.class,
+                JSONReader.autoTypeFilter(PACKAGE_PREFIX));
+        assertFalse(object instanceof ClassLoader, "accept prefix must not resolve a ClassLoader");
+
+        // control: the same accept prefix still deserializes an ordinary bean
+        TestBean bean = (TestBean) JSON.parseObject(
+                "{\"@type\":\"" + TEST_BEAN + "\",\"id\":123}",
+                Object.class,
+                JSONReader.autoTypeFilter(PACKAGE_PREFIX));
+        assertEquals(123, bean.id);
+    }
+
+    @Test
+    public void testParseWithAutoTypeFilterNormal() {
+        String json = "{\"@type\":\"java.util.HashMap\",\"value\":1}";
+        Object obj = JSON.parseObject(json, Object.class,
+                JSONReader.autoTypeFilter("java.util.HashMap"));
+        // not merely non-null, falling back to a JSONObject would satisfy that too
+        assertEquals(HashMap.class, obj.getClass());
+    }
+
+    @Test
+    public void testDenyPrefixOnlyRejectionIsDistinguishable() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        long features = JSONReader.Feature.SupportAutoType.mask;
+
+        // no accept entry covers it, the generic rejection
+        JSONException plain = assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, features));
+        assertFalse(plain.getMessage().contains("accept"));
+
+        // an accept prefix covers it but not in full, the actionable rejection
+        provider.addAutoTypeAccept(PACKAGE_PREFIX);
+        JSONException prefixOnly = assertThrows(JSONException.class, () ->
+                provider.checkAutoType(TEST_CLASS_LOADER, null, features));
+        assertTrue(prefixOnly.getMessage().contains("add the type name in full to accept"));
+    }
+
+    public static class TestBean {
+        public int id;
+    }
+
+    public static class TestClassLoader
+            extends ClassLoader {
+    }
+
+    /**
+     * Abstract is enough, {@code checkAutoType} resolves the class without instantiating it.
+     */
+    public abstract static class TestDataSource
+            implements DataSource {
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -1,0 +1,43 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("regression")
+@Tag("jsonb")
+public class Issue7669 {
+    @Test
+    public void testBigIntDeclaredLengthOOM() {
+        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+        byte[] payload = {
+                (byte) 0xBB,
+                (byte) 0x48,
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+    }
+
+    @Test
+    public void testBigIntNegativeLength() {
+        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+        byte[] payload = {
+                (byte) 0xBB,
+                (byte) 0x48,
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+    }
+
+    @Test
+    public void testBigIntValidPayloadStillWorks() {
+        // Verify legitimate BigInteger values still round-trip correctly
+        java.math.BigInteger value = java.math.BigInteger.valueOf(Long.MAX_VALUE).multiply(java.math.BigInteger.TEN);
+        byte[] jsonbBytes = JSONB.toBytes(value);
+        java.math.BigInteger result = (java.math.BigInteger) JSONB.parse(jsonbBytes);
+        org.junit.jupiter.api.Assertions.assertEquals(value, result);
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -2,42 +2,103 @@ package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigInteger;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Tag("regression")
 @Tag("jsonb")
 public class Issue7669 {
+    // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] PAYLOAD_MAX_LEN = {
+            (byte) 0xBB,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+    static final byte[] PAYLOAD_NEG_LEN = {
+            (byte) 0xBB,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0x0FFFFFFF = 256MB-1 (passes readLength cap, exceeds buffer)
+    static final byte[] BINARY_PAYLOAD_MAX_LEN = {
+            (byte) 0x91,
+            (byte) 0x48,
+            (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+    static final byte[] BINARY_PAYLOAD_NEG_LEN = {
+            (byte) 0x91,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
     @Test
     public void testBigIntDeclaredLengthOOM() {
-        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
-        byte[] payload = {
-                (byte) 0xBB,
-                (byte) 0x48,
-                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+        assertThrows(JSONException.class, () -> JSONB.parse(PAYLOAD_MAX_LEN));
     }
 
     @Test
     public void testBigIntNegativeLength() {
-        // 0xBB = BC_BIGINT, 0x48 = BC_INT32, 0xFFFFFFFF = -1
-        byte[] payload = {
-                (byte) 0xBB,
-                (byte) 0x48,
-                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
-        };
-        assertThrows(JSONException.class, () -> JSONB.parse(payload));
+        assertThrows(JSONException.class, () -> JSONB.parse(PAYLOAD_NEG_LEN));
+    }
+
+    @Test
+    public void testBigIntDeclaredLengthOOM_readBigInteger() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(PAYLOAD_MAX_LEN, BigInteger.class));
+    }
+
+    @Test
+    public void testBigIntDeclaredLengthOOM_readString() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(PAYLOAD_MAX_LEN, String.class));
+    }
+
+    @Test
+    public void testBigIntDeclaredLengthOOM_readNumber() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(PAYLOAD_MAX_LEN, Number.class));
     }
 
     @Test
     public void testBigIntValidPayloadStillWorks() {
-        // Verify legitimate BigInteger values still round-trip correctly
-        java.math.BigInteger value = java.math.BigInteger.valueOf(Long.MAX_VALUE).multiply(java.math.BigInteger.TEN);
+        BigInteger value = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN);
         byte[] jsonbBytes = JSONB.toBytes(value);
-        java.math.BigInteger result = (java.math.BigInteger) JSONB.parse(jsonbBytes);
-        org.junit.jupiter.api.Assertions.assertEquals(value, result);
+        BigInteger result = (BigInteger) JSONB.parse(jsonbBytes);
+        assertEquals(value, result);
+    }
+
+    @Test
+    public void testBinaryDeclaredLengthOOM() {
+        assertThrows(JSONException.class, () -> JSONB.parse(BINARY_PAYLOAD_MAX_LEN));
+    }
+
+    @Test
+    public void testBinaryNegativeLength() {
+        assertThrows(JSONException.class, () -> JSONB.parse(BINARY_PAYLOAD_NEG_LEN));
+    }
+
+    @Test
+    public void testReadBinaryDeclaredLengthOOM() {
+        // Explicit readBinary() path
+        try (JSONReader reader = JSONReader.ofJSONB(BINARY_PAYLOAD_MAX_LEN)) {
+            assertThrows(JSONException.class, reader::readBinary);
+        }
+    }
+
+    @Test
+    public void testBinaryValidPayloadStillWorks() {
+        byte[] value = {1, 2, 3, 4, 5};
+        byte[] jsonbBytes = JSONB.toBytes(value);
+        byte[] result = (byte[]) JSONB.parse(jsonbBytes);
+        assertArrayEquals(value, result);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1591.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_1500/Issue1591.java
@@ -1,0 +1,36 @@
+package com.alibaba.fastjson2.issues_1500;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Tag("regression")
+public class Issue1591 {
+    /**
+     * Regression test for writeFloat(float[]) buffer overflow when
+     * WriteNonStringValueAsString is enabled. Max float representation
+     * is 15 chars (e.g. "-1.00017205E-36"), and the capacity calculation
+     * must account for comma + 2 quotes + number per element.
+     */
+    @Test
+    public void testWriteFloatArrayAsString() {
+        float worstCaseFloat = -1.00017205E-36f;
+        for (int len : new int[]{1, 10, 100, 456, 500, 1000}) {
+            float[] arr = new float[len];
+            Arrays.fill(arr, worstCaseFloat);
+            {
+                String str = JSON.toJSONString(arr, JSONWriter.Feature.WriteNonStringValueAsString);
+                assertNotNull(str);
+            }
+            {
+                String str = JSON.toJSONString(arr, JSONWriter.Feature.WriteNonStringValueAsString, JSONWriter.Feature.OptimizedForAscii);
+                assertNotNull(str);
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7668.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7668.java
@@ -1,0 +1,85 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Issue7668 {
+    @Test
+    public void testExceedsMaxDigits() {
+        int n = 10_001;
+        StringBuilder sb = new StringBuilder("{\"x\":");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertThrows(JSONException.class, () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testWithinMaxDigits() {
+        int n = 100;
+        StringBuilder sb = new StringBuilder("{\"x\":");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        Object val = JSON.parseObject(json).get("x");
+        assertInstanceOf(BigInteger.class, val);
+
+        Object val2 = JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)).get("x");
+        assertInstanceOf(BigInteger.class, val2);
+    }
+
+    @Test
+    public void testErrorMessage() {
+        int n = 20_000;
+        StringBuilder sb = new StringBuilder("{\"x\":");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        JSONException ex = assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertTrue(ex.getMessage().contains("Number literal too long"));
+    }
+
+    @Test
+    public void testNegativeNumber() {
+        int n = 10_001;
+        StringBuilder sb = new StringBuilder("{\"x\":-");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertThrows(JSONException.class, () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testDecimalExceedsMaxDigits() {
+        int n = 10_001;
+        StringBuilder sb = new StringBuilder("{\"x\":0.");
+        for (int i = 0; i < n; i++) {
+            sb.append('9');
+        }
+        sb.append('}');
+        String json = sb.toString();
+
+        assertThrows(JSONException.class, () -> JSON.parseObject(json));
+        assertThrows(JSONException.class, () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7678.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7678.java
@@ -1,0 +1,170 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Issue7678 {
+    public static class Person {
+        public Set<Bean> testSet;
+    }
+
+    public static class Bean {
+        public String xxx1;
+        public String xxx2;
+        public String xxx3;
+    }
+
+    public static class Root {
+        public List<Object> data;
+        public Person person;
+    }
+
+    @Test
+    public void testHashSetRefDetectJSON() {
+        Bean bean = new Bean();
+        bean.xxx1 = "123";
+        bean.xxx2 = "123";
+        bean.xxx3 = "123";
+
+        Person person = new Person();
+        person.testSet = new HashSet<>();
+        person.testSet.add(bean);
+
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("Person", person);
+
+        Root root = new Root();
+        root.data = new ArrayList<>();
+        root.data.add(item);
+        root.person = person;
+
+        String json = JSON.toJSONString(root, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+
+        Object parsed = JSON.parse(json);
+        assertNotNull(parsed);
+    }
+
+    @Test
+    public void testHashSetRefDetectJSONB() {
+        Bean bean = new Bean();
+        bean.xxx1 = "123";
+        bean.xxx2 = "123";
+        bean.xxx3 = "123";
+
+        Person person = new Person();
+        person.testSet = new HashSet<>();
+        person.testSet.add(bean);
+
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("Person", person);
+
+        Root root = new Root();
+        root.data = new ArrayList<>();
+        root.data.add(item);
+        root.person = person;
+
+        byte[] bytes = JSONB.toBytes(root, JSONWriter.Feature.ReferenceDetection);
+        Root parsed = JSONB.parseObject(bytes, Root.class);
+        assertNotNull(parsed);
+        assertNotNull(parsed.person);
+        assertEquals(1, parsed.person.testSet.size());
+        Bean parsedBean = parsed.person.testSet.iterator().next();
+        assertEquals("123", parsedBean.xxx1);
+    }
+
+    @Test
+    public void testHashSetMultiElementRefDetect() {
+        Bean bean1 = new Bean();
+        bean1.xxx1 = "a";
+
+        Bean bean2 = new Bean();
+        bean2.xxx1 = "b";
+
+        Set<Bean> set = new HashSet<>();
+        set.add(bean1);
+        set.add(bean2);
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("set1", set);
+        map.put("set2", set);
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+
+    @Test
+    public void testLinkedHashSetRefDetect() {
+        Bean bean = new Bean();
+        bean.xxx1 = "123";
+
+        Person person = new Person();
+        person.testSet = new LinkedHashSet<>();
+        person.testSet.add(bean);
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("p1", person);
+        map.put("p2", person);
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+
+    @Test
+    public void testTreeSetRefDetect() {
+        Set<String> set = new TreeSet<>();
+        set.add("a");
+        set.add("b");
+
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("s1", set);
+        map.put("s2", set);
+
+        String json = JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref in output: " + json);
+    }
+
+    /**
+     * The same instance twice inside a single collection: the $ref can only come from the
+     * per-item setPath/popPath in ObjectWriterImplCollection, not from a parent-level writer.
+     * ArrayDeque is used because it is a Collection (so it routes to ObjectWriterImplCollection
+     * rather than ObjectWriterImplList) and, unlike a Set, it keeps duplicate elements.
+     */
+    @Test
+    public void testDuplicateItemWithinCollection() {
+        Bean bean = new Bean();
+        bean.xxx1 = "shared";
+
+        Collection<Bean> collection = new ArrayDeque<>();
+        collection.add(bean);
+        collection.add(bean);
+
+        String json = JSON.toJSONString(collection, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(json.contains("$ref"), "Expected $ref for duplicate item within collection: " + json);
+    }
+
+    @Test
+    public void testDuplicateItemWithinCollectionJSONB() {
+        Bean bean = new Bean();
+        bean.xxx1 = "shared";
+
+        Collection<Bean> collection = new ArrayDeque<>();
+        collection.add(bean);
+        collection.add(bean);
+
+        byte[] bytes = JSONB.toBytes(collection, JSONWriter.Feature.ReferenceDetection);
+        assertTrue(JSONB.toJSONString(bytes).contains("$ref"), "Expected $ref for duplicate item within collection: " + JSONB.toJSONString(bytes));
+
+        List<Bean> parsed = JSONB.parseObject(bytes, new TypeReference<List<Bean>>() {}.getType());
+        assertEquals(2, parsed.size());
+        assertSame(parsed.get(0), parsed.get(1));
+        assertEquals("shared", parsed.get(0).xxx1);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-parent</artifactId>
-    <version>2.0.61.android5</version>
+    <version>2.0.63.android5</version>
     <name>${project.artifactId}</name>
     <description>Fastjson is a JSON processor (JSON parser + JSON generator) written in Java</description>
     <packaging>pom</packaging>


### PR DESCRIPTION
Port 2.0.63 安全修复到 android5 分支（与 android8 相同的 6 个修复，逐 commit 内容一致）：

- AutoType 类型名校验与白名单回验加固 (#7703, RCE 修复)
- JSONB BC_BINARY declared-length OOM (#7705)
- JSONB BC_BIGINT declared-length OOM (#7696)
- 数字字面量位数上限防 BigInteger O(n²) DoS (#7694)
- writeFloat(float[]) AIOOBE (#1591)
- Collection 元素引用检测 (#7678)

未 port：`bdfe92f76` readString AIOOBE —— 本分支无 strBuf 缓存机制，bug 不存在。

验证：core 全量测试 5062 个全绿。