### PR TITLE
fix: bound jsonb array item count to remaining input

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -2556,7 +2556,7 @@ final class JSONReaderJSONB
                 if (type >= BC_ARRAY_FIX_MIN && type <= BC_ARRAY) {
                     int itemCnt;
                     if (type == BC_ARRAY) {
-                        itemCnt = readInt32Value();
+                        itemCnt = checkItemCnt(readInt32Value());
                     } else {
                         itemCnt = type - BC_ARRAY_FIX_MIN;
                     }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -398,7 +398,7 @@ final class JSONReaderJSONB
                             offset++;
                             len = itemType;
                         } else {
-                            len = readLength();
+                            len = checkItemCnt(readLength());
                         }
                     } else {
                         len = valueType - BC_ARRAY_FIX_MIN;
@@ -924,7 +924,7 @@ final class JSONReaderJSONB
 
                 if (type >= BC_ARRAY_FIX_MIN && type <= BC_ARRAY) {
                     int len = type == BC_ARRAY
-                            ? readLength()
+                            ? checkItemCnt(readLength())
                             : type - BC_ARRAY_FIX_MIN;
 
                     if (len == 0) {
@@ -1095,7 +1095,7 @@ final class JSONReaderJSONB
             } else if (valueType >= BC_ARRAY_FIX_MIN && valueType <= BC_ARRAY) {
                 offset++;
                 int len = valueType == BC_ARRAY
-                        ? readLength()
+                        ? checkItemCnt(readLength())
                         : valueType - BC_ARRAY_FIX_MIN;
 
                 if (len == 0) {
@@ -1435,14 +1435,14 @@ final class JSONReaderJSONB
         }
 
         if (type == BC_BINARY) {
-            return readInt32Value();
+            return checkItemCnt(readInt32Value());
         }
 
         if (type != BC_ARRAY) {
             throw new JSONException("array not support input " + error(type));
         }
 
-        return readInt32Value();
+        return checkItemCnt(readInt32Value());
     }
 
     public String error(byte type) {
@@ -6307,6 +6307,17 @@ final class JSONReaderJSONB
         if (len < 0 || len > end - offset) {
             throw new JSONException("BC_BIGINT length out of range: " + len + ", available: " + (end - offset));
         }
+    }
+
+    /**
+     * Every array item occupies at least one byte, so a declared item count larger than the
+     * bytes left in the input cannot be satisfied and the array must not be sized from it.
+     */
+    private int checkItemCnt(int itemCnt) {
+        if (itemCnt < 0 || itemCnt > end - offset) {
+            throw new JSONException("array item count out of range: " + itemCnt + ", available: " + (end - offset));
+        }
+        return itemCnt;
     }
 
     static JSONException outOfBoundsCheckFromToIndex(int offset, int end) {

--- a/core/src/test/java/com/alibaba/fastjson2/JSONBArrayItemCountTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONBArrayItemCountTest.java
@@ -1,0 +1,128 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@Tag("regression")
+@Tag("jsonb")
+public class JSONBArrayItemCountTest {
+    // 0xA4 = BC_ARRAY, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] ARRAY_MAX_CNT = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0x0FFFFFFF stays under readLength()'s 256MB cap but still exceeds the input
+    static final byte[] ARRAY_LARGE_CNT = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0xFFFFFFFF = -1
+    static final byte[] ARRAY_NEG_CNT = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0xA6 = BC_OBJECT, "a" -> array with declared count 0x0FFFFFFF, 0xA5 = BC_OBJECT_END
+    static final byte[] OBJECT_ARRAY_LARGE_CNT = {
+            (byte) 0xA6,
+            (byte) 0x4A, (byte) 0x61,
+            (byte) 0xA4, (byte) 0x48, (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF,
+            (byte) 0xA5
+    };
+
+    @Test
+    public void testInt32ValueArrayItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_MAX_CNT, int[].class));
+    }
+
+    @Test
+    public void testInt64ValueArrayItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_MAX_CNT, long[].class));
+    }
+
+    @Test
+    public void testInt8ValueArrayItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_MAX_CNT, byte[].class));
+    }
+
+    @Test
+    public void testStringArrayItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_MAX_CNT, String[].class));
+    }
+
+    @Test
+    public void testObjectArrayItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_MAX_CNT, Object[].class));
+    }
+
+    @Test
+    public void testArrayItemCountNegative() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_NEG_CNT, int[].class));
+    }
+
+    @Test
+    public void testReadAnyItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parse(ARRAY_LARGE_CNT));
+    }
+
+    @Test
+    public void testReadArrayItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_LARGE_CNT, List.class));
+    }
+
+    @Test
+    public void testReadObjectItemCountOverflow() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(OBJECT_ARRAY_LARGE_CNT, Map.class));
+    }
+
+    @Test
+    public void testItemCountMustNotReadBeyondEnd() {
+        // a two byte frame declaring eight items, followed in the same buffer by data
+        // that belongs to the next frame
+        byte[] buffer = {
+                (byte) 0xA4, (byte) 0x08,
+                41, 42, 43, 44, 45, 46, 47, 10
+        };
+        assertThrows(JSONException.class, () -> JSONB.parseObject(buffer, 0, 2, int[].class));
+    }
+
+    @Test
+    public void testValidArraysStillParse() {
+        int[] ints = {1, 2, 3, 4, 5};
+        assertArrayEquals(ints, JSONB.parseObject(JSONB.toBytes(ints), int[].class));
+
+        long[] longs = {Long.MIN_VALUE, 0L, Long.MAX_VALUE};
+        assertArrayEquals(longs, JSONB.parseObject(JSONB.toBytes(longs), long[].class));
+
+        String[] strings = {"a", "b", "c"};
+        assertArrayEquals(strings, JSONB.parseObject(JSONB.toBytes(strings), String[].class));
+
+        List<Object> list = Arrays.asList(1, "two", 3);
+        assertEquals(list, JSONB.parseObject(JSONB.toBytes(list), List.class));
+
+        JSONObject object = JSON.parseObject("{\"a\":[1,2],\"b\":{\"c\":[3]}}");
+        assertEquals(object, JSONB.parseObject(JSONB.toBytes(object), Map.class));
+    }
+
+    @Test
+    public void testLargeValidArrayStillParses() {
+        int[] ints = new int[100000];
+        for (int i = 0; i < ints.length; i++) {
+            ints[i] = i;
+        }
+        assertArrayEquals(ints, JSONB.parseObject(JSONB.toBytes(ints), int[].class));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/JSONBArrayItemCountTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONBArrayItemCountTest.java
@@ -49,6 +49,17 @@ public class JSONBArrayItemCountTest {
     }
 
     @Test
+    public void testBinaryArrayItemCountOverflow() {
+        // 0x91 = BC_BINARY, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+        byte[] binaryMaxCnt = {
+                (byte) 0x91,
+                (byte) 0x48,
+                (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parseObject(binaryMaxCnt, int[].class));
+    }
+
+    @Test
     public void testInt64ValueArrayItemCountOverflow() {
         assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_MAX_CNT, long[].class));
     }
