### PR TITLE
docs: add performance and bilingual PR conventions to AGENTS.md, add CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,8 @@ mvn validate             # checkstyle + modernizer checks
 - Java (primary), Kotlin (for `kotlin` module)
 - Tests: JUnit 5 / Kotest
 - Code style: Checkstyle (`src/checkstyle/fastjson2-checks.xml`), enforced via `mvn validate`
+- Performance-first project: every change must consider performance impact
+- Watch method bytecode size (codeSize) — keep hot-path methods under the two JIT inlining thresholds: 35 bytes (C1, `-XX:MaxInlineSize`) and 325 bytes (C2, `-XX:FreqInlineSize`) so they can be inlined
+- Prefer the implementation with smaller codeSize when choosing between equivalent approaches
 - PRs should be small and focused; ensure `mvn validate` and `mvn test` pass
+- PRs and comments should be bilingual: English first, Chinese version collapsed in a `<details>` block

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What

Update `AGENTS.md` with new conventions and add `CLAUDE.md` for Claude Code compatibility:

- **Performance-first**: every change must consider performance impact
- **Bytecode size (codeSize)**: keep hot-path methods under the two JIT inlining thresholds — 35 bytes (C1, `-XX:MaxInlineSize`) and 325 bytes (C2, `-XX:FreqInlineSize`) — so they can be inlined
- **Prefer smaller codeSize** when choosing between equivalent implementations
- **Bilingual PRs/comments**: English first, Chinese version collapsed in a `<details>` block
- **CLAUDE.md**: imports `AGENTS.md` via `@AGENTS.md` so Claude Code loads the same single-source conventions

<details>
<summary>中文说明</summary>

## 变更内容

更新 `AGENTS.md` 约定并新增 `CLAUDE.md` 以兼容 Claude Code：

- **性能优先**：所有修改都要考虑性能影响
- **字节码方法大小（codeSize）**：热路径方法控制在两个 JIT 内联门槛内——35 字节（C1，`-XX:MaxInlineSize`）和 325 字节（C2，`-XX:FreqInlineSize`），保证可被内联
- **等价方案优先选 codeSize 更小的实现**
- **PR 与评论双语**：英文为主，中文版本折叠在 `<details>` 中
- **CLAUDE.md**：通过 `@AGENTS.md` 引入同一份约定，保持单一来源

</details>