### PR TITLE
fix: the getter method is discarded when serializing character fields

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
@@ -1379,11 +1379,11 @@ public class ObjectWriterCreator {
         }
 
         if (fieldClass == char.class) {
-            return new FieldWriterCharValue<>(fieldName, ordinal, features, format, locale, label, fieldClass, fieldClass, field, null, null);
+            return new FieldWriterCharValue<>(fieldName, ordinal, features, format, locale, label, fieldClass, fieldClass, field, method, null);
         }
 
         if (fieldClass == Character.class) {
-            return new FieldWriterChar<>(fieldName, ordinal, features, format, locale, label, fieldClass, fieldClass, field, null, null);
+            return new FieldWriterChar<>(fieldName, ordinal, features, format, locale, label, fieldClass, fieldClass, field, method, null);
         }
 
         if (fieldClass == BigDecimal.class) {

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriter14Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriter14Test.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson2.writer;
 
 import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONPath;
@@ -23,10 +24,11 @@ public class ObjectWriter14Test {
                 Bean.class,
                 Arrays.asList(
                         ObjectWriters.fieldWriter("f0", Bean::getF0),
-                        ObjectWriters.fieldWriter("f1", Bean::getF1)
+                        ObjectWriters.fieldWriter("f1", Bean::getF1),
+                        ObjectWriters.fieldWriter("f2", Bean::getF2)
                 )
         );
-        assertEquals(2, writerAdapter.getFieldWriters().size());
+        assertEquals(3, writerAdapter.getFieldWriters().size());
     }
 
     @Test
@@ -34,17 +36,23 @@ public class ObjectWriter14Test {
         Bean bean = new Bean();
         bean.setF0('0');
         bean.setF1(null);
+        bean.setF2('A');
         String str = JSON.toJSONString(bean);
         Bean bean1 = JSON.parseObject(str, Bean.class);
         assertEquals(bean.getF0(), bean1.getF0());
         assertEquals(bean.getF1(), bean1.getF1());
         assertEquals(String.valueOf(bean.getF1()), JSON.parseObject(str).getString("f1"));
 
+        // the getter of primitive char f2 returns the lowercase form ('a') while
+        // the backing field holds 'A', so the serialized value must come from the getter
+        assertEquals("a", JSON.parseObject(str).getString("f2"));
+
         JSONObject jsonObject = JSONObject.from(bean);
         assertEquals(str, jsonObject.toString());
 
         assertEquals(bean.getF0(), JSONPath.eval(bean, "$.f0"));
         assertEquals(bean.getF1(), JSONPath.eval(bean, "$.f1"));
+        assertEquals(Character.valueOf('a'), JSONPath.eval(bean, "$.f2"));
         assertNull(JSONPath.eval(bean, "$.f100"));
     }
 
