### PR TITLE
perf: detect illegal autoType type name chars while scanning them

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -150,6 +150,7 @@ public abstract class JSONReader
     protected int nameBegin;
 
     protected boolean nameEscape;
+    protected boolean typeNameIllegal;
     protected boolean valueEscape;
     protected boolean wasNull;
     protected boolean boolValue;
@@ -1619,6 +1620,22 @@ public abstract class JSONReader
      */
     public long readTypeHashCode() {
         return readValueHashCode();
+    }
+
+    /**
+     * Returns whether the type name scanned by the last {@link #readTypeHashCode()} call
+     * contains a character that cannot appear in a Java binary class name ({@code ':'} or
+     * {@code '!'}), making it illegal for autoType. Detecting this during the scan lets
+     * callers reject the type name without materializing and re-scanning it.
+     *
+     * <p>The result is conservative: it is only set when the scan saw the raw type name
+     * bytes or chars, so escaped or symbol-referenced names report false and are still
+     * validated by the downstream checks.
+     *
+     * @return true if the last scanned type name contains {@code ':'} or {@code '!'}
+     */
+    public final boolean isTypeNameIllegal() {
+        return typeNameIllegal;
     }
 
     /**
@@ -6798,6 +6815,11 @@ public abstract class JSONReader
      * @return An ObjectReader for the specified type, or null if not found
      */
     public ObjectReader getObjectReaderAutoType(long typeHash, Class expectClass, long features) {
+        if (typeNameIllegal
+                && context.autoTypeBeforeHandler == null
+                && context.provider.getAutoTypeBeforeHandler() == null) {
+            return null;
+        }
         return context.getObjectReaderAutoType(getString(), expectClass, context.features | features);
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1317,7 +1317,10 @@ final class JSONReaderJSONB
                 autoTypeError();
             }
 
-            autoTypeObjectReader = context.provider.getObjectReader(getString(), expectClass, features2);
+            autoTypeObjectReader = typeNameIllegal
+                    && context.provider.getAutoTypeBeforeHandler() == null
+                    ? null
+                    : context.provider.getObjectReader(getString(), expectClass, features2);
             if (autoTypeObjectReader == null) {
                 if ((features2 & Feature.ErrorOnNotSupportAutoType.mask) == 0) {
                     return null;
@@ -1672,6 +1675,8 @@ final class JSONReaderJSONB
                 this.strBegin = strBegin;
                 this.strlen = typelen;
                 this.offset = offset;
+                this.typeNameIllegal = typelen < 192
+                        && IOUtils.containsTypeNameSpecialChar(bytes, strBegin, strBegin + typelen);
 
                 return hashCode;
             }
@@ -1680,6 +1685,7 @@ final class JSONReaderJSONB
     }
 
     public long readTypeHashCode0() {
+        typeNameIllegal = false;
         final byte[] bytes = this.bytes;
         byte strtype = this.strtype = bytes[offset];
         if (strtype == BC_SYMBOL) {
@@ -1788,6 +1794,17 @@ final class JSONReaderJSONB
             strBegin = offset;
         } else {
             throw readStringError();
+        }
+
+        // scan-time illegal type name detection; exact for single-byte encodings, since ':'
+        // and '!' never appear inside a multibyte UTF-8 sequence. UTF-16 variants, symbol
+        // references and names at or above the 192 limit stay conservative and are
+        // validated downstream
+        if (strlen < 192
+                && (strtype == BC_STR_UTF8
+                || strtype == BC_STR_ASCII
+                || (strtype >= BC_STR_ASCII_FIX_MIN && strtype <= BC_STR_ASCII_FIX_MAX))) {
+            typeNameIllegal = IOUtils.containsTypeNameSpecialChar(bytes, strBegin, strBegin + strlen);
         }
 
         long hashCode;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -1668,6 +1668,18 @@ final class JSONReaderUTF16
         return readValueHashCode0();
     }
 
