### PR TITLE
fix: validate declared array length in JSONReaderJSONB.startArray() to prevent pre-allocation OOM (same class as #7669)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1435,14 +1435,28 @@ final class JSONReaderJSONB
         }
 
         if (type == BC_BINARY) {
-            return readInt32Value();
+            int len = readInt32Value();
+            checkArrayLen(len, offset, end);
+            return len;
         }
 
         if (type != BC_ARRAY) {
             throw new JSONException("array not support input " + error(type));
         }
 
-        return readInt32Value();
+        int len = readInt32Value();
+        checkArrayLen(len, offset, end);
+        return len;
+    }
+
+    static void checkArrayLen(int len, int offset, int end) {
+        // Each array/collection element occupies at least one byte in the JSONB stream,
+        // so a declared length larger than the remaining buffer is malformed input.
+        // Guards against a small crafted payload declaring Integer.MAX_VALUE elements
+        // that triggers an immediate over-sized array pre-allocation (OOM / DoS).
+        if (len < 0 || len > end - offset) {
+            throw new JSONException("array length out of range: " + len + ", available: " + (end - offset));
+        }
     }
 
     public String error(byte type) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1454,8 +1454,17 @@ final class JSONReaderJSONB
         // so a declared length larger than the remaining buffer is malformed input.
         // Guards against a small crafted payload declaring Integer.MAX_VALUE elements
         // that triggers an immediate over-sized array pre-allocation (OOM / DoS).
+        checkLength(len, offset, end, "array length");
+    }
+
+    // Shared bounds-check for lengths declared in untrusted JSONB (see #7669).
+    // `label` identifies the context in the error message (e.g. "array length",
+    // "BC_BIGINT length"). A declared length larger than the remaining buffer is
+    // malformed input and must be rejected before any pre-allocation.
+    static void checkLength(int len, int offset, int end, String label) {
         if (len < 0 || len > end - offset) {
-            throw new JSONException("array length out of range: " + len + ", available: " + (end - offset));
+            throw new JSONException(
+                    label + " out of range at offset " + offset + "/" + end + ": " + len + ", available: " + (end - offset));
         }
     }
 
@@ -6318,9 +6327,7 @@ final class JSONReaderJSONB
     }
 
     static void checkBigintLen(int len, int offset, int end) {
-        if (len < 0 || len > end - offset) {
-            throw new JSONException("BC_BIGINT length out of range: " + len + ", available: " + (end - offset));
-        }
+        checkLength(len, offset, end, "BC_BIGINT length");
     }
 
     static JSONException outOfBoundsCheckFromToIndex(int offset, int end) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -167,4 +167,26 @@ public class Issue7669 {
         int[] result = JSONB.parseObject(jsonbBytes, int[].class);
         assertArrayEquals(value, result);
     }
+
+    // --- R2-2 hardening: pin the position-relative bound (len > end - offset),
+    // not an absolute bound. The malformed BC_ARRAY below is NOT at the buffer
+    // end: an outer BC_ARRAY_FIX (0x95, 1 element) wraps an inner BC_ARRAY (0xA4)
+    // declaring 5 elements while only 1 byte (0xF0) remains. A guard that
+    // degenerates to `len > end` would let this slip through and later die with
+    // ArrayIndexOutOfBoundsException instead of JSONException.
+    // 0x95 = BC_ARRAY_FIX(1 elem), 0xA4 = BC_ARRAY, 0x48 = BC_INT32,
+    // 0x00000005 = declares 5 elements, 0xF0 = 1 trailing byte
+    static final byte[] NESTED_ARRAY_BAD_LEN = {
+            (byte) 0x95,
+            (byte) 0xA4,
+            (byte) 0x48,
+            0x00, 0x00, 0x00, 0x05,
+            (byte) 0xF0
+    };
+
+    @Test
+    public void testArrayDeclaredLengthNotAtBufferEnd() {
+        assertThrows(JSONException.class,
+                () -> JSONB.parseObject(NESTED_ARRAY_BAD_LEN, int[][].class));
+    }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -118,6 +118,14 @@ public class Issue7669 {
             (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
     };
 
+    // 0x91 = BC_BINARY (routed through startArray() via typed array deserialization),
+    // 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] BINARY_ARRAY_PAYLOAD_MAX_LEN = {
+            (byte) 0x91,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
     @Test
     public void testArrayDeclaredLengthOOM_int() {
         assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, int[].class));
@@ -139,8 +147,22 @@ public class Issue7669 {
     }
 
     @Test
