### PR TITLE
fix: preserve generic element type for custom List implementations

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1194,10 +1194,10 @@ public class ObjectReaderProvider
                     }
                 }
                 if (typeArguments.length == 1 && List.class.isAssignableFrom(rawClass)) {
-                    // Honor a custom deserializer declared on the List subclass (e.g.
-                    // @JSONType(deserializer = ...), @JSONType(deserializeUsing = ...) or Jackson's
-                    // @JsonDeserialize(using = ...)) before the list fast-path. Otherwise the generic
-                    // list reader is returned and the user's deserializer directive is silently bypassed.
+                    // Honor a custom deserializer declared on the List subclass — any ObjectReader
+                    // populated into beanInfo.deserializer by getBeanInfo (e.g. @JSONType(deserializer = ...))
+                    // — before the list fast-path. Otherwise the generic list reader is returned and the
+                    // user's deserializer directive is silently bypassed.
                     BeanInfo beanInfo = new BeanInfo(this);
                     getBeanInfo(beanInfo, rawClass);
                     if (beanInfo.deserializer != null && ObjectReader.class.isAssignableFrom(beanInfo.deserializer)) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1194,7 +1194,28 @@ public class ObjectReaderProvider
                     }
                 }
                 if (typeArguments.length == 1 && List.class.isAssignableFrom(rawClass)) {
-                    return ObjectReaderImplList.of(objectType, rawClass, 0);
+                    // Honor a custom deserializer declared on the List subclass (e.g.
+                    // @JSONType(deserializer = ...), @JSONType(deserializeUsing = ...) or Jackson's
+                    // @JsonDeserialize(using = ...)) before the list fast-path. Otherwise the generic
+                    // list reader is returned and the user's deserializer directive is silently bypassed.
+                    BeanInfo beanInfo = new BeanInfo(this);
+                    getBeanInfo(beanInfo, rawClass);
+                    if (beanInfo.deserializer != null && ObjectReader.class.isAssignableFrom(beanInfo.deserializer)) {
+                        ObjectReader deserializerReader;
+                        try {
+                            Constructor<?> constructor = beanInfo.deserializer.getDeclaredConstructor();
+                            constructor.setAccessible(true);
+                            deserializerReader = (ObjectReader) constructor.newInstance();
+                        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+                                | InvocationTargetException e) {
+                            throw new JSONException("create deserializer error", e);
+                        }
+                        ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, deserializerReader);
+                        return previous != null ? previous : deserializerReader;
+                    }
+                    ObjectReader listReader = ObjectReaderImplList.of(objectType, rawClass, 0);
+                    ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, listReader);
+                    return previous != null ? previous : listReader;
                 }
 
                 if (typeArguments.length == 2 && Map.class.isAssignableFrom(rawClass)) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1193,7 +1193,7 @@ public class ObjectReaderProvider
                         return rawClassReader;
                     }
                 }
