### PR TITLE
fix(core): validate cached field writer by value type in toJSONObject

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterObject.java
@@ -79,13 +79,7 @@ public class FieldWriterObject<T>
         if (initValueClass == null || initObjectWriter == ObjectWriterBaseModule.VoidObjectWriter.INSTANCE) {
             return getObjectWriterVoid(jsonWriter, valueClass);
         } else {
-            boolean typeMatch = initValueClass == valueClass
-                    || (writeUsing && initValueClass.isAssignableFrom(valueClass))
-                    || (initValueClass == Map.class && initValueClass.isAssignableFrom(valueClass))
-                    || (initValueClass == List.class && initValueClass.isAssignableFrom(valueClass));
-            if (!typeMatch && initValueClass.isPrimitive()) {
-                typeMatch = typeMatch(initValueClass, valueClass);
-            }
+            boolean typeMatch = isTypeMatch(valueClass);
 
             if (typeMatch) {
                 ObjectWriter objectWriter;
@@ -99,6 +93,26 @@ public class FieldWriterObject<T>
                 return getObjectWriterTypeNotMatch(jsonWriter, valueClass);
             }
         }
+    }
+
+    /**
+     * Whether a value of {@code valueClass} is compatible with the writer cached for
+     * {@link #initValueClass}. Mirrors the typeMatch check performed on the write path so that
+     * {@link ObjectWriterAdapter#toJSONObject(Object)} keeps {@code toJSON} consistent with
+     * {@code toJSONString}. Notably this requires an exact class match (plus the writeUsing / Map /
+     * List / primitive-boxing exceptions), so a subclass value does NOT match and must be
+     * re-resolved by its actual class to avoid silently dropping the subclass fields.
+     */
+    public boolean isTypeMatch(Class valueClass) {
+        final Class initValueClass = this.initValueClass;
+        boolean typeMatch = initValueClass == valueClass
+                || (writeUsing && initValueClass.isAssignableFrom(valueClass))
+                || (initValueClass == Map.class && initValueClass.isAssignableFrom(valueClass))
+                || (initValueClass == List.class && initValueClass.isAssignableFrom(valueClass));
+        if (!typeMatch && initValueClass.isPrimitive()) {
+            typeMatch = typeMatch(initValueClass, valueClass);
+        }
+        return typeMatch;
     }
 
     protected final ObjectWriter getObjectWriterVoid(JSONWriter jsonWriter, Class valueClass) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterObject.java
@@ -102,9 +102,14 @@ public class FieldWriterObject<T>
      * {@code toJSONString}. Notably this requires an exact class match (plus the writeUsing / Map /
      * List / primitive-boxing exceptions), so a subclass value does NOT match and must be
      * re-resolved by its actual class to avoid silently dropping the subclass fields.
