### PR TITLE
fix: unify AutoType authorization to type name and reject hash-cache hit

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -5647,7 +5647,9 @@ public abstract class JSONReader
          *
          * @param hashCode The hash code of the type
          * @return An ObjectReader for the specified type hash code, or null if not found
+         * @deprecated a hash hit is not an AutoType authorization; resolve by type name instead
          */
+        @Deprecated
         public ObjectReader getObjectReaderAutoType(long hashCode) {
             return provider.getObjectReader(hashCode);
         }
@@ -6796,21 +6798,7 @@ public abstract class JSONReader
      * @return An ObjectReader for the specified type, or null if not found
      */
     public ObjectReader getObjectReaderAutoType(long typeHash, Class expectClass, long features) {
-        ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
-        if (autoTypeObjectReader != null) {
-            return autoTypeObjectReader;
-        }
-
-        String typeName = getString();
-        if (context.autoTypeBeforeHandler != null) {
-            Class<?> autoTypeClass = context.autoTypeBeforeHandler.apply(typeName, expectClass, features);
-            if (autoTypeClass != null) {
-                boolean fieldBased = (features & Feature.FieldBased.mask) != 0;
-                return context.provider.getObjectReader(autoTypeClass, fieldBased);
-            }
-        }
-
-        return context.provider.getObjectReader(typeName, expectClass, context.features | features);
+        return context.getObjectReaderAutoType(getString(), expectClass, context.features | features);
     }
 
     protected final String readStringNotMatch() {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -754,15 +754,11 @@ final class JSONReaderJSONB
                 );
             }
             case BC_TYPED_ANY: {
-                long typeHash = readTypeHashCode();
+                readTypeHashCode();
 
                 if (context.autoTypeBeforeHandler != null) {
-                    Class<?> filterClass = context.autoTypeBeforeHandler.apply(typeHash, null, context.features);
-
-                    if (filterClass == null) {
-                        String typeName = getString();
-                        filterClass = context.autoTypeBeforeHandler.apply(typeName, null, context.features);
-                    }
+                    String typeName = getString();
+                    Class<?> filterClass = context.autoTypeBeforeHandler.apply(typeName, null, context.features);
 
                     if (filterClass != null) {
                         ObjectReader autoTypeObjectReader = context.getObjectReader(filterClass);
@@ -783,14 +779,10 @@ final class JSONReaderJSONB
                     throw new JSONException("autoType not support , offset " + offset + "/" + bytes.length);
                 }
 
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException("autoType not support : " + typeName + ", offset " + offset + "/" + bytes.length);
-                    }
+                    throw new JSONException("autoType not support : " + typeName + ", offset " + offset + "/" + bytes.length);
                 }
                 return autoTypeObjectReader.readJSONBObject(this, null, null, 0);
             }