+    public void testArrayDeclaredLengthOOM_binaryBranch() {
+        // The BC_BINARY branch of startArray() received the same checkArrayLen guard;
+        // a crafted payload must be rejected through this path too (parseObject typed
+        // array deserialization routes it through startArray()).
+        assertThrows(JSONException.class, () -> JSONB.parseObject(BINARY_ARRAY_PAYLOAD_MAX_LEN, int[].class));
+    }
+
+    @Test
     public void testArrayValidPayloadStillWorks() {
-        int[] value = {1, 2, 3};
+        // ARRAY_FIX_LEN = 15: arrays with <= 15 elements are encoded as BC_ARRAY_FIX
+        // and bypass startArray()'s checkLength entirely. Use 32 elements to force
+        // BC_ARRAY encoding so this test actually exercises the guarded path.
+        int[] value = new int[32];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = i;
+        }
         byte[] jsonbBytes = JSONB.toBytes(value);
         int[] result = JSONB.parseObject(jsonbBytes, int[].class);
         assertArrayEquals(value, result);

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -101,4 +101,48 @@ public class Issue7669 {
         byte[] result = (byte[]) JSONB.parse(jsonbBytes);
         assertArrayEquals(value, result);
     }
+
+    // --- BC_ARRAY declared-length OOM path (same class as #7669, fixed by this PR) ---
+
+    // 0xA4 = BC_ARRAY, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] ARRAY_PAYLOAD_MAX_LEN = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0xA4 = BC_ARRAY, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+    static final byte[] ARRAY_PAYLOAD_NEG_LEN = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    @Test
+    public void testArrayDeclaredLengthOOM_int() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, int[].class));
+    }
+
+    @Test
+    public void testArrayDeclaredLengthOOM_long() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, long[].class));
+    }
+
+    @Test
+    public void testArrayDeclaredLengthOOM_string() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, String[].class));
+    }
+
+    @Test
+    public void testArrayNegativeLength() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_NEG_LEN, int[].class));
+    }
+
+    @Test
+    public void testArrayValidPayloadStillWorks() {
+        int[] value = {1, 2, 3};
+        byte[] jsonbBytes = JSONB.toBytes(value);
+        int[] result = JSONB.parseObject(jsonbBytes, int[].class);
+        assertArrayEquals(value, result);
+    }
 }


### PR DESCRIPTION
### 背景

本 PR 修复的是与 #7669 **完全同一类**的问题（该 issue 由 #7696 / #7705 针对 `BC_BIGINT` / `BC_BINARY` 修复）：**从不可信 JSONB 读到的"声明长度"在任何边界校验之前就被用于预分配**。#7669 的修复只覆盖了 `byte[]` 分配路径（`readBigInteger` / `readBinary`），但**数组容量路径 `startArray()` 至今未修**。

### 根因

`JSONReaderJSONB.startArray()` 的 `BC_ARRAY`（及 `BC_BINARY`）分支直接 `return readInt32Value();`：

```java
if (type != BC_ARRAY) {
    throw new JSONException("array not support input " + error(type));
}
return readInt32Value();   // ← 无 256MB cap，也无 len > end - offset 校验
```

`readInt32Value()` 不带 #7705 引入的缓冲区边界校验。三个数组读取入口全部经由它：

- `readInt32ValueArray()` → `new int[entryCnt]`
- `readInt64ValueArray()` → `new long[entryCnt]`
- `readStringArray()` → `new String[entryCnt]`

因此一个仅 6 字节的 JSONB 载荷（`BC_ARRAY` + `BC_INT32` + `0x7FFFFFFF`）即可让 `entryCnt = Integer.MAX_VALUE`，在读取任何元素之前触发即时 `OutOfMemoryError`（拒绝服务）。

### 复现（防御性 PoC，不含武器化）

```java
// [BC_ARRAY, BC_INT32, 0x7F,0xFF,0xFF,0xFF] —— 声明 Integer.MAX_VALUE 长度
byte[] payload = {(byte) 0xa4, 0x48, 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
JSONB.parseObject(payload, int[].class);   // → OutOfMemoryError
```

在 2.0.62 与 2.0.63（= 当前 master / 2.0.64-SNAPSHOT）下，`int[] / long[] / String[]` 均在 `-Xmx256m` 下即时 OOM；合法数组（如 len=2）行为不变。

### 修复

把 #7705 用于 `BC_BIGINT` / `BC_BINARY` 的同款校验 `len < 0 || len > end - offset` 应用到 `startArray()`：

```java
int len = readInt32Value();
if (len < 0 || len > end - offset) {
    throw new JSONException("array length out of range: " + len);
}
return len;
```

**不影响合法输入**：JSONB 中每个数组元素至少占 1 字节，故合法 `entryCnt` 永远不会超过剩余缓冲区字节数；该下界与 #7705 的判定逻辑完全一致。

### 关联

- Issue: #7669
- 已有同类修复: #7696, #7705
- 本 PR 补齐尚未覆盖的数组容量路径（`startArray`）。

CWE-789 (Memory Allocation with Excessive Size Value) / CWE-20 (Improper Input Validation)