-                if (typeArguments.length == 1 && ArrayList.class.isAssignableFrom(rawClass)) {
+                if (typeArguments.length == 1 && List.class.isAssignableFrom(rawClass)) {
                     return ObjectReaderImplList.of(objectType, rawClass, 0);
                 }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7684.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7684.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * lost its generic element type — elements were decoded as JSONObject.
  */
 @Tag("regression")
-public class Issue7684Test {
+public class Issue7684 {
     public static class CustomList<E> extends AbstractList<E> {
         private final List<E> list = new ArrayList<>();
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7684Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7684Test.java
@@ -1,10 +1,14 @@
 package com.alibaba.fastjson2.issues;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
 import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.annotation.JSONType;
+import com.alibaba.fastjson2.reader.ObjectReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,6 +55,43 @@ public class Issue7684Test {
         public int id;
     }
 
+    /**
+     * A non-{@code ArrayList} {@code List} subclass that declares a custom deserializer.
+     * Used to verify the deserializer is honored (not bypassed by the list fast-path)
+     * when the type is used as a parameterized {@link TypeReference} argument.
+     */
+    @JSONType(deserializer = DeserializerListReader.class)
+    public static class DeserializerList<E> extends AbstractList<E> {
+        private final List<E> list = new ArrayList<>();
+
+        @Override
+        public E get(int index) {
+            return list.get(index);
+        }
+
+        @Override
+        public int size() {
+            return list.size();
+        }
+
+        @Override
+        public void add(int index, E element) {
+            list.add(index, element);
+        }
+    }
+
+    public static class DeserializerListReader implements ObjectReader {
+        @Override
+        public Object readObject(JSONReader jsonReader, Type fieldType, Object fieldName, long features) {
+            jsonReader.readAny(); // consume the JSON payload
+            // Return a recognizable sentinel so the test can prove this reader ran
+            // (rather than the generic list reader that would bypass it).
+            DeserializerList list = new DeserializerList();
+            list.add("INVOKED");
+            return list;
+        }
+    }
+
     @Test
     public void customListGenericPreserved() {
         String json = "[{\"id\":1},{\"id\":2}]";
@@ -60,5 +101,16 @@ public class Issue7684Test {
         assertTrue(result.get(0) instanceof Bean, "element type must be Bean, was: " + result.get(0).getClass());
         assertEquals(1, result.get(0).id);
         assertEquals(2, result.get(1).id);
+    }
+
+    @Test
+    public void customDeserializerOnListSubclassHonored() {
+        // Regression: @JSONType(deserializer=...) on a non-ArrayList List subclass used as a
+        // TypeReference argument must be honored, not silently bypassed by the list fast-path.
+        DeserializerList<String> result = JSON.parseObject(
+                "[\"a\",\"b\"]", new TypeReference<DeserializerList<String>>() {});
+
+        assertEquals(1, result.size());
+        assertEquals("INVOKED", result.get(0));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7684Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7684Test.java
@@ -1,0 +1,64 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * TypeReference with a custom List implementation (not derived from ArrayList)
+ * lost its generic element type — elements were decoded as JSONObject.
+ */
+@Tag("regression")
+public class Issue7684Test {
+    public static class CustomList<E> extends AbstractList<E> {
+        private final List<E> list = new ArrayList<>();
+
+        @Override
+        public E get(int index) {
+            return list.get(index);
+        }
+
+        @Override
+        public int size() {
+            return list.size();
+        }
+
+        @Override
+        public void add(int index, E element) {
+            list.add(index, element);
+        }
+
+        @Override
+        public E set(int index, E element) {
+            return list.set(index, element);
+        }
+
+        @Override
+        public E remove(int index) {
+            return list.remove(index);
+        }
+    }
+
+    public static class Bean {
+        public int id;
+    }
+
+    @Test
+    public void customListGenericPreserved() {
+        String json = "[{\"id\":1},{\"id\":2}]";
+        CustomList<Bean> result = JSON.parseObject(json, new TypeReference<CustomList<Bean>>() {});
+
+        assertEquals(2, result.size());
+        assertTrue(result.get(0) instanceof Bean, "element type must be Bean, was: " + result.get(0).getClass());
+        assertEquals(1, result.get(0).id);
+        assertEquals(2, result.get(1).id);
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
A custom `List` implementation used as a `TypeReference` generic argument now keeps its element type.

## Why
```java
public class CustomList<E> extends AbstractList<E> { ... }
CustomList<Bean> r = JSON.parseObject(json, new TypeReference<CustomList<Bean>>() {});
```
Before, the element generic type was lost. The failure mode differs by entry point:
- compat module (`com.alibaba.fastjson`): `r.get(0)` is `JSONObject`, `ClassCastException` on use.
- core (`com.alibaba.fastjson2`): `JSONException` ("expect {, but [").

After: `r.get(0)` is `Bean`.

Issue #7684 (regression from fastjson 1.x, where this worked). Both entry points reach the same core path (`ObjectReaderProvider.getObjectReaderInternal`), so fixing core fixes both.

## Root cause
In `ObjectReaderProvider.getObjectReader`, the parameterised-type fallback that routes a 1-arg generic type to `ObjectReaderImplList` gated on `ArrayList.class.isAssignableFrom(rawClass)`. A `List` that doesn't extend `ArrayList` (e.g. one extending `AbstractList`, or any plain `implements List`) failed that check and fell through to bean reflection, losing the element generic type. The adjacent 2-arg branch already used the interface `Map.class.isAssignableFrom`, so the List branch was asymmetric.

## How
Use `List.class.isAssignableFrom(rawClass)` instead of `ArrayList.class`, mirroring the Map branch.

Broadening the gate to `List.class` makes a non-`ArrayList` `List` subclass that declares a custom deserializer (`@JSONType(deserializer = ...)` / `deserializeUsing`) match the list fast-path. Before this change such a subclass fell through to `createObjectReader`, which honors `beanInfo.deserializer` (same logic as `ObjectReaderCreator.createObjectReader`). To preserve that, this branch first runs the annotation processors via `getBeanInfo(beanInfo, rawClass)` and, if a deserializer is declared, instantiates and returns it the same way `createObjectReader` does; only when no deserializer is declared does it return `ObjectReaderImplList.of(...)`. Both the deserializer reader and the list reader are cached via `getPreviousObjectReader`, so a reused `TypeReference` returns the same instance.

## Testing
New `Issue7684` (`@Tag("regression")`):
- `customListGenericPreserved`: a `CustomList<Bean>` extending `AbstractList` round-trips with `Bean` elements.
- `customDeserializerOnListSubclassHonored`: a `@JSONType(deserializer = ...)` `AbstractList` subclass used as a `TypeReference` argument invokes the declared reader instead of the list fast-path.

`./mvnw -pl core test`: full core suite green.

Fixes #7684
