### PR TITLE
fix: BigDecimal with @JsonFormat(shape = STRING) produces invalid JSON

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
@@ -121,7 +121,10 @@ public abstract class FieldWriter<T>
         this.nameJSONB = JSONB.toBytes(fieldName);
 
         DecimalFormat decimalFormat = null;
+        // "string" is a sentinel from @JsonFormat(shape = STRING) / WriteNonStringValueAsString,
+        // not a DecimalFormat pattern (which would emit invalid JSON like string200).
         if (format != null
+                && !"string".equals(format)
                 && (fieldClass == float.class
                 || fieldClass == float[].class
                 || fieldClass == Float.class
@@ -1048,7 +1051,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal.class == valueClass) {
-                if (format == null || format.isEmpty()) {
+                if (format == null || format.isEmpty() || "string".equals(format)) {
                     return ObjectWriterImplBigDecimal.INSTANCE;
                 } else {
                     return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);
@@ -1056,7 +1059,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal[].class == valueClass) {
-                if (format == null || format.isEmpty()) {
+                if (format == null || format.isEmpty() || "string".equals(format)) {
                     return new ObjectWriterArrayFinal(BigDecimal.class, null);
                 } else {
                     return new ObjectWriterArrayFinal(BigDecimal.class, new DecimalFormat(format));

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -459,6 +459,19 @@ public class ObjectWriterProvider
      * @return the ObjectWriter for the specified type
      */
     public ObjectWriter getObjectWriter(Type objectType, String format, Locale locale) {
+        // "string" is a sentinel (e.g. @JsonFormat(shape = STRING)), not a DecimalFormat pattern
+        if ("string".equals(format)) {
+            if (objectType == Double.class) {
+                return ObjectWriterImplDouble.INSTANCE;
+            }
+            if (objectType == Float.class) {
+                return ObjectWriterImplFloat.INSTANCE;
+            }
+            if (objectType == BigDecimal.class) {
+                return ObjectWriterImplBigDecimal.INSTANCE;
+            }
+        }
+
         if (objectType == Double.class) {
             return new ObjectWriterImplDouble(new DecimalFormat(format));
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7734.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7734.java
@@ -1,0 +1,33 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("regression")
+@Tag("compat-jackson")
+public class Issue7734 {
+    @Test
+    public void test() {
+        Bean bean = new Bean();
+        bean.quantity = new BigDecimal("6.56000000001");
+        assertEquals("{\"quantity\":\"6.56000000001\"}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void testIntegerScale() {
+        Bean bean = new Bean();
+        bean.quantity = new BigDecimal("200");
+        assertEquals("{\"quantity\":\"200\"}", JSON.toJSONString(bean));
+    }
+
+    public static class Bean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public BigDecimal quantity;
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7734.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7734.java
@@ -26,8 +26,32 @@ public class Issue7734 {
         assertEquals("{\"quantity\":\"200\"}", JSON.toJSONString(bean));
     }
 
+    @Test
+    public void testBigDecimalArray() {
+        BeanArray bean = new BeanArray();
+        bean.values = new BigDecimal[]{new BigDecimal("200"), new BigDecimal("300")};
+        assertEquals("{\"values\":[\"200\",\"300\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void testDouble() {
+        BeanDouble bean = new BeanDouble();
+        bean.price = 6.56;
+        assertEquals("{\"price\":\"6.56\"}", JSON.toJSONString(bean));
+    }
+
     public static class Bean {
         @JsonFormat(shape = JsonFormat.Shape.STRING)
         public BigDecimal quantity;
+    }
+
+    public static class BeanArray {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public BigDecimal[] values;
+    }
+
+    public static class BeanDouble {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Double price;
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #7734: serializing a `BigDecimal` field annotated with Jackson `@JsonFormat(shape = JsonFormat.Shape.STRING)` produced invalid JSON such as `{"quantity":string200}` instead of `{"quantity":"200"}`.

### Summary of your change

`@JsonFormat(shape = STRING)` maps to the internal format sentinel `"string"` and already enables `WriteNonStringValueAsString`. For `BigDecimal` / float / double fields, that sentinel was also passed to `new DecimalFormat("string")`, so `writeDecimal` took the `DecimalFormat` path and wrote the raw literal `string` + digits (e.g. `string200`) without quotes.

- Do not build a `DecimalFormat` when `format` is `"string"`.
- Same guard in `FieldWriter.getObjectWriter` and `ObjectWriterProvider.getObjectWriter` for the formatted writer path.
- Add regression test `Issue7734`.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

**Tested:**
```
./mvnw -pl core -Dtest=Issue7734,Issue1167 test
./mvnw -pl core -Dtest=Issue7734 -Dfastjson2.creator=reflect surefire:test
./mvnw -pl core -Dtest=JsonFormatTest surefire:test
```
All green (JDK 17).