@@ -97,6 +108,16 @@ public class JSONBArrayItemCountTest {
                 41, 42, 43, 44, 45, 46, 47, 10
         };
         assertThrows(JSONException.class, () -> JSONB.parseObject(buffer, 0, 2, int[].class));
+    }
+
+    @Test
+    public void testItemCountExactlyMatchesRemainingBytes() {
+        // BC_ARRAY, count=3 (single-byte int 0x03), three 1-byte items
+        byte[] buffer = {
+                (byte) 0xA4, 0x03,
+                0x01, 0x02, 0x03
+        };
+        assertArrayEquals(new int[]{1, 2, 3}, JSONB.parseObject(buffer, int[].class));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/JSONBArrayItemCountTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONBArrayItemCountTest.java
@@ -100,6 +100,38 @@ public class JSONBArrayItemCountTest {
     }
 
     @Test
+    public void testReadObjectNoTypeItemCountOverflow() {
+        // the no-type overload routes through readObject()'s field-value branch
+        assertThrows(JSONException.class, () -> JSONB.parseObject(OBJECT_ARRAY_LARGE_CNT));
+    }
+
+    @Test
+    public void testNestedArrayItemCountOverflow() {
+        // outer BC_ARRAY with count 2, first element a small int, second element a
+        // nested BC_ARRAY declaring 0x0FFFFFFF items with no bytes left; parseArray
+        // routes the nested element through readArray() rather than readAny()
+        byte[] buffer = {
+                (byte) 0xA4, 0x02,
+                0x01,
+                (byte) 0xA4, (byte) 0x48, (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parseArray(buffer));
+    }
+
+    @Test
+    public void testSkipValueItemCountOverflow() {
+        // BC_OBJECT with unknown field "x" whose value declares Integer.MAX_VALUE items
+        // and no bytes behind it, so the bean reader skips it through skipValue()'s
+        // BC_ARRAY branch and the item loop would run past the end of the input
+        byte[] buffer = {
+                (byte) 0xA6,
+                (byte) 0x4A, (byte) 0x78,
+                (byte) 0xA4, (byte) 0x48, (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parseObject(buffer, Bean.class));
+    }
+
+    @Test
     public void testItemCountMustNotReadBeyondEnd() {
         // a two byte frame declaring eight items, followed in the same buffer by data
         // that belongs to the next frame
@@ -145,5 +177,9 @@ public class JSONBArrayItemCountTest {
             ints[i] = i;
         }
         assertArrayEquals(ints, JSONB.parseObject(JSONB.toBytes(ints), int[].class));
+    }
+
+    public static class Bean {
+        public int id;
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it?

`JSONReaderJSONB` sizes array allocations from the item count on the wire without checking it against the input. `startArray()` returns the `BC_ARRAY`/`BC_BINARY` count from `readInt32Value()` unbounded, and `readObject()`, `readAny()` and `readArray()` each size a `JSONArray`/`ArrayList` from a `BC_ARRAY` length. The 6 byte payload `A4 48 7F FF FF FF` declares `Integer.MAX_VALUE` items, so `JSONB.parseObject(payload, long[].class)` reaches `new long[Integer.MAX_VALUE]` and dies with `OutOfMemoryError`; every primitive, boxed and object array reader behaves the same, and `0x0FFFFFFF` stays under the 256MB cap in `readLength()` while doing the same through `JSONB.parse` and `List`/`Map` targets.

The count is also what keeps element reads inside the message. Under `JSONB.parseObject(byte[], off, len, type)` the reader's `end` is the frame boundary, not the end of the buffer, so the two byte frame `A4 08` declaring eight items runs the item loop past `end` and returns the eight bytes that follow it. For a framed protocol decoding messages out of a shared or pooled buffer, that hands the caller data belonging to the neighboring frame.

### Summary of your change

A JSONB item always costs at least one byte, so a count larger than the bytes left in the input is malformed by construction. `checkItemCnt()` rejects counts that are negative or larger than `end - offset`, applied at the four places a count comes off the wire, which also covers the array readers that reach it through `startArray()`.

The bound sits in the reader rather than in each `ObjectReaderImpl*Array` because that is where `end` is known, and it follows the existing `checkBigintLen` guard. `JSONBArrayItemCountTest` covers the four paths, the read past `end`, and valid arrays including a 100k element one; without the fix it exhausts the forked test JVM, with it the core suite stays green.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
