### PR TITLE
fix: do not collapse consecutive ".." refs to #-1 in JSONB, for issue…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONB.java
@@ -3187,11 +3187,7 @@ public interface JSONB {
          * @return the new offset
          */
         static int writeReference(byte[] bytes, int off, String path, JSONWriter jsonWriter) {
-            if (jsonWriter.lastReference == path) {
-                path = "#-1";
-            } else {
-                jsonWriter.lastReference = path;
-            }
+            path = jsonWriter.collapseReference(path);
             bytes[off] = BC_REFERENCE;
             return writeString(bytes, off + 1, path);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -3081,6 +3081,22 @@ public abstract class JSONWriter
     }
 
     /**
+     * For JSONB, collapses a path equal to {@link #lastReference} into {@code "#-1"}.
+     * {@code ".."} is excluded: consecutive equal {@code ".."} paths may refer to different
+     * enclosing objects.
+     *
+     * @param path the reference path about to be written
+     * @return {@code "#-1"} if collapsed, otherwise {@code path}
+     */
+    final String collapseReference(String path) {
+        if (Objects.equals(path, lastReference) && !"..".equals(path)) {
+            return "#-1";
+        }
+        lastReference = path;
+        return path;
+    }
+
+    /**
      * Writes a reference to a previously serialized object.
      * This is used for handling circular references and avoiding infinite loops during serialization.
      *

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -3081,15 +3081,15 @@ public abstract class JSONWriter
     }
 
     /**
-     * For JSONB, collapses a path equal to {@link #lastReference} into {@code "#-1"}.
-     * {@code ".."} is excluded: consecutive equal {@code ".."} paths may refer to different
+     * For JSONB, collapses a path identical to {@link #lastReference} into {@code "#-1"}.
+     * {@code ".."} is excluded: consecutive identical {@code ".."} paths may refer to different
      * enclosing objects.
      *
      * @param path the reference path about to be written
      * @return {@code "#-1"} if collapsed, otherwise {@code path}
      */
     final String collapseReference(String path) {
-        if (Objects.equals(path, lastReference) && !"..".equals(path)) {
+        if (path == lastReference && !"..".equals(path)) {
             return "#-1";
         }
         lastReference = path;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriterJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriterJSONB.java
@@ -1505,8 +1505,7 @@ final class JSONWriterJSONB
         int off = this.off;
         grow1(off)[off] = BC_REFERENCE;
         this.off = off + 1;
-        writeString(path == this.lastReference ? "#-1" : path);
-        this.lastReference = path;
+        writeString(collapseReference(path));
     }
 
     @Override

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7746.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7746.java
@@ -1,0 +1,90 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * https://github.com/alibaba/fastjson2/issues/7746
+ */
+public class Issue7746 {
+    public static class SelfBean {
+        public String name;
+        public SelfBean self;
+    }
+
+    @Test
+    public void test() {
+        String[] names = {"a", "b"};
+
+        byte[] bytes = JSONB.toBytes(selfReferencingList(names), JSONWriter.Feature.ReferenceDetection);
+        List<SelfBean> parsed = JSONB.parseObject(
+                bytes,
+                new TypeReference<List<SelfBean>>() {
+                }.getType()
+        );
+        assertSelfReferencesPreserved(parsed, names);
+    }
+
+    @Test
+    public void testFieldBased() {
+        String[] names = {"a", "b"};
+
+        byte[] bytes = JSONB.toBytes(
+                selfReferencingList(names),
+                JSONWriter.Feature.ReferenceDetection,
+                JSONWriter.Feature.FieldBased
+        );
+        List<SelfBean> parsed = JSONB.parseObject(
+                bytes,
+                new TypeReference<List<SelfBean>>() {
+                }.getType(),
+                JSONReader.Feature.FieldBased
+        );
+        assertSelfReferencesPreserved(parsed, names);
+    }
+
+    /**
+     * Consecutive ".." self-references must remain intact for every element, not only the first.
+     */
+    @Test
+    public void testMultipleElements() {
+        String[] names = {"a", "b", "c"};
+
+        byte[] bytes = JSONB.toBytes(selfReferencingList(names), JSONWriter.Feature.ReferenceDetection);
+        List<SelfBean> parsed = JSONB.parseObject(
+                bytes,
+                new TypeReference<List<SelfBean>>() {
+                }.getType()
+        );
+        assertSelfReferencesPreserved(parsed, names);
+    }
+
+    static List<SelfBean> selfReferencingList(String... names) {
+        List<SelfBean> list = new ArrayList<>();
+        for (String name : names) {
+            SelfBean bean = new SelfBean();
+            bean.name = name;
+            bean.self = bean;
+            list.add(bean);
+        }
+        return list;
+    }
+
+    static void assertSelfReferencesPreserved(List<SelfBean> parsed, String... names) {
+        assertEquals(names.length, parsed.size());
+        for (int i = 0; i < names.length; i++) {
+            SelfBean bean = parsed.get(i);
+            assertEquals(names[i], bean.name);
+            assertSame(bean, bean.self);
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7746.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7746.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * https://github.com/alibaba/fastjson2/issues/7746
@@ -96,6 +97,37 @@ public class Issue7746 {
             assertEquals(names[i], map.get("name"));
             assertSame(map, map.get("self"));
         }
+    }
+
+    /**
+     * Covers ASM {@code JSONB.IO.writeReference}: Collection-typed bean fields that share one
+     * instance go through that path under ReferenceDetection, not JSONWriterJSONB.writeReference.
+     */
+    @Test
+    public void testAsmCollectionFieldRefs() {
+        List<String> shared = new ArrayList<>();
+        shared.add("x");
+
+        CollectionRefBean bean = new CollectionRefBean();
+        bean.first = shared;
+        bean.second = shared;
+        bean.third = shared;
+
+        byte[] bytes = JSONB.toBytes(bean, JSONWriter.Feature.ReferenceDetection);
+        String dump = JSONB.toJSONString(bytes);
+        assertTrue(dump.contains("#-1"), dump);
+
+        CollectionRefBean parsed = JSONB.parseObject(bytes, CollectionRefBean.class);
+        assertSame(parsed.first, parsed.second);
+        assertSame(parsed.first, parsed.third);
+        assertEquals(1, parsed.first.size());
+        assertEquals("x", parsed.first.get(0));
+    }
+
+    public static class CollectionRefBean {
+        public List<String> first;
+        public List<String> second;
+        public List<String> third;
     }
 
     static List<SelfBean> selfReferencingList(String... names) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7746.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7746.java
@@ -7,7 +7,9 @@ import com.alibaba.fastjson2.TypeReference;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -66,6 +68,34 @@ public class Issue7746 {
                 }.getType()
         );
         assertSelfReferencesPreserved(parsed, names);
+    }
+
+    /**
+     * Covers ObjectWriterImplMap's writeReference("..") path, which Bean field writers do not hit.
+     */
+    @Test
+    public void testMapSelfReference() {
+        String[] names = {"a", "b", "c"};
+        List<Map<String, Object>> list = new ArrayList<>();
+        for (String name : names) {
+            Map<String, Object> map = new HashMap<>();
+            map.put("name", name);
+            map.put("self", map);
+            list.add(map);
+        }
+
+        byte[] bytes = JSONB.toBytes(list, JSONWriter.Feature.ReferenceDetection);
+        List<Map<String, Object>> parsed = JSONB.parseObject(
+                bytes,
+                new TypeReference<List<Map<String, Object>>>() {
+                }.getType()
+        );
+        assertEquals(names.length, parsed.size());
+        for (int i = 0; i < names.length; i++) {
+            Map<String, Object> map = parsed.get(i);
+            assertEquals(names[i], map.get("name"));
+            assertSame(map, map.get("self"));
+        }
     }
 
     static List<SelfBean> selfReferencingList(String... names) {


### PR DESCRIPTION
… #7746

### What this PR does / why we need it?

Fixes #7746 

JSONB 在 ReferenceDetection 下若本次引用路径与上次相同会折叠为 #-1。这对 ".." 不正确：它是相对路径，表示当前外层对象自身，相邻的 ".." 可能指向不同对象。折叠后后续自引用解析错误，反序列化时 self 等字段从第二个元素起变为 null。文本 JSON 无此逻辑，不受影响。


### Summary of your change

抽出共用的 JSONWriter#collapseReference(String)，供 JSONWriterJSONB.writeReference 与 JSONB.IO.writeReference 使用。
路径为 ".." 时不再折叠为 #-1。
新增 Issue7746：覆盖 2 元素、FieldBased、3 元素自引用列表。



#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
