### PR TITLE
fix(core): honor fastjson2.properties when -D system property is absent

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONFactory.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONFactory.java
@@ -165,66 +165,23 @@ public final class JSONFactory {
     static {
         Properties properties = Conf.DEFAULT_PROPERTIES;
         {
-            String property = System.getProperty("fastjson2.creator");
-            if (property != null) {
-                property = property.trim();
-            }
-
-            if (property == null || property.isEmpty()) {
-                property = properties.getProperty("fastjson2.creator");
-                if (property != null) {
-                    property = property.trim();
-                }
-            }
-
+            String property = resolveProperty(properties, "fastjson2.creator");
             CREATOR = property == null ? "asm" : property;
         }
         {
-            boolean disableReferenceDetect0 = false,
-                    disableArrayMapping0 = false,
-                    disableJSONB0 = false,
-                    disableAutoType0 = false,
-                    disableSmartMatch0 = false;
-            String features = System.getProperty("fastjson2.features");
-            if (features == null) {
-                features = getProperty("fastjson2.features");
-            }
-            if (features != null) {
-                for (String feature : features.split(",")) {
-                    switch (feature) {
-                        case "disableReferenceDetect":
-                            disableReferenceDetect0 = true;
-                            break;
-                        case "disableArrayMapping":
-                            disableArrayMapping0 = true;
-                            break;
-                        case "disableJSONB":
-                            disableJSONB0 = true;
-                            break;
-                        case "disableAutoType":
-                            disableAutoType0 = true;
-                            break;
-                        case "disableSmartMatch":
-                            disableSmartMatch0 = true;
-                            break;
-                        default:
-                            break;
-                    }
-                }
-            }
-
-            disableReferenceDetect = disableReferenceDetect0;
-            disableArrayMapping = disableArrayMapping0;
-            disableJSONB = disableJSONB0;
-            disableAutoType = disableAutoType0;
-            disableSmartMatch = disableSmartMatch0;
+            String features = resolveProperty(properties, "fastjson2.features");
+            disableReferenceDetect = featureEnabled(features, "disableReferenceDetect");
+            disableArrayMapping = featureEnabled(features, "disableArrayMapping");
+            disableJSONB = featureEnabled(features, "disableJSONB");
+            disableAutoType = featureEnabled(features, "disableAutoType");
+            disableSmartMatch = featureEnabled(features, "disableSmartMatch");
         }
 
         useJacksonAnnotation = getPropertyBool(properties, "fastjson2.useJacksonAnnotation", true);
         useGsonAnnotation = getPropertyBool(properties, "fastjson2.useGsonAnnotation", true);
         defaultWriterAlphabetic = getPropertyBool(properties, "fastjson2.writer.alphabetic", true);
         defaultSkipTransient = getPropertyBool(properties, "fastjson2.writer.skipTransient", true);
-        defaultMaxLevel = getPropertyInt(properties, "fastjson2.writer.maxLevel", 2048);
+        defaultMaxLevel = validMaxLevel(getPropertyInt(properties, "fastjson2.writer.maxLevel", 2048));
         PropertyAccessorFactory propertyAccessorFactory = null;
         if (JDKUtils.JVM_VERSION >= 11) {
             try {
@@ -241,26 +198,71 @@ public final class JSONFactory {
         PROPERTY_ACCESSOR_FACTORY = propertyAccessorFactory;
     }
 
-    private static boolean getPropertyBool(Properties properties, String name, boolean defaultValue) {
-        boolean propertyValue = defaultValue;
-
+    /**
+     * Resolves a configuration value: the {@code -D} system property wins when set
+     * (after trimming), otherwise the {@code fastjson2.properties} entry is used,
+     * otherwise {@code null}. An empty or blank value, from either source, counts
+     * as unset and resolves to {@code null}, so an entry like {@code key=} behaves
+     * like an absent one. Shared by the {@code fastjson2.creator} and
+     * {@code fastjson2.features} initializers, {@link #getPropertyBool} and
+     * {@link #getPropertyInt} so the resolution order cannot drift between them.
+     */
+    private static String resolveProperty(Properties properties, String name) {
         String property = System.getProperty(name);
         if (property != null) {
             property = property.trim();
-            if (property.isEmpty()) {
-                property = properties.getProperty(name);
-                if (property != null) {
-                    property = property.trim();
-                }
+        }
+        if (property == null || property.isEmpty()) {
+            property = properties.getProperty(name);
+            if (property != null) {
+                property = property.trim();
             }
-            if (defaultValue) {
-                if ("false".equals(property)) {
-                    propertyValue = false;
-                }
+        }
+        return property == null || property.isEmpty() ? null : property;
+    }
+
+    /**
+     * Checks whether a comma-separated feature list (e.g. {@code fastjson2.features})
+     * names {@code feature}. Tokens are trimmed, so whitespace around the separator
+     * is tolerated; unknown tokens are ignored.
+     */
+    static boolean featureEnabled(String features, String feature) {
+        if (features == null || features.isEmpty()) {
+            return false;
+        }
+        for (String part : features.split(",")) {
+            if (part.trim().equals(feature)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Coerces a non-positive {@code fastjson2.writer.maxLevel} to the default
+     * {@code 2048}: {@link #setDefaultMaxLevel} rejects it as well, and a frozen
+     * non-positive level would make every serialization throw at the first
+     * {@code startObject}.
+     */
+    static int validMaxLevel(int maxLevel) {
+        if (maxLevel <= 0) {
+            System.err.println("fastjson2: invalid value for fastjson2.writer.maxLevel: " + maxLevel + ", using default 2048");
+            return 2048;
+        }
+        return maxLevel;
+    }
+
+    private static boolean getPropertyBool(Properties properties, String name, boolean defaultValue) {
+        boolean propertyValue = defaultValue;
+
+        String property = resolveProperty(properties, name);
+        if (property != null) {
+            if ("true".equals(property)) {
+                propertyValue = true;
+            } else if ("false".equals(property)) {
+                propertyValue = false;
             } else {
-                if ("true".equals(property)) {
-                    propertyValue = true;
-                }
+                System.err.println("fastjson2: invalid value for " + name + ": " + property + ", using default " + defaultValue);
             }
         }
 
@@ -270,20 +272,13 @@ public final class JSONFactory {
     private static int getPropertyInt(Properties properties, String name, int defaultValue) {
         int propertyValue = defaultValue;
 
-        String property = System.getProperty(name);
+        String property = resolveProperty(properties, name);
         if (property != null) {
-            property = property.trim();
-            if (property.isEmpty()) {
-                property = properties.getProperty(name);
-                if (property != null) {
-                    property = property.trim();
-                }
+            try {
+                propertyValue = Integer.parseInt(property);
+            } catch (NumberFormatException ignored) {
+                System.err.println("fastjson2: invalid value for " + name + ": " + property + ", using default " + defaultValue);
             }
-        }
-        try {
-            propertyValue = Integer.parseInt(property);
-        } catch (NumberFormatException ignored) {
-            // ignore
         }
 
         return propertyValue;

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7757.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7757.java
@@ -1,0 +1,235 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSONFactory;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("regression")
+public class Issue7757 {
+    // A fastjson2.properties value must be honored even when the matching -D
+    // system property is absent. The helpers run only in the JSONFactory static
+    // initializer, so they are exercised directly here for a deterministic result.
+    // The property names are test-local on purpose: clearing a real production
+    // key could race the JSONFactory class initialization and freeze the flags
+    // with the user's -D overrides discarded; the helpers take the key as a
+    // parameter, so the exercised code path is the same.
+
+    private static boolean getPropertyBool(Properties properties, String name, boolean defaultValue) throws Exception {
+        Method method = JSONFactory.class.getDeclaredMethod("getPropertyBool", Properties.class, String.class, boolean.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, properties, name, defaultValue);
+    }
+
+    private static int getPropertyInt(Properties properties, String name, int defaultValue) throws Exception {
+        Method method = JSONFactory.class.getDeclaredMethod("getPropertyInt", Properties.class, String.class, int.class);
+        method.setAccessible(true);
+        return (int) method.invoke(null, properties, name, defaultValue);
+    }
+
+    private static String resolveProperty(Properties properties, String name) throws Exception {
+        Method method = JSONFactory.class.getDeclaredMethod("resolveProperty", Properties.class, String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(null, properties, name);
+    }
+
+    private static boolean featureEnabled(String features, String feature) throws Exception {
+        Method method = JSONFactory.class.getDeclaredMethod("featureEnabled", String.class, String.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(null, features, feature);
+    }
+
+    private static int validMaxLevel(int maxLevel) throws Exception {
+        Method method = JSONFactory.class.getDeclaredMethod("validMaxLevel", int.class);
+        method.setAccessible(true);
+        return (int) method.invoke(null, maxLevel);
+    }
+
+    @Test
+    public void booleanFromPropertiesFile() throws Exception {
+        String name = "fastjson2.test.issue7757.bool";
+        String previous = System.clearProperty(name);
+        try {
+            // System property absent: the properties file value is honored.
+            Properties properties = new Properties();
+            properties.setProperty(name, "false");
+            assertFalse(getPropertyBool(properties, name, true));
+            properties.setProperty(name, "true");
+            assertTrue(getPropertyBool(properties, name, false));
+
+            // Absent from both system property and properties file -> default.
+            Properties empty = new Properties();
+            assertTrue(getPropertyBool(empty, name, true));
+            assertFalse(getPropertyBool(empty, name, false));
+
+            // A padded properties file value is trimmed before parsing.
+            properties.setProperty(name, " false ");
+            assertFalse(getPropertyBool(properties, name, true));
+
+            // A non-empty -D system property wins over the properties file.
+            properties.setProperty(name, "false");
+            System.setProperty(name, " true ");
+            assertTrue(getPropertyBool(properties, name, false));
+
+            // An empty/blank -D system property still falls back to the file.
+            System.setProperty(name, " ");
+            assertFalse(getPropertyBool(properties, name, true));
+
+            // An unrecognized file value keeps the default.
+            properties.setProperty(name, "not-a-boolean");
+            assertFalse(getPropertyBool(properties, name, false));
+            assertTrue(getPropertyBool(properties, name, true));
+
+            // An empty or blank file entry counts as unset: the default is used.
+            properties.setProperty(name, "");
+            assertTrue(getPropertyBool(properties, name, true));
+            properties.setProperty(name, " ");
+            assertFalse(getPropertyBool(properties, name, false));
+
+            // An unrecognized -D value keeps the default as well.
+            System.setProperty(name, "not-a-boolean");
+            assertFalse(getPropertyBool(properties, name, false));
+        } finally {
+            if (previous != null) {
+                System.setProperty(name, previous);
+            } else {
+                System.clearProperty(name);
+            }
+        }
+    }
+
+    @Test
+    public void intFromPropertiesFile() throws Exception {
+        String name = "fastjson2.test.issue7757.int";
+        String previous = System.clearProperty(name);
+        try {
+            // System property absent: the properties file value is honored.
+            Properties properties = new Properties();
+            properties.setProperty(name, "512");
+            assertEquals(512, getPropertyInt(properties, name, 2048));
+
+            // A padded properties file value is trimmed before parsing
+            // (Properties.load keeps trailing whitespace).
+            properties.setProperty(name, "512 ");
+            assertEquals(512, getPropertyInt(properties, name, 2048));
+
+            // Absent from both -> default.
+            Properties empty = new Properties();
+            assertEquals(2048, getPropertyInt(empty, name, 2048));
+
+            // A non-empty -D system property wins over the properties file.
+            System.setProperty(name, " 4096 ");
+            assertEquals(4096, getPropertyInt(properties, name, 2048));
+
+            // An empty/blank -D system property still falls back to the file.
+            System.setProperty(name, " ");
+            assertEquals(512, getPropertyInt(properties, name, 2048));
+
+            // A malformed file value falls back to the default.
+            properties.setProperty(name, "not-a-number");
+            assertEquals(2048, getPropertyInt(properties, name, 2048));
+
+            // An empty file entry counts as unset: the default is used.
+            properties.setProperty(name, "");
+            assertEquals(2048, getPropertyInt(properties, name, 2048));
+        } finally {
+            if (previous != null) {
+                System.setProperty(name, previous);
+            } else {
+                System.clearProperty(name);
+            }
+        }
+    }
+
+    @Test
+    public void featureListTokensAreTrimmed() throws Exception {
+        // fastjson2.features tokens are trimmed, so a comma-space list enables
+        // every named flag; null, empty, blank and unknown tokens enable nothing.
+        String features = "disableSmartMatch, disableAutoType";
+        assertTrue(featureEnabled(features, "disableSmartMatch"));
+        assertTrue(featureEnabled(features, "disableAutoType"));
+        assertFalse(featureEnabled(features, "disableReferenceDetect"));
+
+        assertTrue(featureEnabled(" disableSmartMatch , unknown ", "disableSmartMatch"));
+        assertFalse(featureEnabled(" disableSmartMatch , unknown ", "disableAutoType"));
+
+        assertFalse(featureEnabled(null, "disableAutoType"));
+        assertFalse(featureEnabled("", "disableAutoType"));
+        assertFalse(featureEnabled(" , ", "disableAutoType"));
+
+        // Tokens match exactly: a longer token that contains or extends a real
+        // feature name enables nothing.
+        assertFalse(featureEnabled("disableAutoTypeExtra", "disableAutoType"));
+        assertFalse(featureEnabled("disableSmartMatch2", "disableSmartMatch"));
+        assertFalse(featureEnabled("disableAutoTypeExtra, disableJSONB", "disableAutoType"));
+        assertTrue(featureEnabled("disableAutoTypeExtra, disableAutoType", "disableAutoType"));
+    }
+
+    @Test
+    public void featuresResolvedFromPropertiesFile() throws Exception {
+        String name = "fastjson2.test.issue7757.features";
+        String previous = System.clearProperty(name);
+        try {
+            // A file entry keeps its trailing whitespace; resolution trims the
+            // whole value and each token, so the spaced list enables both flags.
+            Properties properties = new Properties();
+            properties.setProperty(name, "disableSmartMatch, disableAutoType ");
+            String features = resolveProperty(properties, name);
+            assertTrue(featureEnabled(features, "disableSmartMatch"));
+            assertTrue(featureEnabled(features, "disableAutoType"));
+
+            // An empty/blank -D system property still falls back to the file.
+            System.setProperty(name, " ");
+            features = resolveProperty(properties, name);
+            assertTrue(featureEnabled(features, "disableAutoType"));
+        } finally {
+            if (previous != null) {
+                System.setProperty(name, previous);
+            } else {
+                System.clearProperty(name);
+            }
+        }
+    }
+
+    @Test
+    public void emptyValuesCountAsUnset() throws Exception {
+        String name = "fastjson2.test.issue7757.empty";
+        String previous = System.clearProperty(name);
+        try {
+            // An empty or blank file entry resolves to null, like an absent
+            // entry, instead of surfacing "" to the leaf helpers.
+            Properties properties = new Properties();
+            properties.setProperty(name, "");
+            assertNull(resolveProperty(properties, name));
+            properties.setProperty(name, " ");
+            assertNull(resolveProperty(properties, name));
+
+            // A blank -D system property with no file entry resolves to null too.
+            System.setProperty(name, " ");
+            assertNull(resolveProperty(new Properties(), name));
+        } finally {
+            if (previous != null) {
+                System.setProperty(name, previous);
+            } else {
+                System.clearProperty(name);
+            }
+        }
+    }
+
+    @Test
+    public void maxLevelIsValidated() throws Exception {
+        // A parseable but non-positive maxLevel falls back to the 2048 default;
+        // positive values pass through unchanged.
+        assertEquals(2048, validMaxLevel(0));
+        assertEquals(2048, validMaxLevel(-1));
+        assertEquals(1, validMaxLevel(1));
+        assertEquals(512, validMaxLevel(512));
+    }
+}


### PR DESCRIPTION
AI 披露：本改动由 AI 编码代理辅助完成，我已逐行审改。

## What

`JSONFactory.getPropertyBool` / `getPropertyInt` now honor a value declared in `fastjson2.properties` even when the matching `-D` system property is not set. Previously such a value was silently ignored.

## Why

A user putting `fastjson2.useJacksonAnnotation=false` in `src/main/resources/fastjson2.properties` (no `-D` flag, e.g. to scope the setting to one WAR in a shared-JVM deployment) found it had no effect — the library kept the default `true`. Closes #7757.

## Root cause

Both helpers read the system property first and only fell back to the `fastjson2.properties` `Properties` when it was set to an **empty** string:

```java
String property = System.getProperty(name);
if (property != null) {            // outer guard
    property = property.trim();
    if (property.isEmpty()) {      // only empty string reaches the file
        property = properties.getProperty(name);
        ...
    }
    ...
}
```

When the system property is **absent** (`null`) — the common case — the outer `if (property != null)` skips the block entirely, so the properties file is never consulted and the default is returned.

The `fastjson2.creator` resolution block right above (line 173) already implements the intended behavior — fall back when the system property is `null` **or** empty:

```java
if (property == null || property.isEmpty()) {
    property = properties.getProperty(name);
    ...
}
```

## How

Align `getPropertyBool` and `getPropertyInt` with that existing pattern. This also fixes the same latent bug for the other configs that share these helpers: `fastjson2.useGsonAnnotation`, `fastjson2.writer.alphabetic`, `fastjson2.writer.skipTransient`, and `fastjson2.writer.maxLevel`. The `-D` system property still wins when set (non-empty), preserving existing behavior.

Config values that cannot be used are reported instead of silently dropped: a malformed int or a bool other than `true`/`false` prints a one-line `System.err` diagnostic and keeps the default, and `fastjson2.writer.maxLevel <= 0` (parseable, but `setDefaultMaxLevel` rejects it as well) falls back to `2048` instead of freezing an unusable level at class initialization.

## Testing

- New `Issue7757` (regression): drives the helpers directly (they otherwise run only in the static initializer) and asserts the file value wins when the `-D` property is absent, the `-D` value wins when set, blank values fall back to the file, padded values are trimmed, malformed int / unrecognized bool values keep the default, and `fastjson2.features` tokens are trimmed.
- Verified the test **fails on the original code** (`expected: <false> but was: <true>`, `expected: <512> but was: <2048>`) and **passes after the fix**; the new fallback cases fail under mutation (catch removed → `NumberFormatException` escapes; unrecognized-bool branch flipped).
- Fresh-JVM probe with a classpath `fastjson2.properties` (`fastjson2.writer.maxLevel=0`): pre-fix `getDefaultMaxLevel()=0` and `toJSONString` throws `JSONException: level too large : 1`; post-fix `2048` and serialization OK with the diagnostic on stderr.

<details>
<summary>中文说明</summary>

## 问题

`JSONFactory.getPropertyBool` / `getPropertyInt` 在未设置对应 `-D` 系统参数时，不再读取 `fastjson2.properties` 中的配置，导致其中的设置被静默忽略。

## 背景

在 `src/main/resources/fastjson2.properties` 中设置 `fastjson2.useJacksonAnnotation=false`（不带 `-D`，例如多应用共享 JVM 时只让某一个 WAR 生效）实际不生效，库仍使用默认值 `true`。对应 #7757。

## 根因

两个 helper 先读系统参数，仅当其值为**空串**时才回退读 `fastjson2.properties`。当系统参数**不存在**（`null`，最常见情形）时，外层 `if (property != null)` 直接跳过整块，从不读配置文件，返回默认值。其上方 `fastjson2.creator` 的解析块（173 行）已是正确写法（`null` 或空串都回退）。

## 修复

让两个 helper 与该既有写法对齐。同时修好了共用这两个 helper 的其它配置（`useGsonAnnotation`、`writer.alphabetic`、`writer.skipTransient`、`writer.maxLevel`）的相同隐患。系统参数非空时仍优先生效，行为不变。

无法使用的配置值不再被静默丢弃：malformed 整数与 `true`/`false` 之外的布尔值会打印一行 `System.err` 诊断并保留默认值；`fastjson2.writer.maxLevel <= 0`（可解析，但 `setDefaultMaxLevel` 同样拒绝）回退 `2048`，不再把不可用值冻结进静态初始化器。

## 测试

- 新增 `Issue7757`（regression）：直接驱动各 helper（它们否则只在静态块里跑一次），断言系统参数缺失时配置文件值生效、非空 `-D` 优先、空白 `-D` 回退文件、带空白值被 trim、malformed 整数 / 无法识别布尔值保留默认、`fastjson2.features` 逐 token trim。
- 已验证测试在**修复前失败**、**修复后通过**；新增回退用例在变异下失败（删 catch → `NumberFormatException` 逸出；翻转无法识别布尔分支 → 断言失败）。
- fresh-JVM 探针（classpath 放 `fastjson2.properties` 且 `fastjson2.writer.maxLevel=0`）：修复前 `getDefaultMaxLevel()=0`、`toJSONString` 抛 `JSONException: level too large : 1`；修复后 `2048`、序列化正常且 stderr 出现诊断行。

</details>

Fixes #7757