@@ -815,15 +807,11 @@ final class JSONReaderJSONB
                     if (supportAutoType && i == 0 && type >= BC_STR_ASCII_FIX_MIN) {
                         long hash = readFieldNameHashCode();
                         if (hash == ObjectReader.HASH_TYPE) {
-                            long typeHash = readValueHashCode();
-                            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                            readValueHashCode();
+                            String typeName = getString();
+                            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                             if (autoTypeObjectReader == null) {
-                                String typeName = getString();
-                                autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                                if (autoTypeObjectReader == null) {
-                                    throw new JSONException("autoType not support : " + typeName + ", offset " + offset + "/" + bytes.length);
-                                }
+                                throw new JSONException("autoType not support : " + typeName + ", offset " + offset + "/" + bytes.length);
                             }
 
                             typeRedirect = true;
@@ -1262,15 +1250,12 @@ final class JSONReaderJSONB
 
         Context context = this.context;
         offset++;
-        final long typeHash = readTypeHashCode();
+        readTypeHashCode();
 
         ObjectReader autoTypeObjectReader = null;
         AutoTypeBeforeHandler autoTypeBeforeHandler = context.autoTypeBeforeHandler;
         if (autoTypeBeforeHandler != null) {
-            Class<?> objectClass = autoTypeBeforeHandler.apply(typeHash, Object.class, 0L);
-            if (objectClass == null) {
-                objectClass = autoTypeBeforeHandler.apply(getString(), Object.class, 0L);
-            }
+            Class<?> objectClass = autoTypeBeforeHandler.apply(getString(), Object.class, 0L);
             if (objectClass != null) {
                 autoTypeObjectReader = context.getObjectReader(objectClass);
             }
@@ -1285,23 +1270,6 @@ final class JSONReaderJSONB
                 }
                 autoTypeError();
             }
-            autoTypeObjectReader = context.provider.getObjectReader(typeHash);
-        }
-
-        if (autoTypeObjectReader != null) {
-            Class objectClass = autoTypeObjectReader.getObjectClass();
-            if (objectClass != null) {
-                ClassLoader classLoader = objectClass.getClassLoader();
-                if (classLoader != null) {
-                    ClassLoader tcl = Thread.currentThread().getContextClassLoader();
-                    if (classLoader != tcl) {
-                        autoTypeObjectReader = getObjectReaderContext(autoTypeObjectReader, objectClass, tcl);
-                    }
-                }
-            }
-        }
-
-        if (autoTypeObjectReader == null) {
             autoTypeObjectReader = context.provider.getObjectReader(getString(), Object.class, features);
             if (autoTypeObjectReader == null) {
                 if ((features & Feature.ErrorOnNotSupportAutoType.mask) == 0) {
@@ -1335,7 +1303,7 @@ final class JSONReaderJSONB
 
             AutoTypeBeforeHandler autoTypeBeforeHandler = context.autoTypeBeforeHandler;
             if (autoTypeBeforeHandler != null) {
-                ObjectReader objectReader = checkAutoTypeWithHandler(expectClass, features, autoTypeBeforeHandler, typeHash);
+                ObjectReader objectReader = checkAutoTypeWithHandler(expectClass, features, autoTypeBeforeHandler);
                 if (objectReader != null) {
                     return objectReader;
                 }
@@ -1349,29 +1317,12 @@ final class JSONReaderJSONB
                 autoTypeError();
             }
 
-            autoTypeObjectReader = context.provider.getObjectReader(typeHash);
-
-            if (autoTypeObjectReader != null) {
-                Class objectClass = autoTypeObjectReader.getObjectClass();
-                if (objectClass != null) {
-                    ClassLoader classLoader = objectClass.getClassLoader();
-                    if (classLoader != null) {
-                        ClassLoader tcl = Thread.currentThread().getContextClassLoader();
-                        if (classLoader != tcl) {
-                            autoTypeObjectReader = getObjectReaderContext(autoTypeObjectReader, objectClass, tcl);
-                        }
-                    }
-                }
-            }
-
+            autoTypeObjectReader = context.provider.getObjectReader(getString(), expectClass, features2);
             if (autoTypeObjectReader == null) {
-                autoTypeObjectReader = context.provider.getObjectReader(getString(), expectClass, features2);
-                if (autoTypeObjectReader == null) {
-                    if ((features2 & Feature.ErrorOnNotSupportAutoType.mask) == 0) {
-                        return null;
-                    }
-                    autoTypeError();
+                if ((features2 & Feature.ErrorOnNotSupportAutoType.mask) == 0) {
+                    return null;
                 }
+                autoTypeError();
             }
 
             this.type = bytes[offset];
@@ -1382,13 +1333,9 @@ final class JSONReaderJSONB
     ObjectReader checkAutoTypeWithHandler(
             Class expectClass,
             long features,
-            AutoTypeBeforeHandler autoTypeBeforeHandler,
-            long typeHash
+            AutoTypeBeforeHandler autoTypeBeforeHandler
     ) {
-        Class<?> objectClass = autoTypeBeforeHandler.apply(typeHash, expectClass, features);
-        if (objectClass == null) {
-            objectClass = autoTypeBeforeHandler.apply(getString(), expectClass, features);
-        }
+        Class<?> objectClass = autoTypeBeforeHandler.apply(getString(), expectClass, features);
         if (objectClass != null) {
             return context.getObjectReader(objectClass);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
@@ -228,16 +228,13 @@ public class FieldReaderList<T, V>
     @Override
     public ObjectReader checkObjectAutoType(JSONReader jsonReader) {
         if (jsonReader.nextIfMatch(JSONB.Constants.BC_TYPED_ANY)) {
-            long typeHash = jsonReader.readTypeHashCode();
+            jsonReader.readTypeHashCode();
             final long features = jsonReader.features(this.features);
             JSONReader.Context context = jsonReader.getContext();
             JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
+            String typeName = jsonReader.getString();
             if (autoTypeFilter != null) {
-                Class<?> filterClass = autoTypeFilter.apply(typeHash, fieldClass, features);
-                if (filterClass == null) {
-                    String typeName = jsonReader.getString();
-                    filterClass = autoTypeFilter.apply(typeName, fieldClass, features);
-                }
+                Class<?> filterClass = autoTypeFilter.apply(typeName, fieldClass, features);
                 if (filterClass != null) {
                     return context.getObjectReader(fieldClass);
                 }
@@ -252,7 +249,7 @@ public class FieldReaderList<T, V>
                 throw new JSONException(jsonReader.info("autoType not support input " + jsonReader.getString()));
             }
 
-            ObjectReader autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, fieldClass, features);
+            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, fieldClass, features);
 
             if (autoTypeObjectReader instanceof ObjectReaderImplList) {
                 ObjectReaderImplList listReader = (ObjectReaderImplList) autoTypeObjectReader;

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectArrayTypedReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectArrayTypedReader.java
@@ -96,9 +96,11 @@ final class ObjectArrayTypedReader
                 // skip
             } else {
                 if (jsonReader.isSupportAutoType(features)) {
-                    ObjectReader autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, objectClass, features);
+                    String typeName = jsonReader.getString();
+                    ObjectReader autoTypeObjectReader = jsonReader.getContext()
+                            .getObjectReaderAutoType(typeName, objectClass, features);
                     if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("autoType not support : " + jsonReader.getString()));
+                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                     }
 
                     return autoTypeObjectReader.readObject(jsonReader, fieldType, fieldName, features);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
@@ -137,11 +137,7 @@ public interface ObjectReader<T> {
 
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
-            ObjectReader<T> reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0 || this instanceof ObjectReaderSeeAlso) {
-                reader = autoType(provider, typeHash);
-            }
+            ObjectReader<T> reader = autoType(provider, Fnv.hashCode64(typeName));
 
             if (reader == null) {
                 reader = provider.getObjectReader(
@@ -347,7 +343,7 @@ public interface ObjectReader<T> {
      * @return the ObjectReader for the type, or null if not found
      */
     default ObjectReader autoType(JSONReader.Context context, long typeHash) {
-        return context.getObjectReaderAutoType(typeHash);
+        return null;
     }
 
     /**
@@ -358,7 +354,7 @@ public interface ObjectReader<T> {
      * @return the ObjectReader for the type, or null if not found
      */
     default ObjectReader autoType(ObjectReaderProvider provider, long typeHash) {
-        return provider.getObjectReader(typeHash);
+        return null;
     }
 
     /**
@@ -389,16 +385,11 @@ public interface ObjectReader<T> {
             long hash = jsonReader.readFieldNameHashCode();
 
             if (hash == getTypeKeyHash() && i == 0) {
-                long typeHash = jsonReader.readTypeHashCode();
-                ObjectReader reader = autoType(context, typeHash);
-
+                jsonReader.readTypeHashCode();
+                String typeName = jsonReader.getString();
+                ObjectReader reader = context.getObjectReaderAutoType(typeName, null);
                 if (reader == null) {
-                    String typeName = jsonReader.getString();
-                    reader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (reader == null) {
-                        throw new JSONException(jsonReader.info("No suitable ObjectReader found for " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("No suitable ObjectReader found for " + typeName));
                 }
 
                 if (reader == this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader1.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader1.java
@@ -156,16 +156,12 @@ public class ObjectReader1<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (hashCode == getTypeKeyHash() && i == 0) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -262,16 +258,12 @@ public class ObjectReader1<T>
 
             long hashCode = jsonReader.readFieldNameHashCode();
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader2.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader2.java
@@ -265,16 +265,12 @@ public class ObjectReader2<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader3.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader3.java
@@ -289,16 +289,12 @@ public class ObjectReader3<T>
             }
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader4.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader4.java
@@ -316,16 +316,12 @@ public class ObjectReader4<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader5.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader5.java
@@ -336,16 +336,12 @@ public class ObjectReader5<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader6.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader6.java
@@ -359,16 +359,12 @@ public class ObjectReader6<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -242,16 +242,14 @@ public class ObjectReaderAdapter<T>
     }
 
     public Object autoType(JSONReader jsonReader, Class expectClass, long features) {
-        long typeHash = jsonReader.readTypeHashCode();
+        jsonReader.readTypeHashCode();
         JSONReader.Context context = jsonReader.getContext();
+        long featuresAll = this.features | features | context.getFeatures();
 
         ObjectReader autoTypeObjectReader = null;
-        if (jsonReader.isSupportAutoTypeOrHandler(features)) {
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
-        }
-        if (autoTypeObjectReader == null) {
+        if (jsonReader.isSupportAutoTypeOrHandler(featuresAll)) {
             String typeName = jsonReader.getString();
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, this.features | features | context.getFeatures());
+            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, featuresAll);
 
             if (autoTypeObjectReader == null) {
                 if (expectClass == objectClass) {
@@ -260,6 +258,10 @@ public class ObjectReaderAdapter<T>
                     throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                 }
             }
+        }
+
+        if (autoTypeObjectReader == null) {
+            throw new JSONException(jsonReader.info("autoType not support"));
         }
 
         return autoTypeObjectReader.readObject(jsonReader, null, null, features);
@@ -536,16 +538,12 @@ public class ObjectReaderAdapter<T>
     }
 
     protected T autoType(JSONReader jsonReader) {
-        long typeHash = jsonReader.readTypeHashCode();
+        jsonReader.readTypeHashCode();
         JSONReader.Context context = jsonReader.getContext();
-        ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+        String typeName = jsonReader.getString();
+        ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
         if (autoTypeObjectReader == null) {
-            String typeName = jsonReader.getString();
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-            if (autoTypeObjectReader == null) {
-                throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-            }
+            throw new JSONException(jsonReader.info("autoType not support : " + typeName));
         }
 
         return (T) autoTypeObjectReader.readJSONBObject(jsonReader, null, null, features);
@@ -584,16 +582,12 @@ public class ObjectReaderAdapter<T>
 
             long hash = jsonReader.readFieldNameHashCode();
             if (hash == typeKeyHashCode && i == 0) {
-                long typeHash = jsonReader.readValueHashCode();
+                jsonReader.readValueHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -646,7 +640,7 @@ public class ObjectReaderAdapter<T>
             return provider.getObjectReader(seeAlsoClass);
         }
 
-        return provider.getObjectReader(typeHash);
+        return null;
     }
 
     @Override
@@ -660,7 +654,7 @@ public class ObjectReaderAdapter<T>
             return context.getObjectReader(seeAlsoClass);
         }
 
-        return context.getObjectReaderAutoType(typeHash);
+        return null;
     }
 
     protected void initStringFieldAsEmpty(Object object) {
@@ -679,10 +673,12 @@ public class ObjectReaderAdapter<T>
         long features2 = features | this.features | JSONFactory.getDefaultReaderFeatures();
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
             ObjectReader<T> reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0 || this instanceof ObjectReaderSeeAlso) {
-                reader = autoType(provider, typeHash);
+            if (seeAlsoMapping != null && seeAlsoMapping.size() > 0) {
+                Class seeAlsoClass = seeAlsoMapping.get(Fnv.hashCode64(typeName));
+                if (seeAlsoClass != null) {
+                    reader = provider.getObjectReader(seeAlsoClass);
+                }
             }
 
             if (reader == null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
@@ -172,30 +172,27 @@ public abstract class ObjectReaderBean<T>
 
     protected final ObjectReader checkAutoType0(JSONReader jsonReader, long features) {
         Class expectClass = this.objectClass;
-        long typeHash = jsonReader.readTypeHashCode();
+        jsonReader.readTypeHashCode();
         JSONReader.Context context = jsonReader.getContext();
         long features3 = jsonReader.features(features | this.features);
         JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
+        String typeName = jsonReader.getString();
 
         ObjectReader autoTypeObjectReader;
         if (autoTypeFilter != null) {
-            Class<?> filterClass = autoTypeFilter.apply(typeHash, expectClass, features);
-            if (filterClass == null) {
-                String typeName = jsonReader.getString();
-                filterClass = autoTypeFilter.apply(typeName, expectClass, features);
+            Class<?> filterClass = autoTypeFilter.apply(typeName, expectClass, features);
 
-                if (filterClass != null && !expectClass.isAssignableFrom(filterClass)) {
-                    if ((jsonReader.features(features) & IgnoreAutoTypeNotMatch.mask) == 0) {
-                        throw notMatchError();
-                    }
-
-                    filterClass = expectClass;
+            if (filterClass != null && !expectClass.isAssignableFrom(filterClass)) {
+                if ((jsonReader.features(features) & IgnoreAutoTypeNotMatch.mask) == 0) {
+                    throw notMatchError();
                 }
+
+                filterClass = expectClass;
             }
 
             autoTypeObjectReader = context.getObjectReader(filterClass);
         } else {
-            autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, expectClass, features);
+            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, features3);
 
             if (autoTypeObjectReader == null) {
                 throw auotypeError(jsonReader);
@@ -211,7 +208,7 @@ public abstract class ObjectReaderBean<T>
 
                 autoTypeObjectReader = context.getObjectReader(expectClass);
             } else {
-                if (typeHash == this.typeNameHash || (features3 & SupportAutoType.mask) == 0) {
+                if (Fnv.hashCode64(typeName) == this.typeNameHash || (features3 & SupportAutoType.mask) == 0) {
                     autoTypeObjectReader = null;
                 }
             }
@@ -329,24 +326,16 @@ public abstract class ObjectReaderBean<T>
             ) {
                 ObjectReader reader = null;
 
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
+                String typeName = jsonReader.getString();
                 if (autoTypeFilter != null) {
-                    Class<?> filterClass = autoTypeFilter.apply(typeHash, objectClass, features3);
-                    if (filterClass == null) {
-                        filterClass = autoTypeFilter.apply(jsonReader.getString(), objectClass, features3);
-                        if (filterClass != null) {
-                            reader = context.getObjectReader(filterClass);
-                        }
+                    Class<?> filterClass = autoTypeFilter.apply(typeName, objectClass, features3);
+                    if (filterClass != null) {
+                        reader = context.getObjectReader(filterClass);
                     }
                 }
 
                 if (reader == null) {
-                    reader = autoType(context, typeHash);
-                }
-
-                String typeName = null;
-                if (reader == null) {
-                    typeName = jsonReader.getString();
                     reader = context.getObjectReaderAutoType(
                             typeName, objectClass, features3
                     );

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderException.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderException.java
@@ -151,17 +151,12 @@ final class ObjectReaderException<T>
             long hash = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hash == HASH_TYPE && jsonReader.isSupportAutoType(features)) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader reader = autoType(context, typeHash);
-                String typeName;
+                String typeName = jsonReader.getString();
+                ObjectReader reader = context.getObjectReaderAutoType(typeName, objectClass, features);
                 if (reader == null) {
-                    typeName = jsonReader.getString();
-                    reader = context.getObjectReaderAutoType(typeName, objectClass, features);
-
-                    if (reader == null) {
-                        throw new JSONException(jsonReader.info("No suitable ObjectReader found for" + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("No suitable ObjectReader found for" + typeName));
                 }
 
                 if (reader == this) {
@@ -357,16 +352,12 @@ final class ObjectReaderException<T>
 
             if (jsonReader.isSupportAutoType(features) || context.getContextAutoTypeBeforeHandler() != null) {
                 jsonReader.next();
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
 
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException("autoType not support : " + typeName + ", offset " + jsonReader.getOffset());
-                    }
+                    throw new JSONException("autoType not support : " + typeName + ", offset " + jsonReader.getOffset());
                 }
                 return (T) autoTypeObjectReader.readJSONBObject(jsonReader, fieldType, fieldName, 0);
             }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapTyped.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapTyped.java
@@ -316,8 +316,9 @@ class ObjectReaderImplMapTyped
                         && (contextFeatures & JSONReader.Feature.SupportAutoType.mask) != 0
                         && name.equals(getTypeKey())
                 ) {
-                    long typeHashCode = jsonReader.readTypeHashCode();
-                    ObjectReader objectReaderAutoType = jsonReader.getObjectReaderAutoType(typeHashCode, mapType, features);
+                    jsonReader.readTypeHashCode();
+                    ObjectReader objectReaderAutoType = jsonReader.getContext()
+                            .getObjectReaderAutoType(jsonReader.getString(), mapType, features);
                     if (objectReaderAutoType != null) {
                         if (objectReaderAutoType instanceof ObjectReaderImplMap) {
                             if (!object.getClass().equals(((ObjectReaderImplMap) objectReaderAutoType).instanceType)) {
@@ -342,8 +343,9 @@ class ObjectReaderImplMapTyped
                 ) {
                     name = jsonReader.readFieldName();
                     if (name.equals(getTypeKey())) {
-                        long typeHashCode = jsonReader.readTypeHashCode();
-                        ObjectReader objectReaderAutoType = jsonReader.getObjectReaderAutoType(typeHashCode, mapType, features);
+                        jsonReader.readTypeHashCode();
+                        ObjectReader objectReaderAutoType = jsonReader.getContext()
+                                .getObjectReaderAutoType(jsonReader.getString(), mapType, features);
                         if (objectReaderAutoType != null) {
                             if (objectReaderAutoType instanceof ObjectReaderImplMap) {
                                 if (!object.getClass().equals(((ObjectReaderImplMap) objectReaderAutoType).instanceType)) {
@@ -368,8 +370,9 @@ class ObjectReaderImplMapTyped
                     if (index == 0
                             && (contextFeatures & JSONReader.Feature.SupportAutoType.mask) != 0
                             && name.equals(getTypeKey())) {
-                        long typeHashCode = jsonReader.readTypeHashCode();
-                        ObjectReader objectReaderAutoType = jsonReader.getObjectReaderAutoType(typeHashCode, mapType, features);
+                        jsonReader.readTypeHashCode();
+                        ObjectReader objectReaderAutoType = jsonReader.getContext()
+                                .getObjectReaderAutoType(jsonReader.getString(), mapType, features);
                         if (objectReaderAutoType != null) {
                             if (objectReaderAutoType instanceof ObjectReaderImplMap) {
                                 if (!object.getClass().equals(((ObjectReaderImplMap) objectReaderAutoType).instanceType)) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplObject.java
@@ -1,7 +1,6 @@
 package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.*;
-import com.alibaba.fastjson2.util.Fnv;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -36,20 +35,12 @@ public final class ObjectReaderImplObject
 
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
-            ObjectReader reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0) {
-                reader = autoType(provider, typeHash);
-            }
+            ObjectReader reader = provider.getObjectReader(
+                    typeName, getObjectClass(), features | getFeatures()
+            );
 
             if (reader == null) {
-                reader = provider.getObjectReader(
-                        typeName, getObjectClass(), features | getFeatures()
-                );
-
-                if (reader == null) {
-                    throw new JSONException("No suitable ObjectReader found for" + typeName);
-                }
+                throw new JSONException("No suitable ObjectReader found for" + typeName);
             }
 
             if (reader != this) {
@@ -79,48 +70,13 @@ public final class ObjectReaderImplObject
 
                 if (hash == HASH_TYPE) {
                     boolean supportAutoType = context.isEnabled(JSONReader.Feature.SupportAutoType);
+                    typeName = jsonReader.readString();
+                    ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
 
-                    ObjectReader autoTypeObjectReader;
-
-                    if (supportAutoType) {
-                        long typeHash = jsonReader.readTypeHashCode();
-                        autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
-
-                        if (autoTypeObjectReader != null) {
-                            Class objectClass = autoTypeObjectReader.getObjectClass();
-                            if (objectClass != null) {
-                                ClassLoader objectClassLoader = objectClass.getClassLoader();
-                                ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-                                if (objectClassLoader != classLoader) {
-                                    Class contextClass = null;
-
-                                    typeName = jsonReader.getString();
-                                    try {
-                                        if (classLoader == null) {
-                                            classLoader = getClass().getClassLoader();
-                                        }
-                                        contextClass = classLoader.loadClass(typeName);
-                                    } catch (ClassNotFoundException ignored) {
-                                    }
-                                    //明确contextClass类型与objectClass不一致时才更改reader
-                                    if (contextClass != null && !objectClass.equals(contextClass)) {
-                                        autoTypeObjectReader = context.getObjectReader(contextClass);
-                                    }
-                                }
-                            }
-                        }
-
-                        if (autoTypeObjectReader == null) {
-                            typeName = jsonReader.getString();
-                            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-                        }
-                    } else {
-                        typeName = jsonReader.readString();
-                        autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                        if (autoTypeObjectReader == null && jsonReader.getContext().isEnabled(JSONReader.Feature.ErrorOnNotSupportAutoType)) {
-                            throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-                        }
+                    if (!supportAutoType
+                            && autoTypeObjectReader == null
+                            && context.isEnabled(JSONReader.Feature.ErrorOnNotSupportAutoType)) {
+                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                     }
 
                     if (autoTypeObjectReader != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderInterface.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderInterface.java
@@ -52,16 +52,12 @@ public final class ObjectReaderInterface<T>
 
             long hash = jsonReader.readFieldNameHashCode();
             if (hash == typeKeyHashCode && i == 0) {
-                long typeHash = jsonReader.readValueHashCode();
+                jsonReader.readValueHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -142,24 +138,16 @@ public final class ObjectReaderInterface<T>
             ) {
                 ObjectReader reader = null;
 
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
+                String typeName = jsonReader.getString();
                 if (autoTypeFilter != null) {
-                    Class<?> filterClass = autoTypeFilter.apply(typeHash, objectClass, features3);
-                    if (filterClass == null) {
-                        filterClass = autoTypeFilter.apply(jsonReader.getString(), objectClass, features3);
-                        if (filterClass != null) {
-                            reader = context.getObjectReader(filterClass);
-                        }
+                    Class<?> filterClass = autoTypeFilter.apply(typeName, objectClass, features3);
+                    if (filterClass != null) {
+                        reader = context.getObjectReader(filterClass);
                     }
                 }
 
                 if (reader == null) {
-                    reader = autoType(context, typeHash);
-                }
-
-                String typeName = null;
-                if (reader == null) {
-                    typeName = jsonReader.getString();
                     reader = context.getObjectReaderAutoType(
                             typeName, objectClass, features3
                     );

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
@@ -149,16 +149,12 @@ public class ObjectReaderNoneDefaultConstructor<T>
                 }
 
                 if (hashCode == HASH_TYPE && i == 0) {
-                    long typeHash = jsonReader.readTypeHashCode();
+                    jsonReader.readTypeHashCode();
                     JSONReader.Context context = jsonReader.getContext();
-                    ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                    String typeName = jsonReader.getString();
+                    ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                     if (autoTypeObjectReader == null) {
-                        String typeName = jsonReader.getString();
-                        autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                        if (autoTypeObjectReader == null) {
-                            throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-                        }
+                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                     }
 
                     Object object = autoTypeObjectReader.readJSONBObject(jsonReader, fieldType, fieldName, features);
@@ -318,21 +314,10 @@ public class ObjectReaderNoneDefaultConstructor<T>
                     continue;
                 }
 
-                boolean supportAutoType = (featuresAll & JSONReader.Feature.SupportAutoType.mask) != 0;
-
-                ObjectReader autoTypeObjectReader;
-
-                if (supportAutoType) {
-                    autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, objectClass, this.features);
-                } else {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-                }
-
-                if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass, this.features);
-                }
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(
+                        typeName, objectClass, this.features | featuresAll
+                );
 
                 if (autoTypeObjectReader != null) {
                     Object object = autoTypeObjectReader.readObject(jsonReader, fieldType, fieldName, 0);
@@ -515,17 +500,9 @@ public class ObjectReaderNoneDefaultConstructor<T>
 
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
-            ObjectReader<T> reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0) {
-                reader = autoType(provider, typeHash);
-            }
-
-            if (reader == null) {
-                reader = provider.getObjectReader(
-                        typeName, getObjectClass(), features | getFeatures()
-                );
-            }
+            ObjectReader<T> reader = provider.getObjectReader(
+                    typeName, getObjectClass(), features | getFeatures()
+            );
 
             if (reader != this && reader != null) {
                 return reader.createInstance(map, features);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
@@ -112,16 +112,21 @@ final class ObjectReaderSeeAlso<T>
 
             long hash = jsonReader.readFieldNameHashCode();
             if (hash == typeKeyHashCode) {
-                long typeHash = jsonReader.readValueHashCode();
+                jsonReader.readValueHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
-                if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = null;
+                if (seeAlsoMapping != null && seeAlsoMapping.size() > 0) {
+                    Class seeAlsoClass = seeAlsoMapping.get(Fnv.hashCode64(typeName));
+                    if (seeAlsoClass != null) {
+                        autoTypeObjectReader = context.getObjectReader(seeAlsoClass);
                     }
+                }
+                if (autoTypeObjectReader == null) {
+                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
+                }
+                if (autoTypeObjectReader == null) {
+                    throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -247,35 +252,31 @@ final class ObjectReaderSeeAlso<T>
                     && ((((features3 = (features | getFeatures() | context.getFeatures())) & JSONReader.Feature.SupportAutoType.mask) != 0) || autoTypeFilter != null)
             ) {
                 ObjectReader reader = null;
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
 
                 Number typeNumber = null;
                 String typeNumberStr = null;
-                if (typeHash == -1 && jsonReader.isNumber()) {
+                if (jsonReader.isNumber()) {
                     typeNumber = jsonReader.readNumber();
                     typeNumberStr = typeNumber.toString();
-                    typeHash = Fnv.hashCode64(typeNumberStr);
                 }
-                if (autoTypeFilter != null) {
-                    Class<?> filterClass = autoTypeFilter.apply(typeHash, objectClass, features3);
-                    if (filterClass == null) {
-                        filterClass = autoTypeFilter.apply(jsonReader.getString(), objectClass, features3);
-                        if (filterClass != null) {
-                            reader = context.getObjectReader(filterClass);
-                        }
+
+                String typeName = typeNumberStr != null ? typeNumberStr : jsonReader.getString();
+                if (seeAlsoMapping != null && seeAlsoMapping.size() > 0) {
+                    Class seeAlsoClass = seeAlsoMapping.get(Fnv.hashCode64(typeName));
+                    if (seeAlsoClass != null) {
+                        reader = context.getObjectReader(seeAlsoClass);
                     }
                 }
 
-                String typeName = null;
-                if (reader == null) {
-                    reader = autoType(context, typeHash);
-                    if (reader != null && hash != HASH_TYPE) {
-                        typeName = jsonReader.getString();
+                if (reader == null && autoTypeFilter != null) {
+                    Class<?> filterClass = autoTypeFilter.apply(typeName, objectClass, features3);
+                    if (filterClass != null) {
+                        reader = context.getObjectReader(filterClass);
                     }
                 }
 
                 if (reader == null) {
-                    typeName = jsonReader.getString();
                     reader = context.getObjectReaderAutoType(
                             typeName, objectClass, features3
                     );

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -1,8 +1,11 @@
 package com.alibaba.fastjson2.autoType;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
 import com.alibaba.fastjson2.reader.ObjectReaderProvider;
 import com.alibaba.fastjson2.util.Fnv;
@@ -26,6 +29,7 @@ public class AutoTypeValidationTest {
     static final String PACKAGE_PREFIX = "com.alibaba.fastjson2.autoType.";
     static final String TEST_BEAN = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean";
     static final String TEST_CLASS_LOADER = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestClassLoader";
+    static final String UNAUTHORIZED_TYPE = "com.example.Unauthorized";
     static final String TEST_DATA_SOURCE = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestDataSource";
 
     // =========================================================================
@@ -364,6 +368,144 @@ public class AutoTypeValidationTest {
     }
 
     @Test
+    public void testParseHashCacheDoesNotBypassTypeNameValidation() {
+        String typeName = "jar:http://127.0.0.1/evil.jar!/Evil";
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(typeName),
+                provider.getObjectReader(TestBean.class)
+        );
+
+        AtomicReference<String> requested = new AtomicReference<>();
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader recording = new ClassLoader(contextClassLoader) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                requested.set(name);
+                return super.loadClass(name);
+            }
+        };
+
+        try {
+            Thread.currentThread().setContextClassLoader(recording);
+            Object object = JSON.parseObject(
+                    "{\"@type\":\"" + typeName + "\",\"id\":123}",
+                    Object.class,
+                    JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+            );
+            assertInstanceOf(Map.class, object);
+            assertNull(requested.get(), "invalid type name must not reach the class loader");
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    @Test
+    public void testParseHashCacheDoesNotBypassDenyClassCheck() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(TEST_CLASS_LOADER),
+                provider.getObjectReader(TestClassLoader.class)
+        );
+
+        JSONReader.Context context = JSONFactory.createReadContext(
+                provider,
+                JSONReader.Feature.SupportAutoType
+        );
+        assertThrows(JSONException.class, () -> JSON.parseObject(
+                "{\"@type\":\"" + TEST_CLASS_LOADER + "\"}",
+                Object.class,
+                context
+        ));
+    }
+
+    @Test
+    public void testParseHashCacheRequiresMatchingTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(TEST_BEAN),
+                provider.getObjectReader(String.class)
+        );
+
+        TestBean bean = (TestBean) JSON.parseObject(
+                "{\"@type\":\"" + TEST_BEAN + "\",\"id\":123}",
+                Object.class,
+                JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+        );
+        assertEquals(123, bean.id);
+    }
+
+    @Test
+    public void testParseJSONBHashCacheRequiresMatchingTypeName() {
+        TestBean bean = new TestBean();
+        bean.id = 123;
+        byte[] jsonb = JSONB.toBytes(bean, JSONWriter.Feature.WriteClassName);
+
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(TEST_BEAN),
+                provider.getObjectReader(String.class)
+        );
+
+        try (JSONReader jsonReader = JSONReader.ofJSONB(
+                jsonb,
+                JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+        )) {
+            TestBean parsed = (TestBean) jsonReader.readAny();
+            assertEquals(123, parsed.id);
+        }
+    }
+
+    @Test
+    public void testConcreteBeanHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, OneFieldBean.class, provider);
+        assertFalse(SideEffect.created, "concrete bean hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testInterfaceHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, TestInterface.class, provider);
+        assertFalse(SideEffect.created, "interface hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testNoDefaultConstructorHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, NoDefaultBean.class, provider);
+        assertFalse(SideEffect.created, "no-default-constructor hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testExceptionHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, TestException.class, provider);
+        assertFalse(SideEffect.created, "exception hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testJSONBEmbeddedHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+        byte[] jsonb = embeddedTypedJsonb(UNAUTHORIZED_TYPE);
+
+        try {
+            JSONB.parseObject(jsonb, TestInterface.class, JSONFactory.createReadContext(provider));
+        } catch (JSONException ignored) {
+        }
+        assertFalse(SideEffect.created, "JSONB embedded @type hash cache hit must not authorize reader");
+    }
+
+    @Test
     public void testDenyPrefixOnlyRejectionIsDistinguishable() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
         long features = JSONReader.Feature.SupportAutoType.mask;
@@ -378,6 +520,71 @@ public class AutoTypeValidationTest {
         JSONException prefixOnly = assertThrows(JSONException.class, () ->
                 provider.checkAutoType(TEST_CLASS_LOADER, null, features));
         assertTrue(prefixOnly.getMessage().contains("add the type name in full to accept"));
+    }
+
+    static ObjectReaderProvider registerSideEffect(String typeName) {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(typeName),
+                provider.getObjectReader(SideEffect.class)
+        );
+        return provider;
+    }
+
+    static void parseTextIgnoreError(String typeName, Class<?> expectClass, ObjectReaderProvider provider) {
+        try {
+            JSON.parseObject(
+                    "{\"@type\":\"" + typeName + "\",\"id\":1}",
+                    expectClass,
+                    JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+            );
+        } catch (JSONException ignored) {
+        }
+    }
+
+    static byte[] embeddedTypedJsonb(String typeName) {
+        byte[] typeNameField = JSONB.toBytes("@type");
+        byte[] typeNameValue = JSONB.toBytes(typeName);
+        byte[] idField = JSONB.toBytes("id");
+        byte[] bytes = new byte[1 + typeNameField.length + typeNameValue.length + idField.length + 5 + 1];
+        int off = 0;
+        bytes[off++] = JSONB.Constants.BC_OBJECT;
+        System.arraycopy(typeNameField, 0, bytes, off, typeNameField.length);
+        off += typeNameField.length;
+        System.arraycopy(typeNameValue, 0, bytes, off, typeNameValue.length);
+        off += typeNameValue.length;
+        System.arraycopy(idField, 0, bytes, off, idField.length);
+        off += idField.length;
+        off = JSONB.IO.writeInt32(bytes, off, 1);
+        bytes[off++] = JSONB.Constants.BC_OBJECT_END;
+        return Arrays.copyOf(bytes, off);
+    }
+
+    public interface TestInterface {
+    }
+
+    public static class TestException
+            extends RuntimeException {
+    }
+
+    public static class SideEffect {
+        static volatile boolean created;
+
+        public SideEffect() {
+            created = true;
+        }
+    }
+
+    public static class OneFieldBean {
+        public int id;
+    }
+
+    public static class NoDefaultBean {
+        public final int id;
+
+        public NoDefaultBean(int id) {
+            this.id = id;
+        }
     }
 
     public static class TestBean {

--- a/safemode-test/src/test/java/com/alibaba/fastjson2/SafeModeTest.java
+++ b/safemode-test/src/test/java/com/alibaba/fastjson2/SafeModeTest.java
@@ -1,5 +1,7 @@
 package com.alibaba.fastjson2;
 
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.util.Fnv;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -19,6 +21,56 @@ public class SafeModeTest {
     }
 
     public static class Bean {
+    }
+
+    public static class OneFieldBean {
+        public int id;
+    }
+
+    public static class SideEffect {
+        static volatile boolean created;
+
+        public SideEffect() {
+            created = true;
+        }
+    }
+
+    @Test
+    public void testHashCacheDoesNotBypassSafeMode() {
+        String typeName = Bean.class.getName();
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(typeName),
+                provider.getObjectReader(Bean.class)
+        );
+
+        Object object = JSON.parseObject(
+                "{\"@type\":\"" + typeName + "\"}",
+                Object.class,
+                JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+        );
+        assertInstanceOf(Map.class, object);
+    }
+
+    @Test
+    public void testConcreteBeanHashCacheDoesNotBypassSafeMode() {
+        String unauthorized = "com.example.Unauthorized";
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(unauthorized),
+                provider.getObjectReader(SideEffect.class)
+        );
+
+        SideEffect.created = false;
+        try {
+            JSON.parseObject(
+                    "{\"@type\":\"" + unauthorized + "\",\"id\":1}",
+                    OneFieldBean.class,
+                    JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+            );
+        } catch (JSONException ignored) {
+        }
+        assertFalse(SideEffect.created);
     }
 
     @Test


### PR DESCRIPTION
## Summary

AutoType type resolution must not treat an FNV-64 hash-cache hit as authorization. This change removes all hash-only AutoType dispatch paths from untrusted input and requires the real `@type` string to pass the existing provider security checks.

- Replace hash-first AutoType lookups with real type-name resolution.
- Keep explicit `SeeAlso` local mapping behavior for compatibility.
- Add regression tests for concrete beans, interfaces, exceptions, no-default-constructor, JSONB embedded `@type`, and SafeMode.

## Validation

- `./mvnw -pl core -Dtest=com.alibaba.fastjson2.autoType.AutoTypeValidationTest,com.alibaba.fastjson2.v1issues.Issue1233,com.alibaba.fastjson2.v1issues.issue_1200.Issue1233 test`
- `./mvnw -pl safemode-test -am -Dtest=com.alibaba.fastjson2.SafeModeTest,com.alibaba.fastjson2.issues_1500.Issue1503S -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl core,safemode-test -am test`
- `./mvnw validate`

---

<details>
<summary>中文说明</summary>

AutoType 类型解析不应将 FNV-64 哈希缓存命中视为授权。本次修改移除不可信输入中的所有纯哈希 AutoType 分发路径，要求真实 `@type` 字符串经过现有 provider 安全检查。

- 将哈希优先的 AutoType 查询改为按真实类型名解析。
- 保留显式 `SeeAlso` 局部映射以兼容既有行为。
- 补充具体 bean、接口、异常、无默认构造、JSONB 内嵌 `@type` 与 SafeMode 回归测试。

</details>