### PR TITLE
2.0.64 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add the dependency and start parsing JSON in seconds:
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -91,7 +91,7 @@ The `groupId` for FASTJSON 2 is `com.alibaba.fastjson2` (different from 1.x):
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -99,7 +99,7 @@ The `groupId` for FASTJSON 2 is `com.alibaba.fastjson2` (different from 1.x):
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2:2.0.64'
 }
 ```
 
@@ -115,7 +115,7 @@ If you are migrating from `fastjson 1.2.x`, you can use the compatibility packag
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -123,7 +123,7 @@ If you are migrating from `fastjson 1.2.x`, you can use the compatibility packag
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba:fastjson:2.0.63'
+    implementation 'com.alibaba:fastjson:2.0.64'
 }
 ```
 
@@ -137,7 +137,7 @@ For projects using Kotlin, the `fastjson2-kotlin` module provides idiomatic Kotl
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -161,7 +161,7 @@ Add the Kotlin standard library and reflection library as needed. The reflection
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.63")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.64")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 }
@@ -177,7 +177,7 @@ For Spring Framework projects, use the appropriate extension module. See the ful
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring5</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -187,7 +187,7 @@ For Spring Framework projects, use the appropriate extension module. See the ful
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring6</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -196,9 +196,9 @@ For Spring Framework projects, use the appropriate extension module. See the ful
 ```groovy
 dependencies {
     // Choose one based on your Spring version:
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.64'
     // or
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.64'
 }
 ```
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -66,7 +66,7 @@
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -92,7 +92,7 @@ String json = JSON.toJSONString(user);
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -100,7 +100,7 @@ String json = JSON.toJSONString(user);
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2:2.0.64'
 }
 ```
 
@@ -116,7 +116,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -124,7 +124,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba:fastjson:2.0.63'
+    implementation 'com.alibaba:fastjson:2.0.64'
 }
 ```
 
@@ -138,7 +138,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -162,7 +162,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.63")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.64")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlin_version")
 }
@@ -178,7 +178,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring5</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -188,7 +188,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring6</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -197,9 +197,9 @@ dependencies {
 ```groovy
 dependencies {
     // 根据 Spring 版本选择：
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.64'
     // 或
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.64'
 }
 ```
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/benchmark_25/pom.xml
+++ b/benchmark_25/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/codegen-test/pom.xml
+++ b/codegen-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/codegen/pom.xml
+++ b/codegen/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/FAQ_cn.md
+++ b/docs/FAQ_cn.md
@@ -272,7 +272,7 @@ public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factor
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 

--- a/docs/FAQ_en.md
+++ b/docs/FAQ_en.md
@@ -272,7 +272,7 @@ Use the compatibility package as a drop-in replacement:
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 

--- a/docs/Kotlin/kotlin_cn.md
+++ b/docs/Kotlin/kotlin_cn.md
@@ -10,7 +10,7 @@
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.63")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.64")
 }
 ```
 

--- a/docs/Kotlin/kotlin_en.md
+++ b/docs/Kotlin/kotlin_en.md
@@ -10,7 +10,7 @@ If your project uses `kotlin`, you can use the` Fastjson-Kotlin` module, and use
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ If the data class is used or the parameters are passed in through constructor, t
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.63")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.64")
 }
 ```
 

--- a/docs/Spring/spring_support_cn.md
+++ b/docs/Spring/spring_support_cn.md
@@ -10,7 +10,7 @@ Fastjson2采用多module的结构设计，对SpringFramework等框架的支持�
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring5</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 
 or
@@ -18,7 +18,7 @@ or
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring6</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -26,13 +26,13 @@ or
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.64'
 }
 
 or
 
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.64'
 }
 ```
 > 2.0.23版本之后为了兼容Spring 5.x / 6.x，将不同版本独立开不同的依赖包。

--- a/docs/Spring/spring_support_en.md
+++ b/docs/Spring/spring_support_en.md
@@ -11,7 +11,7 @@ independent in the `extension` dependency.
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring5</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 
 or
@@ -19,7 +19,7 @@ or
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension-spring6</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -27,13 +27,13 @@ or
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring5:2.0.64'
 }
 
 or
 
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension-spring6:2.0.64'
 }
 ```
 > After version 2.0.23, in order to be compatible with Spring 5.x / 6.x, different versions are independently opened with different dependency packages.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -39,7 +39,7 @@
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2:2.0.64'
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba</groupId>
     <artifactId>fastjson</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -65,7 +65,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba:fastjson:2.0.63'
+    implementation 'com.alibaba:fastjson:2.0.64'
 }
 ```
 
@@ -79,7 +79,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-kotlin</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -87,7 +87,7 @@ dependencies {
 
 ```kotlin
 dependencies {
-    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.63")
+    implementation("com.alibaba.fastjson2:fastjson2-kotlin:2.0.64")
 }
 ```
 
@@ -101,7 +101,7 @@ dependencies {
 <dependency>
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-extension</artifactId>
-    <version>2.0.63</version>
+    <version>2.0.64</version>
 </dependency>
 ```
 
@@ -109,7 +109,7 @@ dependencies {
 
 ```groovy
 dependencies {
-    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.63'
+    implementation 'com.alibaba.fastjson2:fastjson2-extension:2.0.64'
 }
 ```
 

--- a/example-solon-test/pom.xml
+++ b/example-solon-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/example-spring-test/pom.xml
+++ b/example-spring-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/example-spring6-test/pom.xml
+++ b/example-spring6-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -15,7 +15,7 @@
     <properties>
         <maven.test.skip>true</maven.test.skip>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <fastjson2.version>2.0.64-SNAPSHOT</fastjson2.version>
+        <fastjson2.version>2.0.64</fastjson2.version>
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>

--- a/extension-jaxrs/extension-jaxrs-jakarta/pom.xml
+++ b/extension-jaxrs/extension-jaxrs-jakarta/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-extension-jaxrs</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
     </parent>
 
     <artifactId>fastjson2-extension-jaxrs-jakarta</artifactId>

--- a/extension-jaxrs/extension-jaxrs-javax/pom.xml
+++ b/extension-jaxrs/extension-jaxrs-javax/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-extension-jaxrs</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
     </parent>
 
     <artifactId>fastjson2-extension-jaxrs-javax</artifactId>

--- a/extension-jaxrs/pom.xml
+++ b/extension-jaxrs/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
     </parent>
 
     <artifactId>fastjson2-extension-jaxrs</artifactId>

--- a/extension-solon/pom.xml
+++ b/extension-solon/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-spring5/pom.xml
+++ b/extension-spring5/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension-spring6/pom.xml
+++ b/extension-spring6/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/fastjson1-compatible/pom.xml
+++ b/fastjson1-compatible/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-parent</artifactId>
-    <version>2.0.64-SNAPSHOT</version>
+    <version>2.0.64</version>
     <name>${project.artifactId}</name>
     <description>Fastjson is a JSON processor (JSON parser + JSON generator) written in Java</description>
     <packaging>pom</packaging>

--- a/safemode-test/pom.xml
+++ b/safemode-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-jdk17/pom.xml
+++ b/test-jdk17/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-jdk25/pom.xml
+++ b/test-jdk25/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64-SNAPSHOT</version>
+        <version>2.0.64</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Version bump: 2.0.64-SNAPSHOT → 2.0.64, update version references in README and docs.

Generated with Qwen Code (1-shotted by Qwen-Coder)