### PR TITLE
fix(compat): add ParserConfig.propertyNamingStrategy for fastjson 1.x compat

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/ParserConfig.java
@@ -1,5 +1,6 @@
 package com.alibaba.fastjson.parser;
 
+import com.alibaba.fastjson.PropertyNamingStrategy;
 import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONFactory;
@@ -24,6 +25,13 @@ public class ParserConfig {
 
     final ObjectReaderProvider provider;
     public final boolean fieldBase;
+    /**
+     * Mirrors fastjson 1.x's public field so migration code that assigns it directly
+     * (e.g. {@code parserConfig.propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;})
+     * no longer raises {@link NoSuchFieldError}. Kept for source/binary compatibility,
+     * matching {@link com.alibaba.fastjson.serializer.SerializeConfig#propertyNamingStrategy}.
+     */
+    public PropertyNamingStrategy propertyNamingStrategy;
     private boolean asmEnable;
     private boolean autoTypeSupport;
 

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/parser/ParserConfigTest.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/parser/ParserConfigTest.java
@@ -1,5 +1,6 @@
 package com.alibaba.fastjson.parser;
 
+import com.alibaba.fastjson.PropertyNamingStrategy;
 import com.alibaba.fastjson.parser.deserializer.ObjectDeserializer;
 import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONObject;
@@ -70,5 +71,17 @@ public class ParserConfigTest {
         assertNotSame(config0.provider, config1.provider);
 
         assertSame(JSONFactory.getDefaultObjectReaderProvider(), ParserConfig.getGlobalInstance().provider);
+    }
+
+    @Test
+    public void propertyNamingStrategyField() {
+        // Regression for issue #7704: fastjson 1.x ParserConfig exposes a public
+        // propertyNamingStrategy field; migration code assigns it directly. The compat
+        // package previously lacked the field, raising NoSuchFieldError. Mirror what
+        // SerializeConfig already exposes.
+        ParserConfig config = new ParserConfig();
+        assertNull(config.propertyNamingStrategy);
+        config.propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;
+        assertSame(PropertyNamingStrategy.SnakeCase, config.propertyNamingStrategy);
     }
 }


### PR DESCRIPTION
## What

The fastjson 1.x compatibility package's `ParserConfig` now exposes the public `propertyNamingStrategy` field, so migration code that assigns it directly no longer raises `NoSuchFieldError`.

## Why

Code migrating from fastjson 1.x commonly does:

```java
ParserConfig parserConfig = new ParserConfig();
parserConfig.propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;
```

fastjson 1.x's `ParserConfig` declares this as a public field, but the compatibility package's `ParserConfig` did not, so the assignment threw at runtime:

```
java.lang.NoSuchFieldError: propertyNamingStrategy
```

The sibling `SerializeConfig` (serialization side) already exposes the same field for compatibility; `ParserConfig` was the only one missing it.

## Root cause

`fastjson1-compatible/.../parser/ParserConfig.java` never declared a `propertyNamingStrategy` field, unlike `SerializeConfig#propertyNamingStrategy` which already exists for the same compatibility reason.

## How

Add `public PropertyNamingStrategy propertyNamingStrategy;` to `ParserConfig`, mirroring `SerializeConfig`. This restores source/binary compatibility for migration code. As with `SerializeConfig`, the field is held for API compatibility; the active naming strategy on the reader path is governed by the underlying `ObjectReaderProvider` (`getNamingStrategy()`/`setNamingStrategy(...)`).

## Testing

- New test `ParserConfigTest#propertyNamingStrategyField` — fails before the fix with `NoSuchFieldError`, passes after: the field is `null` by default and accepts `PropertyNamingStrategy.SnakeCase`.
- `./mvnw checkstyle:check` → `0 Checkstyle violations`.
- Regression: `ParserConfigTest` → `Tests run: 3, Failures: 0`.

## Verification of the original issue

Before the fix:
```
new ParserConfig().propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;
  → java.lang.NoSuchFieldError: propertyNamingStrategy
```

After the fix:
```
new ParserConfig().propertyNamingStrategy = PropertyNamingStrategy.SnakeCase;
  → assigns cleanly (no error)
```

Fixes #7704