@@ -53,7 +61,14 @@ public class ObjectWriter14Test {
         Bean bean = new Bean();
         bean.setF0('0');
         bean.setF1(null);
+        bean.setF2('A');
         byte[] jsonbBytes = JSONB.toBytes(bean);
+
+        JSONObject jsonObject = JSONB.parseObject(jsonbBytes);
+        assertNull(jsonObject.get("f0"));
+        assertEquals(Character.valueOf('0'), jsonObject.get("f1"));
+        assertEquals(Character.valueOf('a'), jsonObject.get("f2"));
+
         Bean bean1 = JSONB.parseObject(jsonbBytes, Bean.class);
         assertEquals(bean.getF0(), bean1.getF0());
         assertEquals(bean.getF1(), bean1.getF1());
@@ -64,7 +79,14 @@ public class ObjectWriter14Test {
         Bean bean = new Bean();
         bean.setF0('0');
         bean.setF1(null);
+        bean.setF2('A');
         byte[] jsonbBytes = JSONB.toBytes(bean, JSONWriter.Feature.BeanToArray);
+
+        JSONArray array = JSONB.parseArray(jsonbBytes);
+        assertNull(array.get(0));
+        assertEquals(Character.valueOf('0'), array.get(1));
+        assertEquals(Character.valueOf('a'), array.get(2));
+
         Bean bean1 = JSONB.parseObject(jsonbBytes, Bean.class, JSONReader.Feature.SupportArrayToBean);
         assertEquals(bean.getF0(), bean1.getF0());
         assertEquals(bean.getF1(), bean1.getF1());
@@ -81,6 +103,7 @@ public class ObjectWriter14Test {
 
     public static class Bean implements BeanIf {
         private Character f1 = '0';
+        private char f2 = 'A';
 
         public Character getF1() {
             return null == f1 ? '0' : f1;
@@ -88,6 +111,14 @@ public class ObjectWriter14Test {
 
         public void setF1(Character f1) {
             this.f1 = f1;
+        }
+
+        public char getF2() {
+            return f2 >= 'A' && f2 <= 'Z' ? (char) (f2 + 32) : f2;
+        }
+
+        public void setF2(char f2) {
+            this.f2 = f2;
         }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriter14Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriter14Test.java
@@ -1,0 +1,93 @@
+package com.alibaba.fastjson2.writer;
+
+import com.alibaba.fastjson2.*;
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONPath;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@Tag("writer")
+public class ObjectWriter14Test {
+    @Test
+    public void testAdapter() {
+        ObjectWriterAdapter writerAdapter = new ObjectWriterAdapter(
+                Bean.class,
+                Arrays.asList(
+                        ObjectWriters.fieldWriter("f0", Bean::getF0),
+                        ObjectWriters.fieldWriter("f1", Bean::getF1)
+                )
+        );
+        assertEquals(2, writerAdapter.getFieldWriters().size());
+    }
+
+    @Test
+    public void test() {
+        Bean bean = new Bean();
+        bean.setF0('0');
+        bean.setF1(null);
+        String str = JSON.toJSONString(bean);
+        Bean bean1 = JSON.parseObject(str, Bean.class);
+        assertEquals(bean.getF0(), bean1.getF0());
+        assertEquals(bean.getF1(), bean1.getF1());
+        assertEquals(String.valueOf(bean.getF1()), JSON.parseObject(str).getString("f1"));
+
+        JSONObject jsonObject = JSONObject.from(bean);
+        assertEquals(str, jsonObject.toString());
+
+        assertEquals(bean.getF0(), JSONPath.eval(bean, "$.f0"));
+        assertEquals(bean.getF1(), JSONPath.eval(bean, "$.f1"));
+        assertNull(JSONPath.eval(bean, "$.f100"));
+    }
+
+    @Test
+    public void testJsonb() {
+        Bean bean = new Bean();
+        bean.setF0('0');
+        bean.setF1(null);
+        byte[] jsonbBytes = JSONB.toBytes(bean);
+        Bean bean1 = JSONB.parseObject(jsonbBytes, Bean.class);
+        assertEquals(bean.getF0(), bean1.getF0());
+        assertEquals(bean.getF1(), bean1.getF1());
+    }
+
+    @Test
+    public void testJsonbArray() {
+        Bean bean = new Bean();
+        bean.setF0('0');
+        bean.setF1(null);
+        byte[] jsonbBytes = JSONB.toBytes(bean, JSONWriter.Feature.BeanToArray);
+        Bean bean1 = JSONB.parseObject(jsonbBytes, Bean.class, JSONReader.Feature.SupportArrayToBean);
+        assertEquals(bean.getF0(), bean1.getF0());
+        assertEquals(bean.getF1(), bean1.getF1());
+    }
+
+    interface BeanIf {
+        default Character getF0() {
+            return null;
+        }
+
+        default void setF0(Character f0) {
+        }
+    }
+
+    public static class Bean implements BeanIf {
+        private Character f1 = '0';
+
+        public Character getF1() {
+            return null == f1 ? '0' : f1;
+        }
+
+        public void setF1(Character f1) {
+            this.f1 = f1;
+        }
+    }
+}


### PR DESCRIPTION
### What is the purpose of this PR/why is it needed?

When serializing beans containing char/Character fields, getter methods are silently discarded, leading to NullPointerExceptions or lost field values ​​(serialized as null or missing). This is because `ObjectWriterCreator` passes null instead of the resolved getter methods when constructing FieldWriterCharValue and FieldWriterChar.

在序列化包含 char/Character 字段的 bean 时，getter 方法会被静默丢弃，导致出现空指针异常或者字段值丢失（序列化为 null 或缺失）。这是因为 `ObjectWriterCreator` 在构造 FieldWriterCharValue 和 FieldWriterChar 时传递了 null 而不是已解析的 getter 方法。

### Summary of Changes

In [ObjectWriterCreator#createFieldWriter](url), the resolved getter methods (instead of null) are now passed to the FieldWriterCharValue and FieldWriterChar constructors for char.class and Character.class fields, respectively.
A new ObjectWriter14Test has been added to reproduce the issue and verify the fix, including: 
- When the optional default method of an interface is not implemented (no corresponding field receives a value), a null pointer exception is thrown in `com.alibaba.fastjson2.writer.ObjectWriterCreatorASM#genGetObject` (because both field and method are null, causing member to be null).
- When getter methods contain (protected) logic, this logic is ignored, leading to inconsistent output.

在 `ObjectWriterCreator#createFieldWriter` 中，将已解析的 getter 方法（而不是 null）分别传递给 char.class 和 Character.class 字段的 FieldWriterCharValue 和 FieldWriterChar 构造函数。
新增 ObjectWriter14Test，可复现问题并验证修复，包含：
- 当接口的可选default方法未实现（没有对应的field接收值）时，会导致`com.alibaba.fastjson2.writer.ObjectWriterCreatorASM#genGetObject`里报空指针异常（因为field和method都是null导致member是null）。
- 当getter方法中有（保护）逻辑时，逻辑被忽略，导致输出与预期不一致。

**If this fix is ​​not the intended design, please explain the design considerations behind forcibly passing null here.**
**如果修复不是设计预期的，请帮忙解释此处强传null的设计考虑。**