### PR TITLE
fix: handle unavailable Kotlin parameter names

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -319,10 +319,12 @@ public class ObjectWriterBaseModule
                 Constructor kotlinConstructor = KotlinUtils.getKotlinConstructor(getConstructor(objectClass));
                 if (kotlinConstructor != null) {
                     String[] paramNames = KotlinUtils.getKoltinConstructorParameters(objectClass);
-                    for (int i = 0; i < paramNames.length; i++) {
-                        if (paramNames[i].equals(field.getName())) {
-                            annotations = kotlinConstructor.getParameterAnnotations()[i];
-                            break;
+                    if (paramNames != null) {
+                        for (int i = 0; i < paramNames.length; i++) {
+                            if (paramNames[i].equals(field.getName())) {
+                                annotations = kotlinConstructor.getParameterAnnotations()[i];
+                                break;
+                            }
                         }
                     }
                     if (fieldInfo.ignore) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7749.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7749.java
@@ -1,0 +1,48 @@
+package com.alibaba.fastjson2.issues;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.util.KotlinUtils;
+import kotlin.Metadata;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("regression")
+public class Issue7749 {
+    @Test
+    public void serializeKotlinClassWithoutKotlinReflect() throws Exception {
+        Field constructorField = KotlinUtils.class.getDeclaredField("kotlin_kclass_constructor");
+        Field errorField = KotlinUtils.class.getDeclaredField("kotlin_class_klass_error");
+        constructorField.setAccessible(true);
+        errorField.setAccessible(true);
+
+        synchronized (KotlinUtils.class) {
+            Object constructor = constructorField.get(null);
+            boolean error = errorField.getBoolean(null);
+            try {
+                constructorField.set(null, null);
+                errorField.setBoolean(null, true);
+                assertEquals("{\"sourceType\":\"Test\"}", JSON.toJSONString(new KotlinBean("Test")));
+            } finally {
+                constructorField.set(null, constructor);
+                errorField.setBoolean(null, error);
+            }
+        }
+    }
+
+    @Metadata(k = 1, mv = {1, 9, 0})
+    public static class KotlinBean {
+        private final String sourceType;
+
+        public KotlinBean(String sourceType) {
+            this.sourceType = sourceType;
+        }
+
+        public String getSourceType() {
+            return sourceType;
+        }
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

### What this PR does / why we need it?

Serializing a Kotlin class without `kotlin-reflect` on the classpath throws an NPE: `KotlinUtils.getKoltinConstructorParameters` returns `null` when kotlin-reflect cannot be loaded, but the writer still reads the array length unconditionally. Fixes #7749.

### Summary of your change

Match constructor parameter annotations only when parameter names are available; when they are not, skip this optional mapping and continue serialization. Adds regression test `Issue7749` (`@Tag("regression")`) simulating a class whose Kotlin parameter names cannot be resolved.

Testing: `./mvnw -pl core -Dfastjson2.creator=reflect -Dtest=Issue7749 test`

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

<details>
<summary>中文说明</summary>

### 这个 PR 做什么 / 为什么需要？

避免 Kotlin 类在缺少 `kotlin-reflect` 时序列化触发 NPE：`KotlinUtils.getKoltinConstructorParameters` 在无法加载 kotlin-reflect 时返回 `null`，writer 仍直接读取数组长度。修复 #7749。

### 改动摘要

仅在参数名可用时匹配构造器参数注解；不可用时跳过该可选映射，继续序列化。新增带 `@Tag("regression")` 的回归测试，模拟参数名不可解析的 Kotlin 元数据类。

测试：`./mvnw -pl core -Dfastjson2.creator=reflect -Dtest=Issue7749 test`

</details>