+     * Returns {@code false} when {@link #initValueClass} is {@code null} (no value has been
+     * observed for this field yet, so nothing is cached to match against).
      */
     public boolean isTypeMatch(Class valueClass) {
         final Class initValueClass = this.initValueClass;
+        if (initValueClass == null) {
+            return false;
+        }
         boolean typeMatch = initValueClass == valueClass
                 || (writeUsing && initValueClass.isAssignableFrom(valueClass))
                 || (initValueClass == Map.class && initValueClass.isAssignableFrom(valueClass))

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
@@ -697,6 +697,13 @@ public class ObjectWriterAdapter<T>
                 if (objectFieldWriter.initValueClass != null
                         && !objectFieldWriter.isTypeMatch(fieldValue.getClass())) {
                     valueWriter = JSONFactory.getObjectWriter(fieldValue.getClass(), this.features | features);
+                    // When the re-resolved writer is not an ObjectWriterAdapter (arrays, Date, enums,
+                    // etc.), convert the value via JSON.toJSON so it matches the shape the unprimed
+                    // path and toJSONString produce, instead of leaving the raw Java object in the
+                    // JSONObject. See issue #7714.
+                    if (!(valueWriter instanceof ObjectWriterAdapter)) {
+                        fieldValue = JSON.toJSON(fieldValue);
+                    }
                 }
                 if (valueWriter instanceof ObjectWriterAdapter) {
                     ObjectWriterAdapter objectWriterAdapter = (ObjectWriterAdapter) valueWriter;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterAdapter.java
@@ -685,6 +685,19 @@ public class ObjectWriterAdapter<T>
                 if (valueWriter == null) {
                     valueWriter = JSONFactory.getObjectWriter(fieldWriter.fieldType, this.features | features);
                 }
+                // The cached writer was selected by the first value seen on this field (e.g. an Object
+                // or generic field whose fieldClass erases to Object). When a later value has a
+                // different runtime type, reusing that writer throws ClassCastException (wrapped as
+                // "key get error"); and a subclass value would be written with the parent writer,
+                // silently dropping the subclass fields. Re-resolve by the actual value class using
+                // the same typeMatch check the write path applies in
+                // FieldWriterObject.getObjectWriter(jsonWriter, valueClass), so toJSON stays
+                // consistent with toJSONString. See issue #7714.
+                FieldWriterObject objectFieldWriter = (FieldWriterObject) fieldWriter;
+                if (objectFieldWriter.initValueClass != null
+                        && !objectFieldWriter.isTypeMatch(fieldValue.getClass())) {
+                    valueWriter = JSONFactory.getObjectWriter(fieldValue.getClass(), this.features | features);
+                }
                 if (valueWriter instanceof ObjectWriterAdapter) {
                     ObjectWriterAdapter objectWriterAdapter = (ObjectWriterAdapter) valueWriter;
                     if (!objectWriterAdapter.getFieldWriters().isEmpty()) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7714.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7714.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
 import com.alibaba.fastjson2.JSONObject;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -145,5 +146,30 @@ public class Issue7714 {
         // aligning toJSONObject's type-match with the write path).
         String expected = JSON.toJSONString(m2);
         assertEquals(expected, ((JSONObject) r).toJSONString());
+    }
+
+    @Test
+    public void toJSON_nonAdapterValueAfterBeanCacheConvertsLikeUnprimed() {
+        // Prime the payload FieldWriterObject with a bean so initValueClass is set, then send a
+        // value whose writer re-resolves to a non-ObjectWriterAdapter (an int[]). The re-resolved
+        // writer is not an adapter, so the value must still be converted via JSON.toJSON to a
+        // JSONArray — matching the unprimed path and toJSONString — rather than stored as a raw
+        // int[] whose shape depends on cache priming order.
+        DefaultMessage m1 = new DefaultMessage();
+        DataChangeNotification dcn = new DataChangeNotification();
+        dcn.setKey("K1");
+        dcn.setTenantId("10000");
+        m1.setPayload(dcn);
+        JSON.toJSONString(m1);
+
+        DefaultMessage m2 = new DefaultMessage();
+        m2.setPayload(new int[]{1, 2, 3});
+        Object r = JSON.toJSON(m2);
+
+        Object payload = ((JSONObject) r).get("payload");
+        assertTrue(payload instanceof JSONArray, "payload should be a JSONArray, not the raw int[]");
+        JSONArray array = (JSONArray) payload;
+        assertEquals(3, array.size());
+        assertEquals(1, array.getIntValue(0));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7714.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7714.java
@@ -2,6 +2,7 @@ package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code JSONException: key get error} (a wrapped ClassCastException), and — for a subclass
  * value — silently dropping the subclass fields by reusing the parent writer.
  */
+@Tag("regression")
 public class Issue7714 {
     public static class DataChangeNotification {
         private String key;

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7714.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7714.java
@@ -1,0 +1,147 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for issue #7714: when a bean has an {@code Object} (or generic) field,
+ * {@link com.alibaba.fastjson2.JSON#toJSON(Object)} reused the field writer cached for the
+ * first serialized value type without checking it still matches the current value, raising
+ * {@code JSONException: key get error} (a wrapped ClassCastException), and — for a subclass
+ * value — silently dropping the subclass fields by reusing the parent writer.
+ */
+public class Issue7714 {
+    public static class DataChangeNotification {
+        private String key;
+        private String tenantId;
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getTenantId() {
+            return tenantId;
+        }
+
+        public void setTenantId(String tenantId) {
+            this.tenantId = tenantId;
+        }
+    }
+
+    // Subclass adds a field; if toJSONObject reused the parent's cached writer it would be lost.
+    public static class DataChangeNotificationExt
+            extends DataChangeNotification {
+        private String scope;
+
+        public String getScope() {
+            return scope;
+        }
+
+        public void setScope(String scope) {
+            this.scope = scope;
+        }
+    }
+
+    // MQ-style envelope with an untyped payload; the generic getter makes fieldClass erase to Object.
+    public static class DefaultMessage {
+        private Object payLoad;
+
+        public <T> T getPayload() {
+            return (T) payLoad;
+        }
+
+        public boolean setPayload(Object payload) {
+            this.payLoad = payload;
+            return true;
+        }
+    }
+
+    @Test
+    public void toJSON_afterWriterCachedForDifferentType() {
+        // Step 1: write path caches a DataChangeNotification writer for the payload FieldWriterObject.
+        DefaultMessage m1 = new DefaultMessage();
+        DataChangeNotification dcn = new DataChangeNotification();
+        dcn.setKey("K1");
+        dcn.setTenantId("10000");
+        m1.setPayload(dcn);
+        JSON.toJSONString(m1);
+
+        // Step 2: toJSONObject path with a String payload must not reuse that cached writer.
+        // The String value must be preserved as-is instead of throwing "key get error".
+        DefaultMessage m2 = new DefaultMessage();
+        m2.setPayload("{\"key\":\"abc\"}");
+        Object r = JSON.toJSON(m2);
+
+        JSONObject json = (JSONObject) r;
+        assertEquals("{\"key\":\"abc\"}", json.get("payload"));
+    }
+
+    @Test
+    public void toJSON_consistentAfterWriterCachedForSameType() {
+        // Regression guard: once the writer is cached for DataChangeNotification, a second
+        // DataChangeNotification payload must still convert to a nested JSONObject.
+        DefaultMessage m1 = new DefaultMessage();
+        DataChangeNotification dcn1 = new DataChangeNotification();
+        dcn1.setKey("K1");
+        dcn1.setTenantId("10000");
+        m1.setPayload(dcn1);
+        JSON.toJSONString(m1);
+
+        DefaultMessage m2 = new DefaultMessage();
+        DataChangeNotification dcn2 = new DataChangeNotification();
+        dcn2.setKey("K2");
+        dcn2.setTenantId("20000");
+        m2.setPayload(dcn2);
+        Object r = JSON.toJSON(m2);
+
+        JSONObject payload = (JSONObject) ((JSONObject) r).get("payload");
+        assertEquals("K2", payload.get("key"));
+        assertEquals("20000", payload.get("tenantId"));
+    }
+
+    @Test
+    public void toJSON_beanToBeanSubclassReparseAndRecurses() {
+        // Step 1: cache the writer for the parent type on the payload FieldWriterObject.
+        DefaultMessage m1 = new DefaultMessage();
+        DataChangeNotification dcn = new DataChangeNotification();
+        dcn.setKey("K1");
+        dcn.setTenantId("10000");
+        m1.setPayload(dcn);
+        JSON.toJSONString(m1);
+
+        // Step 2: payload is now a subclass value. The write path (typeMatch) requires an exact
+        // class match, so toJSONObject must re-resolve the writer by the subclass and recurse,
+        // rather than reuse the parent writer and silently drop DataChangeNotificationExt.scope.
+        DefaultMessage m2 = new DefaultMessage();
+        DataChangeNotificationExt ext = new DataChangeNotificationExt();
+        ext.setKey("K2");
+        ext.setTenantId("20000");
+        ext.setScope("online");
+        m2.setPayload(ext);
+        Object r = JSON.toJSON(m2);
+
+        // The payload must be a nested JSONObject built from the subclass writer, not the raw bean.
+        Object payload = ((JSONObject) r).get("payload");
+        assertTrue(payload instanceof JSONObject, "payload should be a nested JSONObject, not the raw bean");
+        assertNotSame(ext, payload, "payload should be a converted JSONObject, not the original bean");
+
+        JSONObject payloadJson = (JSONObject) payload;
+        assertEquals("K2", payloadJson.get("key"));
+        assertEquals("20000", payloadJson.get("tenantId"));
+        assertEquals("online", payloadJson.get("scope"));
+
+        // toJSON and toJSONString must agree on the same object (the consistency guarantee from
+        // aligning toJSONObject's type-match with the write path).
+        String expected = JSON.toJSONString(m2);
+        assertEquals(expected, ((JSONObject) r).toJSONString());
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

`ObjectWriterAdapter.toJSONObject(T, long)` now checks whether the field writer cached for an `Object` / generic field still matches the current value's runtime type before reusing it, instead of throwing `JSONException: key get error` (a wrapped `ClassCastException`).

## Why

For a bean with an `Object` (or generic) field, `FieldWriterObject` caches the `ObjectWriter` of the **first** value it serializes (`initValueClass` / `initObjectWriter`). The write path (`FieldWriterObject.getObjectWriter(jsonWriter, valueClass)`) validates this cache via `typeMatch` and re-resolves on mismatch. The `toJSONObject` path did not — it pulled the cached writer via `getInitWriter()` and used it unconditionally, so when a later value had a different runtime type the writer's field accessors threw `ClassCastException`, wrapped as `JSONException: key get error`.

This commonly hits MQ-style envelopes with an untyped `payload` field (`public <T> T getPayload()`): after one `JSON.toJSONString(msg)` with a typed payload, a later `JSON.toJSON(msg)` with a `String` payload on the same bean class blows up.

## Root cause

`ObjectWriterAdapter.java:684` resolved the field value writer via `fieldWriter.getInitWriter()` (the cached writer) with no validation that its `initValueClass` still matches `fieldValue.getClass()`.

## How

- Extract the write path's exact-class `typeMatch` predicate into `FieldWriterObject.isTypeMatch(Class)` and call it from both `ObjectWriterAdapter.toJSONObject` and `FieldWriterObject.getObjectWriter`, so the two paths share one predicate and cannot drift. A subclass value no longer matches the parent's cached writer (matching `toJSONString`), so its fields are no longer silently dropped.
- Right after resolving the cached writer, compare `initValueClass` to the actual value. On mismatch, re-resolve the writer via `JSONFactory.getObjectWriter(fieldValue.getClass(), features)` — mirroring the `typeMatch` re-resolution the write path already performs. When the re-resolved writer is not an `ObjectWriterAdapter` (arrays, `Date`, enums, etc.), convert the value via `JSON.toJSON` so its in-memory shape matches the unprimed path and `toJSONString`.
- When `initValueClass` is `null` (nothing cached yet) or matches, behavior is unchanged.

## Testing

New test `Issue7714` (4 cases). 3 fail before the fix (two with the issue's `JSONException: key get error`, one with silent subclass-field loss), all pass after; the 4th guards the unchanged match path:
- `toJSON_afterWriterCachedForDifferentType` — the issue's scenario: cache a `DataChangeNotification` writer via `toJSONString`, then `JSON.toJSON` a `String` payload. Before: `JSONException: key get error` (`ClassCastException: String cannot be cast to DataChangeNotification`). After: the `String` payload is preserved.
- `toJSON_beanToBeanSubclassReparseAndRecurses` — cache the writer for the parent type, then `JSON.toJSON` a subclass payload (`DataChangeNotificationExt`, adds `scope`). Before: `expected: <online> but was: <null>` (the subclass field was dropped by the parent's cached writer). After: payload is a nested `JSONObject` carrying `scope`, and `toJSON` agrees with `toJSONString`.
- `toJSON_nonAdapterValueAfterBeanCacheConvertsLikeUnprimed` — prime the field with a bean, then send an `int[]` payload whose re-resolved writer is not an `ObjectWriterAdapter`. Before: `JSONException: key get error` (`ClassCastException: [I cannot be cast to DataChangeNotification`). After: payload is a `JSONArray`, matching the unprimed path.
- `toJSON_consistentAfterWriterCachedForSameType` — regression guard: a second value of the cached type still converts to a nested `JSONObject` (passes before and after, guarding the unchanged match path).
- `./mvnw checkstyle:check` → `0 Checkstyle violations`.
- Regression: `JSONTest, JSONObjectTest, JSONReader*Test, *ObjectWriter*Test, Issue*` → `Tests run: 2501, Failures: 0`.

## Verification of the original issue

Before the fix:
```
JSON.toJSON(m2) → JSONException: key get error
  Caused by: ClassCastException: class java.lang.String cannot be cast to class ...DataChangeNotification
```

After the fix:
```
JSON.toJSON(m2) → {"payload":"{\"key\":\"abc\"}"}
```
The `String` payload is preserved as-is instead of being fed to the wrong writer.

Fixes #7714
