### PR TITLE
fix: skip whitespace after Base64 string in readBase64, for issue #7751

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -7684,6 +7684,10 @@ class JSONReaderUTF8
         offset = index + 1;
 
         ch = offset == end ? EOI : (char) bytes[offset++];
+        while (ch <= ' ' && (1L << ch & SPACE) != 0) {
+            ch = offset == end ? EOI : bytes[offset++];
+        }
+
         if (comma = ch == ',') {
             ch = offset == end ? EOI : bytes[offset++];
             while (ch <= ' ' && (1L << ch & SPACE) != 0) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7751.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7751.java
@@ -1,0 +1,115 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7751 {
+    static final byte[] HELLO_WORLD = "hello world".getBytes(StandardCharsets.UTF_8);
+    static final String BASE64 = "aGVsbG8gd29ybGQ=";
+
+    @Test
+    public void testCompact() {
+        String json = "{\"data\":\"" + BASE64 + "\"}";
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    @Test
+    public void testTrailingNewline() {
+        String json = "{\"data\":\"" + BASE64 + "\"\n}";
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    @Test
+    public void testTrailingSpace() {
+        String json = "{\"data\":\"" + BASE64 + "\" }";
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    @Test
+    public void testTrailingTab() {
+        String json = "{\"data\":\"" + BASE64 + "\"\t}";
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    @Test
+    public void testPrettyJson() {
+        String json = "{\n\t\"data\":\"" + BASE64 + "\"\n}";
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    @Test
+    public void testPrettyJsonGetterSetter() {
+        String json = "{\n\t\"data\":\"" + BASE64 + "\"\n}";
+        Bean data = JSON.parseObject(json, Bean.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.getData());
+    }
+
+    @Test
+    public void testGlobalConfig() {
+        JSON.config(JSONReader.Feature.Base64StringAsByteArray);
+        try {
+            String json = "{\n\t\"data\":\"" + BASE64 + "\"\n}";
+            Bean data = JSON.parseObject(json, Bean.class);
+            assertArrayEquals(HELLO_WORLD, data.getData());
+        } finally {
+            JSON.config(JSONReader.Feature.Base64StringAsByteArray, false);
+        }
+    }
+
+    @Test
+    public void testPrettyFormatRoundTrip() {
+        TestData origin = new TestData();
+        origin.data = HELLO_WORLD;
+        String json = JSON.toJSONString(origin,
+                JSONWriter.Feature.WriteByteArrayAsBase64,
+                JSONWriter.Feature.PrettyFormat);
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+        assertEquals(11, data.data.length);
+    }
+
+    @Test
+    public void testUtf8Bytes() {
+        String json = "{\n\t\"data\":\"" + BASE64 + "\"\n}";
+        TestData data = JSON.parseObject(
+                json.getBytes(StandardCharsets.UTF_8),
+                TestData.class,
+                JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    @Test
+    public void testLeadingWhitespaceOk() {
+        String json = "{\n\t\"data\":\"" + BASE64 + "\"}";
+        TestData data = JSON.parseObject(json, TestData.class, JSONReader.Feature.Base64StringAsByteArray);
+        assertArrayEquals(HELLO_WORLD, data.data);
+    }
+
+    public static class TestData {
+        public byte[] data;
+    }
+
+    public static class Bean {
+        private byte[] data;
+
+        public byte[] getData() {
+            return data;
+        }
+
+        public void setData(byte[] data) {
+            this.data = data;
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #7751 

开启 JSONReader.Feature.Base64StringAsByteArray 后，byte[] 字段若以 Base64 字符串反序列化， 且字符串结束引号后紧跟空白（空格 / 换行 / Tab，如 PrettyFormat 输出），会抛出 JSONException: illegal fieldName。紧凑 JSON（值后直接跟 } / ,）正常。

该回归自 2.0.58 引入：JSONReaderUTF8#readBase64（436db2bbc，optimize for #3528） 新增快路径时，结束引号后只在遇到 , 时跳空白，缺少与 readString() 相同的前置空白跳过逻辑。

### Summary of your change

在 JSONReaderUTF8#readBase64 中，逗号判断前补充与 readString() 一致的空白跳过： while (ch <= ' ' && (1L << ch & SPACE) != 0)。 
新增 Issue7751 用例

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
