### PR TITLE
fix: apply autoType whitelist to array elements under ErrorOnNotSupportAutoType (#7730)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -232,6 +232,9 @@ public interface JSON {
 
         try (JSONReader reader = JSONReader.of(text, context)) {
             Object object = objectReader.readObject(reader, null, null, 0);
+            if (reader.resolveTasks != null) {
+                reader.handleResolveTasks(object);
+            }
             if (reader.ch != EOI && (context.features & IgnoreCheckClose.mask) == 0) {
                 throw new JSONException(reader.info("input not end"));
             }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -4111,7 +4111,8 @@ public abstract class JSONReader
                     val = readArray();
                     break;
                 case '{':
-                    if (context.autoTypeBeforeHandler != null || (context.features & Feature.SupportAutoType.mask) != 0) {
+                    if (context.autoTypeBeforeHandler != null
+                            || (context.features & (Feature.SupportAutoType.mask | Feature.ErrorOnNotSupportAutoType.mask)) != 0) {
                         val = ObjectReaderImplObject.INSTANCE.readObject(this, null, null, 0);
                     } else if (isReference()) {
                         val = JSONPath.of(readReference());

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -4111,11 +4111,11 @@ public abstract class JSONReader
                     val = readArray();
                     break;
                 case '{':
-                    if (context.autoTypeBeforeHandler != null
+                    if (isReference()) {
+                        val = JSONPath.of(readReference());
+                    } else if (context.autoTypeBeforeHandler != null
                             || (context.features & (Feature.SupportAutoType.mask | Feature.ErrorOnNotSupportAutoType.mask)) != 0) {
                         val = ObjectReaderImplObject.INSTANCE.readObject(this, null, null, 0);
-                    } else if (isReference()) {
-                        val = JSONPath.of(readReference());
                     } else {
                         val = readObject();
                     }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7730.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7730.java
@@ -15,10 +15,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * https://github.com/alibaba/fastjson2/issues/7730
@@ -127,12 +125,33 @@ public class Issue7730 {
 
     @Test
     public void whitelistedListVsRejectedListConsistency() {
-        // Whitelisted element restores; non-whitelisted element in an array is rejected.
+        // Two-sided consistency: a whitelisted element restores, and a non-whitelisted
+        // element in an array is rejected. Both paths must apply the accept whitelist
+        // the same way — the rejection path is what makes ErrorOnNotSupportAutoType
+        // meaningful, so guard it alongside the accept path.
         String accepted = JSON.toJSONString(
                 new ArrayList<>(Arrays.asList(new Bean("x"))), JSONWriter.Feature.WriteClassName);
         Object parsed = JSON.parse(accepted, context());
-        assertTrue(parsed instanceof List);
-        assertFalse(((List<?>) parsed).isEmpty());
         assertInstanceOf(Bean.class, ((List<?>) parsed).get(0));
+
+        String rejected = "[{\"@type\":\"java.io.File\",\"path\":\"/tmp/x\"}]";
+        assertThrows(JSONException.class, () -> JSON.parse(rejected, context()));
+    }
+
+    @Test
+    public void refInArrayUnderErrorOnNotSupportAutoType() {
+        // $ref array element under ErrorOnNotSupportAutoType must still resolve when
+        // the caller uses an API that runs handleResolveTasks (e.g. parseObject with
+        // a Type). Routing array elements through ObjectReaderImplObject for the
+        // autoType whitelist must not bypass the isReference() check — otherwise
+        // {"$ref":"$[0]"} would become a literal JSONObject instead of a reference.
+        JSONReader.Context ctx = JSONFactory.createReadContext(JSONReader.Feature.ErrorOnNotSupportAutoType);
+        ctx.getProvider().addAutoTypeAccept("com.alibaba.fastjson2.issues.");
+        ctx.getProvider().addAutoTypeAccept("java.util.");
+
+        String json = "[{\"id\":\"a\"},{\"$ref\":\"$[0]\"}]";
+        Object parsed = JSON.parseObject(json, Object.class, ctx);
+        List<?> list = (List<?>) parsed;
+        assertEquals(list.get(0), list.get(1));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7730.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7730.java
@@ -140,17 +140,30 @@ public class Issue7730 {
 
     @Test
     public void refInArrayUnderErrorOnNotSupportAutoType() {
-        // $ref array element under ErrorOnNotSupportAutoType must still resolve when
-        // the caller uses an API that runs handleResolveTasks (e.g. parseObject with
-        // a Type). Routing array elements through ObjectReaderImplObject for the
-        // autoType whitelist must not bypass the isReference() check — otherwise
-        // {"$ref":"$[0]"} would become a literal JSONObject instead of a reference.
+        // $ref array element under ErrorOnNotSupportAutoType must resolve via
+        // parseObject(String, Type, Context), which runs handleResolveTasks.
         JSONReader.Context ctx = JSONFactory.createReadContext(JSONReader.Feature.ErrorOnNotSupportAutoType);
         ctx.getProvider().addAutoTypeAccept("com.alibaba.fastjson2.issues.");
         ctx.getProvider().addAutoTypeAccept("java.util.");
 
         String json = "[{\"id\":\"a\"},{\"$ref\":\"$[0]\"}]";
         Object parsed = JSON.parseObject(json, Object.class, ctx);
+        List<?> list = (List<?>) parsed;
+        assertEquals(list.get(0), list.get(1));
+    }
+
+    @Test
+    public void refInArrayViaParseWithContext() {
+        // $ref array element under ErrorOnNotSupportAutoType must also resolve via
+        // JSON.parse(String, Context), the untyped entry point. Previously this
+        // overload did not invoke handleResolveTasks, so $ref array elements
+        // became null (data loss). Regression guard for that pre-existing bug.
+        JSONReader.Context ctx = JSONFactory.createReadContext(JSONReader.Feature.ErrorOnNotSupportAutoType);
+        ctx.getProvider().addAutoTypeAccept("com.alibaba.fastjson2.issues.");
+        ctx.getProvider().addAutoTypeAccept("java.util.");
+
+        String json = "[{\"id\":\"a\"},{\"$ref\":\"$[0]\"}]";
+        Object parsed = JSON.parse(json, ctx);
         List<?> list = (List<?>) parsed;
         assertEquals(list.get(0), list.get(1));
     }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7730.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7730.java
@@ -1,0 +1,138 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * https://github.com/alibaba/fastjson2/issues/7730
+ *
+ * With Feature.ErrorOnNotSupportAutoType enabled and an autoType whitelist configured
+ * (addAutoTypeAccept), deserializing a single object with "@type" works, but the same
+ * object nested inside an array throws "autoType not support". The array element path in
+ * JSONReader.readArray fell through to the generic readObject() branch, which throws
+ * unconditionally without consulting the accept whitelist, whereas the single-object path
+ * (ObjectReaderImplObject) does consult it.
+ */
+@Tag("regression")
+public class Issue7730 {
+    public static class Bean {
+        public String id;
+
+        public Bean() {
+        }
+
+        public Bean(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof Bean)) {
+                return false;
+            }
+            String a = this.id;
+            String b = ((Bean) o).id;
+            return a == null ? b == null : a.equals(b);
+        }
+
+        @Override
+        public int hashCode() {
+            return id == null ? 0 : id.hashCode();
+        }
+    }
+
+    private static final String ACCEPT_PREFIX = "com.alibaba.fastjson2.issues.";
+
+    private static JSONReader.Context context() {
+        JSONReader.Context context = JSONFactory.createReadContext(JSONReader.Feature.ErrorOnNotSupportAutoType);
+        context.getProvider().addAutoTypeAccept(ACCEPT_PREFIX);
+        // container types carry their own @type when written with WriteClassName
+        // (e.g. java.util.LinkedHashMap for a root Map), so they must be whitelisted too
+        context.getProvider().addAutoTypeAccept("java.util.");
+        return context;
+    }
+
+    @Test
+    public void singleObject() {
+        Bean bean = new Bean("test-data");
+        String json = JSON.toJSONString(bean, JSONWriter.Feature.WriteClassName);
+        Object parsed = JSON.parse(json, context());
+        assertInstanceOf(Bean.class, parsed);
+        assertEquals("test-data", ((Bean) parsed).id);
+    }
+
+    @Test
+    public void list() {
+        List<Bean> list = new ArrayList<>(Arrays.asList(new Bean("test-data")));
+        String json = JSON.toJSONString(list, JSONWriter.Feature.WriteClassName);
+        Object parsed = JSON.parse(json, context());
+        assertInstanceOf(List.class, parsed);
+        Object element = ((List<?>) parsed).get(0);
+        assertInstanceOf(Bean.class, element);
+        assertEquals("test-data", ((Bean) element).id);
+    }
+
+    @Test
+    public void nestedList() {
+        List<List<Bean>> nested = new ArrayList<>(
+                Arrays.asList(new ArrayList<>(Arrays.asList(new Bean("test-data")))));
+        String json = JSON.toJSONString(nested, JSONWriter.Feature.WriteClassName);
+        Object parsed = JSON.parse(json, context());
+        assertInstanceOf(List.class, parsed);
+        Object inner = ((List<?>) parsed).get(0);
+        assertInstanceOf(List.class, inner);
+        Object element = ((List<?>) inner).get(0);
+        assertInstanceOf(Bean.class, element);
+        assertEquals("test-data", ((Bean) element).id);
+    }
+
+    @Test
+    public void listInMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("items", new ArrayList<>(Arrays.asList(new Bean("test-data"))));
+        String json = JSON.toJSONString(map, JSONWriter.Feature.WriteClassName);
+        Object parsed = JSON.parse(json, context());
+        assertInstanceOf(Map.class, parsed);
+        Object items = ((Map<?, ?>) parsed).get("items");
+        assertInstanceOf(List.class, items);
+        Object element = ((List<?>) items).get(0);
+        assertInstanceOf(Bean.class, element);
+        assertEquals("test-data", ((Bean) element).id);
+    }
+
+    @Test
+    public void notAcceptedTypeInListStillThrows() {
+        // The fix must not relax the whitelist: a type outside the accept prefix must still
+        // be rejected under ErrorOnNotSupportAutoType, just like the single-object path.
+        String json = "[{\"@type\":\"java.io.File\",\"path\":\"/tmp/x\"}]";
+        assertThrows(JSONException.class, () -> JSON.parse(json, context()));
+    }
+
+    @Test
+    public void whitelistedListVsRejectedListConsistency() {
+        // Whitelisted element restores; non-whitelisted element in an array is rejected.
+        String accepted = JSON.toJSONString(
+                new ArrayList<>(Arrays.asList(new Bean("x"))), JSONWriter.Feature.WriteClassName);
+        Object parsed = JSON.parse(accepted, context());
+        assertTrue(parsed instanceof List);
+        assertFalse(((List<?>) parsed).isEmpty());
+        assertInstanceOf(Bean.class, ((List<?>) parsed).get(0));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #7730.

When `Feature.ErrorOnNotSupportAutoType` is enabled together with an autoType accept whitelist (`addAutoTypeAccept`), a single object with `@type` is restored correctly, but the **same object nested inside an array** throws `autoType not support`:

```java
JSONReader.Context context = JSONFactory.createReadContext(JSONReader.Feature.ErrorOnNotSupportAutoType);
context.getProvider().addAutoTypeAccept("com.example.");

// single object: OK
JSON.parse(JSON.toJSONString(bean, JSONWriter.Feature.WriteClassName), context);

// list of the same bean: throws "autoType not support"
JSON.parse(JSON.toJSONString(List.of(bean), JSONWriter.Feature.WriteClassName), context);
```

**Root cause:** `JSONReader.readArray()` dispatches object elements to the generic `readObject()` branch unless `autoTypeBeforeHandler` or `SupportAutoType` is set. That generic branch throws unconditionally on `@type` (`JSONReader.java:3744-3746`) **without consulting the accept whitelist**, whereas the single-object path (`ObjectReaderImplObject`) does consult it. Hence single object succeeds but array element fails.

### Summary of your change

- In `JSONReader.readArray()`, also route array object elements through `ObjectReaderImplObject` when `ErrorOnNotSupportAutoType` is enabled, so array elements apply the **same** accept whitelist check as single objects.
- The whitelist stays **exclusive**: types outside the accept prefixes are still rejected (verified by test `notAcceptedTypeInListStillThrows`), so this does not relax security.
- `$ref` handling is unaffected: `ObjectReaderImplObject` already supports references, and existing handler/SupportAutoType scenarios already take this path (covered by `ListRefTest`).
- Default behavior (no autoType feature enabled) is unchanged — still uses the fast `readObject()` path.
- Added regression test `Issue7730` covering single object, top-level list, nested list, list-in-map, and the whitelist-exclusion security case.

Local verification:
- `./mvnw -pl core -Dtest=Issue7730 test` — 6/6 pass
- `./mvnw -pl core -Dtest=ListRefTest test` — pass (no $ref regression)
- `./mvnw -pl core clean test` — 7953/7953 pass
- `./mvnw -pl core -Dfastjson2.creator=reflect -Dtest=Issue7730 test` — pass
- `./mvnw -pl core validate` — 0 Checkstyle violations

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.