+    @Override
+    public long readTypeHashCode() {
+        long hashCode = readValueHashCode();
+        // a name at or above the 192 limit stays conservative and keeps the downstream
+        // length error
+        typeNameIllegal = hashCode != -1
+                && !nameEscape
+                && nameEnd - nameBegin < 192
+                && IOUtils.containsTypeNameSpecialChar(chars, nameBegin, nameEnd);
+        return hashCode;
+    }
+
     public final long readValueHashCode0() {
         final char quote = ch;
         if (quote != '"' && quote != '\'') {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -2809,6 +2809,18 @@ class JSONReaderUTF8
         return nameHashCode;
     }
 
+    @Override
+    public long readTypeHashCode() {
+        long hashCode = readValueHashCode();
+        // gate on the byte length; the char length is never larger, so a name at or above
+        // the 192 limit stays conservative and keeps the downstream length error
+        typeNameIllegal = hashCode != -1
+                && !nameEscape
+                && nameEnd - nameBegin < 192
+                && IOUtils.containsTypeNameSpecialChar(bytes, nameBegin, nameEnd);
+        return hashCode;
+    }
+
     private long readValueHashCode0() {
         int ch = this.ch;
         if (ch != '"' && ch != '\'') {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -248,14 +248,20 @@ public class ObjectReaderAdapter<T>
 
         ObjectReader autoTypeObjectReader = null;
         if (jsonReader.isSupportAutoTypeOrHandler(featuresAll)) {
-            String typeName = jsonReader.getString();
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, featuresAll);
+            if (jsonReader.isTypeNameIllegal()
+                    && context.getContextAutoTypeBeforeHandler() == null
+                    && context.getProvider().getAutoTypeBeforeHandler() == null) {
+                // an illegal type name is unresolvable, the same as the provider returning null
+            } else {
+                String typeName = jsonReader.getString();
+                autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, featuresAll);
+            }
 
             if (autoTypeObjectReader == null) {
                 if (expectClass == objectClass) {
                     autoTypeObjectReader = this;
                 } else {
-                    throw new JSONException(jsonReader.info("autoType not support : " + typeName));
+                    throw new JSONException(jsonReader.info("autoType not support : " + jsonReader.getString()));
                 }
             }
         }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
@@ -176,10 +176,10 @@ public abstract class ObjectReaderBean<T>
         JSONReader.Context context = jsonReader.getContext();
         long features3 = jsonReader.features(features | this.features);
         JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
-        String typeName = jsonReader.getString();
 
         ObjectReader autoTypeObjectReader;
         if (autoTypeFilter != null) {
+            String typeName = jsonReader.getString();
             Class<?> filterClass = autoTypeFilter.apply(typeName, expectClass, features);
 
             if (filterClass != null && !expectClass.isAssignableFrom(filterClass)) {
@@ -191,7 +191,11 @@ public abstract class ObjectReaderBean<T>
             }
 
             autoTypeObjectReader = context.getObjectReader(filterClass);
+        } else if (jsonReader.isTypeNameIllegal()
+                && context.getProvider().getAutoTypeBeforeHandler() == null) {
+            throw auotypeError(jsonReader);
         } else {
+            String typeName = jsonReader.getString();
             autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, features3);
 
             if (autoTypeObjectReader == null) {

--- a/core/src/main/java/com/alibaba/fastjson2/util/IOUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/IOUtils.java
@@ -2451,6 +2451,88 @@ public class IOUtils {
     }
 
     /**
+     * Checks whether a byte array region contains a character that cannot appear in a Java
+     * binary class name but is meaningful in a URL: {@code ':'} (0x3A) or {@code '!'} (0x21).
+     * Used to reject autoType type names while scanning them, see
+     * {@link TypeUtils#hasIllegalTypeNameChars(String)}.
+     *
+     * @param buf the byte array to check
+     * @param off the starting offset in the array
+     * @param end the end offset (exclusive)
+     * @return true if the region contains {@code ':'} or {@code '!'}
+     */
+    public static boolean containsTypeNameSpecialChar(byte[] buf, int off, int end) {
+        int i = off;
+        long address = ARRAY_BYTE_BASE_OFFSET + off;
+        int upperBound = off + ((end - off) & ~7);
+        while (i < upperBound
+                && notContains2(UNSAFE.getLong(buf, address), 0x3A3A3A3A3A3A3A3AL, 0x2121212121212121L)) {
+            i += 8;
+            address += 8;
+        }
+        while (i < end) {
+            byte b = buf[i++];
+            if (b == ':' || b == '!') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean notContains2(long value, long v0, long v1) {
+        long x0 = value ^ v0;
+        long x1 = value ^ v1;
+        return ((((x0 - 0x0101010101010101L) & ~x0) | ((x1 - 0x0101010101010101L) & ~x1)) & 0x8080808080808080L) == 0;
+    }
+
+    /**
+     * Checks whether a char array region contains a character that cannot appear in a Java
+     * binary class name but is meaningful in a URL: {@code ':'} or {@code '!'}.
+     * Used to reject autoType type names while scanning them, see
+     * {@link TypeUtils#hasIllegalTypeNameChars(String)}.
+     *
+     * @param buf the char array to check
+     * @param off the starting offset in the array
+     * @param end the end offset (exclusive)
+     * @return true if the region contains {@code ':'} or {@code '!'}
+     */
+    public static boolean containsTypeNameSpecialChar(char[] buf, int off, int end) {
+        int i = off;
+        long address = ARRAY_CHAR_BASE_OFFSET + ((long) off << 1);
+        int upperBound = off + ((end - off) & ~3);
+        while (i < upperBound
+                && notContains2UTF16(UNSAFE.getLong(buf, address), 0x003A_003A_003A_003AL, 0x0021_0021_0021_0021L)) {
+            i += 4;
+            address += 8;
+        }
+        while (i < end) {
+            char c = buf[i++];
+            if (c == ':' || c == '!') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean notContains2UTF16(long value, long v0, long v1) {
+        /*
+          for (int i = 0; i < 4; ++i) {
+            short c = (short) value;
+            if (c == (short) v0 || c == (short) v1) {
+                return false;
+            }
+            value >>>= 16;
+          }
+          return true;
+         */
+        long x0 = value ^ v0;
+        long x1 = value ^ v1;
+        x0 = (x0 - 0x0001_0001_0001_0001L) & ~x0;
+        x1 = (x1 - 0x0001_0001_0001_0001L) & ~x1;
+        return ((x0 | x1) & 0x8000_8000_8000_8000L) == 0;
+    }
+
+    /**
      * Checks if a byte array region matches a prefix string.
      * This method compares a segment of a byte array with a string prefix to see
      * if they match exactly.

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeIllegalTypeNameTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeIllegalTypeNameTest.java
@@ -1,0 +1,270 @@
+package com.alibaba.fastjson2.autoType;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.SymbolTable;
+import com.alibaba.fastjson2.util.IOUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the scan-time detection of illegal autoType type name characters
+ * ({@code ':'} and {@code '!'}), see {@link JSONReader#isTypeNameIllegal()}.
+ */
+@Tag("autotype")
+public class AutoTypeIllegalTypeNameTest {
+    static final String BEAN_NAME = "com.alibaba.fastjson2.autoType.AutoTypeIllegalTypeNameTest$Bean";
+
+    // =========================================================================
+    // IOUtils.containsTypeNameSpecialChar boundary coverage
+    // =========================================================================
+
+    @Test
+    public void testContainsTypeNameSpecialCharBytes() {
+        for (int len = 1; len <= 33; len++) {
+            byte[] buf = new byte[len];
+            for (int pos = 0; pos < len; pos++) {
+                Arrays.fill(buf, (byte) 'a');
+
+                buf[pos] = ':';
+                assertTrue(IOUtils.containsTypeNameSpecialChar(buf, 0, len), "len=" + len + ", pos=" + pos);
+
+                buf[pos] = '!';
+                assertTrue(IOUtils.containsTypeNameSpecialChar(buf, 0, len), "len=" + len + ", pos=" + pos);
+
+                // near-miss characters around ':' (0x3A) and '!' (0x21)
+                for (byte b : new byte[] {'9', ';', ' ', '"', '@', '/', (byte) 0x80, (byte) 0xFF}) {
+                    buf[pos] = b;
+                    assertFalse(IOUtils.containsTypeNameSpecialChar(buf, 0, len), "len=" + len + ", pos=" + pos + ", b=" + b);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testContainsTypeNameSpecialCharChars() {
+        for (int len = 1; len <= 17; len++) {
+            char[] buf = new char[len];
+            for (int pos = 0; pos < len; pos++) {
+                Arrays.fill(buf, 'a');
+
+                buf[pos] = ':';
+                assertTrue(IOUtils.containsTypeNameSpecialChar(buf, 0, len), "len=" + len + ", pos=" + pos);
+
+                buf[pos] = '!';
+                assertTrue(IOUtils.containsTypeNameSpecialChar(buf, 0, len), "len=" + len + ", pos=" + pos);
+
+                for (char c : new char[] {'9', ';', ' ', '"', '@', '/', 0x3A00, 0x2100, 0xFF3A, 0xFF01}) {
+                    buf[pos] = c;
+                    assertFalse(IOUtils.containsTypeNameSpecialChar(buf, 0, len), "len=" + len + ", pos=" + pos + ", c=" + (int) c);
+                }
+            }
+        }
+    }
+
+    // =========================================================================
+    // readTypeHashCode scan-time detection, one test per reader implementation
+    // =========================================================================
+
+    @Test
+    public void testDetectUtf8() {
+        assertFalse(readTypeNameIllegalUtf8("com.example.Bean"));
+        assertTrue(readTypeNameIllegalUtf8("com.example.Bean:bad"));
+        assertTrue(readTypeNameIllegalUtf8("com.example.Bean!bad"));
+        assertTrue(readTypeNameIllegalUtf8(":com.example.Bean"));
+        assertTrue(readTypeNameIllegalUtf8("com.example.Bean:"));
+        assertTrue(readTypeNameIllegalUtf8("a:b"));
+        // multibyte characters never alias the raw bytes of ':' or '!'
+        assertFalse(readTypeNameIllegalUtf8("com.example.Bean中"));
+        assertTrue(readTypeNameIllegalUtf8("com.example.Bean中:bad"));
+    }
+
+    @Test
+    public void testDetectAscii() {
+        assertFalse(readTypeNameIllegalOfString("com.example.Bean"));
+        assertTrue(readTypeNameIllegalOfString("com.example.Bean:bad"));
+        assertTrue(readTypeNameIllegalOfString("com.example.Bean!bad"));
+        assertTrue(readTypeNameIllegalOfString("a!b"));
+    }
+
+    @Test
+    public void testDetectUtf16() {
+        assertFalse(readTypeNameIllegalUtf16("com.example.Bean"));
+        assertTrue(readTypeNameIllegalUtf16("com.example.Bean:bad"));
+        assertTrue(readTypeNameIllegalUtf16("com.example.Bean!bad"));
+        assertTrue(readTypeNameIllegalUtf16(":com.example.Bean"));
+        assertTrue(readTypeNameIllegalUtf16("com.example.Bean!"));
+    }
+
+    private static boolean readTypeNameIllegalUtf8(String typeName) {
+        JSONReader reader = JSONReader.of(quote(typeName).getBytes(StandardCharsets.UTF_8));
+        reader.readTypeHashCode();
+        return reader.isTypeNameIllegal();
+    }
+
+    private static boolean readTypeNameIllegalOfString(String typeName) {
+        JSONReader reader = JSONReader.of(quote(typeName));
+        reader.readTypeHashCode();
+        return reader.isTypeNameIllegal();
+    }
+
+    private static boolean readTypeNameIllegalUtf16(String typeName) {
+        JSONReader reader = JSONReader.of(quote(typeName).toCharArray());
+        reader.readTypeHashCode();
+        return reader.isTypeNameIllegal();
+    }
+
+    private static String quote(String typeName) {
+        return '"' + typeName + '"';
+    }
+
+    /**
+     * Escaped characters are not seen by the scan-time check; the type name is still
+     * rejected downstream after unescaping.
+     */
+    @Test
+    public void testEscapedSpecialCharNotFlagged() {
+        JSONReader reader = JSONReader.of("\"com.example.Bean\\u003Abad\"");
+        reader.readTypeHashCode();
+        assertFalse(reader.isTypeNameIllegal());
+        assertEquals("com.example.Bean:bad", reader.getString());
+    }
+
+    // =========================================================================
+    // JSONB
+    // =========================================================================
+
+    @Test
+    public void testDetectJsonb() {
+        assertTrue(readTypeNameIllegalJsonb("com.example.Bean:bad"));
+        assertTrue(readTypeNameIllegalJsonb("com.example.Bean!bad"));
+        assertFalse(readTypeNameIllegalJsonb("com.example.Bean"));
+    }
+
+    private static boolean readTypeNameIllegalJsonb(String typeName) {
+        byte[] jsonbBytes = writeJsonbTypedObject(typeName);
+        JSONReader reader = JSONReader.ofJSONB(jsonbBytes);
+        assertTrue(reader.nextIfMatch(JSONB.Constants.BC_TYPED_ANY));
+        reader.readTypeHashCode();
+        return reader.isTypeNameIllegal();
+    }
+
+    private static byte[] writeJsonbTypedObject(String typeName) {
+        SymbolTable symbolTable = JSONB.symbolTable("abc");
+        JSONWriter.Context writeContext = JSONFactory.createWriteContext(JSONWriter.Feature.WriteNameAsSymbol);
+        JSONWriter writer = JSONWriter.ofJSONB(writeContext, symbolTable);
+        writer.writeTypeName(typeName);
+        writer.startObject();
+        writer.endObject();
+        return writer.getBytes();
+    }
+
+    @Test
+    public void testJsonbCheckAutoTypeIllegalName() {
+        byte[] jsonbBytes = writeJsonbTypedObject("com.example.Bean:bad");
+
+        JSONReader reader = JSONReader.ofJSONB(jsonbBytes);
+        assertNull(reader.checkAutoType(Object.class, 0, JSONReader.Feature.SupportAutoType.mask));
+
+        JSONReader reader2 = JSONReader.ofJSONB(jsonbBytes);
+        assertThrows(JSONException.class, () -> reader2.checkAutoType(
+                Object.class,
+                0,
+                JSONReader.Feature.SupportAutoType.mask | JSONReader.Feature.ErrorOnNotSupportAutoType.mask));
+    }
+
+    /**
+     * Short type names (up to 8 bytes) take the conservative path in JSONB and are
+     * still rejected by the downstream validation.
+     */
+    @Test
+    public void testJsonbCheckAutoTypeShortIllegalName() {
+        byte[] jsonbBytes = writeJsonbTypedObject("A:B");
+        JSONReader reader = JSONReader.ofJSONB(jsonbBytes);
+        assertNull(reader.checkAutoType(Object.class, 0, JSONReader.Feature.SupportAutoType.mask));
+    }
+
+    // =========================================================================
+    // end-to-end behaviour of typed bean reads
+    // =========================================================================
+
+    /**
+     * A type name carrying {@code ':'} is unresolvable, so a typed bean read falls back
+     * to the expected class and keeps reading, the same as before the scan-time check.
+     */
+    @Test
+    public void testTypedBeanIllegalNameFallsBack() {
+        String json = "{\"@type\":\"com.example.Bean:bad\",\"id\":101}";
+        assertEquals(101, JSON.parseObject(json, Bean.class, JSONReader.Feature.SupportAutoType).id);
+        assertEquals(101, JSON.parseObject(json.getBytes(StandardCharsets.UTF_8), Bean.class, JSONReader.Feature.SupportAutoType).id);
+        assertEquals(101, JSON.parseObject(json.toCharArray(), Bean.class, JSONReader.Feature.SupportAutoType).id);
+    }
+
+    /**
+     * An escaped {@code ':'} slips past the scan-time check and must take the downstream
+     * validation path, which rejects it the same way.
+     */
+    @Test
+    public void testTypedBeanEscapedIllegalNameFallsBack() {
+        String json = "{\"@type\":\"com.example.Bean\\u003Abad\",\"id\":101}";
+        assertEquals(101, JSON.parseObject(json, Bean.class, JSONReader.Feature.SupportAutoType).id);
+    }
+
+    /**
+     * Names at or above the 192 length limit keep the downstream length error even when
+     * they also carry an illegal character.
+     */
+    @Test
+    public void testLongIllegalNameKeepsLengthError() {
+        StringBuilder sb = new StringBuilder("{\"@type\":\"");
+        for (int i = 0; i < 199; i++) {
+            sb.append('a');
+        }
+        sb.append(":\"}");
+        String json = sb.toString();
+        JSONException e = assertThrows(JSONException.class,
+                () -> JSON.parseObject(json, Bean.class, JSONReader.Feature.SupportAutoType));
+        assertTrue(e.getMessage().contains("autoType is not support"));
+    }
+
+    /**
+     * A user-provided AutoTypeBeforeHandler still receives illegal type names and may
+     * resolve them; the scan-time check must not bypass the handler.
+     */
+    @Test
+    public void testCustomHandlerStillReceivesIllegalName() {
+        String json = "{\"@type\":\"custom:Bean\",\"id\":101}";
+        JSONReader.AutoTypeBeforeHandler handler = (typeName, expectClass, features) -> {
+            if ("custom:Bean".equals(typeName)) {
+                return Bean.class;
+            }
+            return null;
+        };
+
+        JSONReader.Context context = JSONFactory.createReadContext(handler, JSONReader.Feature.SupportAutoType);
+        Bean bean = JSON.parseObject(json, Bean.class, context);
+        assertEquals(101, bean.id);
+    }
+
+    @Test
+    public void testTypedBeanLegalNameNotAffected() {
+        String json = "{\"@type\":\"" + BEAN_NAME + "\",\"id\":101}";
+        Bean bean = JSON.parseObject(json, Bean.class, JSONReader.Feature.SupportAutoType);
+        assertEquals(101, bean.id);
+        assertEquals(101, JSON.parseObject(json.getBytes(StandardCharsets.UTF_8), Bean.class, JSONReader.Feature.SupportAutoType).id);
+        assertEquals(101, JSON.parseObject(json.toCharArray(), Bean.class, JSONReader.Feature.SupportAutoType).id);
+    }
+
+    public static class Bean {
+        public int id;
+    }
+}


### PR DESCRIPTION
### Motivation

Since #7753 (rejecting hash-cache hits), every text autoType occurrence goes through the full string-based authorization. A type name carrying `:` or `!` is rejected by `hasIllegalTypeNameChars` (two `String.indexOf` scans) — but only after the string has been materialized via `getString()` and re-scanned. For malicious or JSON-LD payloads (`@type` is a JSON-LD keyword whose IRI value always carries `:`), all of that work is spent on a name that will never resolve.

### Changes

- `IOUtils.containsTypeNameSpecialChar(byte[]/char[], off, end)`: SWAR detection of `!` (0x21) and `:` (0x3A), 8 bytes per lane / 4 chars per lane, following the existing `indexOfSlashV` / `containsSlashOrQuoteUTF16` idioms.
- `JSONReader.typeNameIllegal` / `isTypeNameIllegal()`: set by `readTypeHashCode()` overrides in `JSONReaderUTF8` (inherited by `JSONReaderASCII`), `JSONReaderUTF16` and `JSONReaderJSONB` (long-form ASCII fast path plus the direct-string branches of `readTypeHashCode0`).
- Early reject at the reader-adjacent consult points only: `ObjectReaderBean.checkAutoType0`, `ObjectReaderAdapter.autoType` (the ASM text path), `JSONReaderJSONB.checkAutoType` and `JSONReader.getObjectReaderAutoType(long, Class, long)`. When the flag is set they skip `getString()` and the provider lookup and produce exactly the unresolvable outcome the provider would return.
- The flag is conservative: escaped names, JSONB symbol references, UTF-16 strings and names at or above the 192-char limit are not flagged and keep the existing downstream behaviour (including the 192-char length error). Consult points also require both the context-level and the provider-level `AutoTypeBeforeHandler` to be null, so custom handlers still receive and may resolve illegal type names, exactly as before.
- All downstream checks (`hasIllegalTypeNameChars` in the provider, handlers and `loadClass`) stay as defense in depth.

### Benchmark (JDK 26, local)

Parsing `{"@type":"...","id":101}` into the expected bean with `SupportAutoType`:

| case | baseline | this change |
|---|---|---|
| legal type name | 87.9 ns/op | 97.6 ns/op (+10 ns) |
| illegal name (`jar:http://evil/x.jar!/Bad`) | 85.3 ns/op | 79.6 ns/op (−5.7 ns, early reject) |

Note: fusing the detection into `readValueHashCode`'s existing `isASCII` pass was tried and measured slower (+16.6 ns on the legal case), so the wrapper approach was kept.

### Tests

New `AutoTypeIllegalTypeNameTest` (14 cases): `IOUtils` boundary coverage (lengths 1–33 × every position × near-miss characters around 0x21/0x3A), per-reader detection, escaped names falling back to downstream validation, the 192-char length error kept, custom handlers still resolving illegal names, JSON-LD map fallback. Full core suite passes (7988 tests), checkstyle clean, safemode-test 4/4.

<details>
<summary>中文</summary>

### 动机

#7753 拒绝 hash-cache 命中后，文本路径每次 autoType 解析都走完整的字符串授权。类型名中的 `:` 或 `!` 会被 `hasIllegalTypeNameChars`（两次 `String.indexOf` 扫描）拒绝，但此前字符串已经通过 `getString()` 物化并重新扫描。对于恶意构造或 JSON-LD 载荷（`@type` 是 JSON-LD 关键字，IRI 值必含 `:`），这些开销全部花在注定无法解析的名字上。

### 改动

- `IOUtils.containsTypeNameSpecialChar(byte[]/char[], off, end)`：SWAR 检测 `!`（0x21）与 `:`（0x3A），8 字节/lane、4 字符/lane，沿用 `indexOfSlashV` / `containsSlashOrQuoteUTF16` 的既有写法。
- `JSONReader.typeNameIllegal` / `isTypeNameIllegal()`：在 `JSONReaderUTF8`（`JSONReaderASCII` 继承）、`JSONReaderUTF16`、`JSONReaderJSONB`（长格式 ASCII 快路径 + `readTypeHashCode0` 直接字符串分支）的 `readTypeHashCode()` 覆盖中设置。
- 仅在 reader 相邻的消费点提前拒绝：`ObjectReaderBean.checkAutoType0`、`ObjectReaderAdapter.autoType`（ASM 文本路径）、`JSONReaderJSONB.checkAutoType`、`JSONReader.getObjectReaderAutoType(long, Class, long)`。标记命中时跳过 `getString()` 与 provider 查找，结果与 provider 返回 null 完全一致。
- 标记是保守的：转义名、JSONB symbol 引用、UTF-16 字符串、≥192 字符的名字不标记，下游行为（包括 192 长度异常）原样保留；消费点同时要求 context 级与 provider 级 `AutoTypeBeforeHandler` 均为 null，自定义 handler 仍能收到并解析非法类型名，与之前完全一致。
- 下游所有检查（provider、handler、`loadClass` 中的 `hasIllegalTypeNameChars`）保留，作为防御纵深。

### 性能（JDK 26，本机）

将 `{"@type":"...","id":101}` 解析为期望 Bean，开启 `SupportAutoType`：

| 场景 | 基线 | 本次改动 |
|---|---|---|
| 合法类型名 | 87.9 ns/op | 97.6 ns/op（+10 ns） |
| 非法名（`jar:http://evil/x.jar!/Bad`） | 85.3 ns/op | 79.6 ns/op（−5.7 ns，提前拒绝） |

注：尝试过把检测融合进 `readValueHashCode` 已有的 `isASCII` 扫描，实测反而更慢（合法场景 +16.6 ns），因此保留包装方案。

### 测试

新增 `AutoTypeIllegalTypeNameTest`（14 个用例）：`IOUtils` 全边界（长度 1–33 × 每个位置 × 0x21/0x3A 邻近字符）、各 reader 检测、转义名走下游兜底、192 长度错误保留、自定义 handler 仍可解析非法名、JSON-LD 回退。core 全量 7988 个测试通过；checkstyle 无违规；safemode-test 4/4。

</details>