### PR TITLE
fix: align createObjectReader external fieldClass check with none-def…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -292,26 +292,7 @@ public class ObjectReaderCreatorASM
 
         if (match) {
             for (FieldReader fieldReader : fieldReaderArray) {
-                if (fieldReader.defaultValue != null || fieldReader.schema != null) {
-                    match = false;
-                    break;
-                }
-
-                Class fieldClass = fieldReader.fieldClass;
-                if (fieldClass != null
-                        && (!Modifier.isPublic(fieldClass.getModifiers()) || classLoader.isExternalClass(fieldClass))) {
-                    match = false;
-                    break;
-                }
-
-                if (fieldReader instanceof FieldReaderMap
-                        && ((FieldReaderMap<?>) fieldReader).arrayToMapKey != null) {
-                    match = false;
-                    break;
-                }
-
-                if (fieldReader.fieldClass == Number.class
-                        && !Number.class.equals(fieldReader.fieldType)) {
+                if (!isFieldJitCompatible(fieldReader)) {
                     match = false;
                     break;
                 }
@@ -417,25 +398,7 @@ public class ObjectReaderCreatorASM
                     break;
                 }
 
-                if (fieldReader.defaultValue != null || fieldReader.schema != null) {
-                    match = false;
-                    break;
-                }
-
-                Class fieldClass = fieldReader.fieldClass;
-                if (fieldClass != null && (!Modifier.isPublic(fieldClass.getModifiers()) || classLoader.isExternalClass(fieldClass))) {
-                    match = false;
-                    break;
-                }
-
-                if (fieldReader instanceof FieldReaderMap
-                        && ((FieldReaderMap<?>) fieldReader).arrayToMapKey != null) {
-                    match = false;
-                    break;
-                }
-
-                if (fieldReader.fieldClass == Number.class
-                        && !Number.class.equals(fieldReader.fieldType)) {
+                if (!isFieldJitCompatible(fieldReader)) {
                     match = false;
                     break;
                 }
@@ -568,6 +531,35 @@ public class ObjectReaderCreatorASM
                 buildFunction,
                 fieldReaders
         );
+    }
+
+    private boolean isFieldJitCompatible(FieldReader fieldReader) {
+        if (fieldReader.defaultValue != null || fieldReader.schema != null) {
+            return false;
+        }
+
+        Class fieldClass = fieldReader.fieldClass;
+        if (fieldClass != null
+                && (!Modifier.isPublic(fieldClass.getModifiers()) || classLoader.isExternalClass(fieldClass))) {
+            return false;
+        }
+
+        Type itemType = fieldReader.itemType;
+        if (itemType instanceof Class && classLoader.isExternalClass((Class) itemType)) {
+            return false;
+        }
+
+        if (fieldReader instanceof FieldReaderMap
+                && ((FieldReaderMap<?>) fieldReader).arrayToMapKey != null) {
+            return false;
+        }
+
+        if (fieldReader.fieldClass == Number.class
+                && !Number.class.equals(fieldReader.fieldType)) {
+            return false;
+        }
+
+        return true;
     }
 
     private <T> ObjectReaderBean jitObjectReader(

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderCreatorASM.java
@@ -298,7 +298,8 @@ public class ObjectReaderCreatorASM
                 }
 
                 Class fieldClass = fieldReader.fieldClass;
-                if (fieldClass != null && !Modifier.isPublic(fieldClass.getModifiers())) {
+                if (fieldClass != null
+                        && (!Modifier.isPublic(fieldClass.getModifiers()) || classLoader.isExternalClass(fieldClass))) {
                     match = false;
                     break;
                 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -39,6 +40,15 @@ public class Issue7748 {
         assertSame(isolated(Generator.class), generator.getClass());
     }
 
+    @Test
+    public void listItem() throws Exception {
+        Class<?> beanClass = isolated(Issue7748ListBean.class);
+        Object bean = JSON.parseObject("{\"generators\":{}}", beanClass);
+
+        Collection<?> generators = (Collection<?>) beanClass.getMethod("getGenerators").invoke(bean);
+        assertSame(isolated(Generator.class), generators.iterator().next().getClass());
+    }
+
     private Class<?> isolated(Class<?> clazz) throws ClassNotFoundException {
         Class<?> isolated = classLoader.loadClass(clazz.getName());
         assertNotSame(clazz, isolated);
@@ -54,7 +64,8 @@ public class Issue7748 {
 
         @Override
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-            if (!name.startsWith(Issue7748Bean.class.getName())) {
+            if (!name.startsWith(Issue7748Bean.class.getName())
+                    && !name.equals(Issue7748ListBean.class.getName())) {
                 return super.loadClass(name, resolve);
             }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748.java
@@ -1,0 +1,91 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.issues_7000.Issue7748Bean.Generator;
+import com.alibaba.fastjson2.reader.ObjectReaderCreatorASM;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class Issue7748 {
+    private IsolatedClassLoader classLoader;
+
+    @BeforeEach
+    public void setUp() {
+        classLoader = new IsolatedClassLoader();
+        // ASM reader defined by the test class loader, while beans are loaded by IsolatedClassLoader
+        JSONFactory.setContextReaderCreator(new ObjectReaderCreatorASM(Issue7748.class.getClassLoader()));
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JSONFactory.setContextReaderCreator(null);
+    }
+
+    @Test
+    public void objectField() throws Exception {
+        Class<?> beanClass = isolated(Issue7748Bean.class);
+        Object bean = JSON.parseObject("{\"generator\":{}}", beanClass);
+
+        Object generator = beanClass.getMethod("getGenerator").invoke(bean);
+        assertSame(isolated(Generator.class), generator.getClass());
+    }
+
+    private Class<?> isolated(Class<?> clazz) throws ClassNotFoundException {
+        Class<?> isolated = classLoader.loadClass(clazz.getName());
+        assertNotSame(clazz, isolated);
+        return isolated;
+    }
+
+    /** Parent-last for Issue7748Bean*, simulating ParallelWebappClassLoader. */
+    static class IsolatedClassLoader
+            extends ClassLoader {
+        IsolatedClassLoader() {
+            super(Issue7748.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (!name.startsWith(Issue7748Bean.class.getName())) {
+                return super.loadClass(name, resolve);
+            }
+
+            synchronized (getClassLoadingLock(name)) {
+                Class<?> clazz = findLoadedClass(name);
+                if (clazz == null) {
+                    byte[] bytes = read(name);
+                    clazz = defineClass(name, bytes, 0, bytes.length);
+                }
+                if (resolve) {
+                    resolveClass(clazz);
+                }
+                return clazz;
+            }
+        }
+
+        private byte[] read(String name) throws ClassNotFoundException {
+            String resource = name.replace('.', '/') + ".class";
+            try (InputStream in = getParent().getResourceAsStream(resource)) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                byte[] buf = new byte[8192];
+                for (int len; (len = in.read(buf)) != -1;) {
+                    out.write(buf, 0, len);
+                }
+                return out.toByteArray();
+            } catch (IOException e) {
+                throw new ClassNotFoundException(name, e);
+            }
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748Bean.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748Bean.java
@@ -1,0 +1,26 @@
+package com.alibaba.fastjson2.issues_7000;
+
+/** Top-level so IsolatedClassLoader can define a second copy of this class. */
+public class Issue7748Bean {
+    private Generator generator;
+
+    public Generator getGenerator() {
+        return generator;
+    }
+
+    public void setGenerator(Generator generator) {
+        this.generator = generator;
+    }
+
+    public static class Generator {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748ListBean.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7748ListBean.java
@@ -1,0 +1,16 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import java.util.List;
+
+/** Only a List field, so fieldClass isExternalClass does not already disable JIT. */
+public class Issue7748ListBean {
+    private List<Issue7748Bean.Generator> generators;
+
+    public List<Issue7748Bean.Generator> getGenerators() {
+        return generators;
+    }
+
+    public void setGenerators(List<Issue7748Bean.Generator> generators) {
+        this.generators = generators;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #7748 

Tomcat 等容器中多个 web 应用共用一份 fastjson2、各自用 ParallelWebappClassLoader 加载同名 bean 时，
ObjectReaderCreatorASM#createObjectReader 生成的 reader 会按类名引用字段类型。DynamicClassLoader
解析到的可能是另一个 web 应用的 Class，导致反序列化时出现 ClassCastException
（同名类、不同 ClassLoader）。

createNoneDefaultConstructorObjectReader 已对 fieldClass 做 isExternalClass 判断并回退反射路径，
createObjectReader 此前只检查了字段类是否 public，漏了这一步。

### Summary of your change

在 ObjectReaderCreatorASM#createObjectReader 中为 fieldClass 补充 classLoader.isExternalClass(fieldClass)，
与 createNoneDefaultConstructorObjectReader 保持一致；不可见时不再 JIT，回退反射 ObjectReader。
新增 Issue7748：用 IsolatedClassLoader 复现 issue 中的 {"generator":{}} 场景。

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
