### PR TITLE
fix: keep non-null wrapper defaults with NotWriteDefaultValue, for issue #7762

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterBool.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterBool.java
@@ -119,9 +119,6 @@ class FieldWriterBool<T>
     @Override
     public final void writeBool(JSONWriter jsonWriter, boolean value) {
         long features = jsonWriter.getFeatures(this.features);
-        if (!value && (features & Feature.NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return;
-        }
         if ((features & Feature.WriteNonStringValueAsString.mask) != 0) {
             writeFieldName(jsonWriter);
             jsonWriter.writeString(value ? "true" : "false");

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterChar.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterChar.java
@@ -77,9 +77,6 @@ class FieldWriterChar<T>
     }
 
     protected final boolean writeChar(JSONWriter jsonWriter, char value) {
-        if (value == '\0' && (jsonWriter.getFeatures(features) & Feature.NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return false;
-        }
         writeFieldName(jsonWriter);
         jsonWriter.writeChar(value);
         return true;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterDouble.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterDouble.java
@@ -78,9 +78,6 @@ class FieldWriterDouble<T>
 
     protected final void writeDoubleValue(JSONWriter jsonWriter, Double value, long features) {
         double doubleValue = value;
-        if (doubleValue == 0.0 && (features & Feature.NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return;
-        }
 
         writeFieldName(jsonWriter);
 

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterFloat.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterFloat.java
@@ -78,9 +78,6 @@ class FieldWriterFloat<T>
 
     protected final void writeFloatValue(JSONWriter jsonWriter, Float value, long features) {
         float floatValue = value;
-        if (floatValue == 0.0f && (features & Feature.NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return;
-        }
 
         writeFieldName(jsonWriter);
 

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt16.java
@@ -42,9 +42,6 @@ class FieldWriterInt16<T>
 
     protected final void writeInt16(JSONWriter jsonWriter, short value) {
         long features = jsonWriter.getFeatures(this.features);
-        if (value == 0 && (features & Feature.NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return;
-        }
         boolean writeNonStringValueAsString = (features & Feature.WriteNonStringValueAsString.mask) != 0;
         if (writeNonStringValueAsString) {
             writeFieldName(jsonWriter);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt32.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt32.java
@@ -50,10 +50,6 @@ class FieldWriterInt32<T>
 
     @Override
     public final void writeInt32(JSONWriter jsonWriter, int value) {
-        long features = jsonWriter.getFeatures() | this.features;
-        if (value == 0 && (features & MASK_NOT_WRITE_DEFAULT_VALUE) != 0 && defaultValue == null) {
-            return;
-        }
         if (toString) {
             writeFieldName(jsonWriter);
             jsonWriter.writeString(Integer.toString(value));

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt64.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt64.java
@@ -74,9 +74,6 @@ class FieldWriterInt64<T>
 
     public final void writeInt64(JSONWriter jsonWriter, long value) {
         long features = jsonWriter.getFeatures() | this.features;
-        if (value == 0 && (features & NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return;
-        }
         boolean writeAsString = (features & (WriteNonStringValueAsString.mask | WriteLongAsString.mask)) != 0;
         writeFieldName(jsonWriter);
         if (!writeAsString) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterInt8.java
@@ -73,9 +73,6 @@ class FieldWriterInt8<T>
 
     protected final boolean writeInt8(JSONWriter jsonWriter, byte value) {
         long features = jsonWriter.getFeatures(this.features);
-        if (value == 0 && (features & Feature.NotWriteDefaultValue.mask) != 0 && defaultValue == null) {
-            return false;
-        }
         boolean writeNonStringValueAsString = (features & Feature.WriteNonStringValueAsString.mask) != 0;
         writeFieldName(jsonWriter);
         if (writeNonStringValueAsString) {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7762.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7762.java
@@ -1,0 +1,189 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONFactory;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.writer.ObjectWriterCreator;
+import com.alibaba.fastjson2.writer.ObjectWriterCreatorASM;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7762 {
+    static final String WRAPPERS = "\"b\":false,\"by\":0,\"c\":\"\\u0000\",\"d\":0.0,\"f\":0.0,\"i\":0,\"l\":0,\"s\":0";
+
+    static Stream<ObjectWriterCreator> creators() {
+        return Stream.of(ObjectWriterCreatorASM.INSTANCE, ObjectWriterCreator.INSTANCE);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        JSONFactory.setContextWriterCreator(null);
+        JSONFactory.getDefaultObjectWriterProvider().clear();
+    }
+
+    @ParameterizedTest
+    @MethodSource("creators")
+    public void wrapperDefaultValueKept(ObjectWriterCreator creator) {
+        use(creator);
+        assertEquals(
+                "{" + WRAPPERS + "}",
+                JSON.toJSONString(zero(), JSONWriter.Feature.NotWriteDefaultValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("creators")
+    public void wrapperNullDiscarded(ObjectWriterCreator creator) {
+        use(creator);
+        assertEquals(
+                "{}",
+                JSON.toJSONString(new Bean(), JSONWriter.Feature.NotWriteDefaultValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("creators")
+    public void nonDefaultValueKept(ObjectWriterCreator creator) {
+        use(creator);
+        assertEquals(
+                "{\"b\":true,\"by\":1,\"c\":\"x\",\"d\":1.0,\"f\":1.0,\"i\":1,\"l\":1,"
+                        + "\"pb\":true,\"pby\":1,\"pc\":\"x\",\"pd\":1.0,\"pf\":1.0,\"pi\":1,\"pl\":1,\"ps\":1,\"s\":1}",
+                JSON.toJSONString(nonDefault(), JSONWriter.Feature.NotWriteDefaultValue));
+    }
+
+    @ParameterizedTest
+    @MethodSource("creators")
+    public void featureDisabled(ObjectWriterCreator creator) {
+        use(creator);
+        assertEquals(
+                "{\"b\":false,\"by\":0,\"c\":\"\\u0000\",\"d\":0.0,\"f\":0.0,\"i\":0,\"l\":0,"
+                        + "\"pb\":false,\"pby\":0,\"pc\":\"\\u0000\",\"pd\":0.0,\"pf\":0.0,\"pi\":0,\"pl\":0,\"ps\":0,\"s\":0}",
+                JSON.toJSONString(zero()));
+    }
+
+    static void use(ObjectWriterCreator creator) {
+        JSONFactory.setContextWriterCreator(creator);
+        JSONFactory.getDefaultObjectWriterProvider().clear();
+    }
+
+    /** wrapper fields hold the primitive default values, primitive fields are left at their defaults */
+    static Bean zero() {
+        Bean bean = new Bean();
+        bean.i = 0;
+        bean.l = 0L;
+        bean.d = 0D;
+        bean.f = 0F;
+        bean.b = false;
+        bean.s = (short) 0;
+        bean.by = (byte) 0;
+        bean.c = '\0';
+        return bean;
+    }
+
+    static Bean nonDefault() {
+        Bean bean = new Bean();
+        bean.i = 1;
+        bean.l = 1L;
+        bean.d = 1D;
+        bean.f = 1F;
+        bean.b = true;
+        bean.s = (short) 1;
+        bean.by = (byte) 1;
+        bean.c = 'x';
+        bean.pi = 1;
+        bean.pl = 1L;
+        bean.pd = 1D;
+        bean.pf = 1F;
+        bean.pb = true;
+        bean.ps = (short) 1;
+        bean.pby = (byte) 1;
+        bean.pc = 'x';
+        return bean;
+    }
+
+    public static class Bean {
+        private Integer i;
+        private Long l;
+        private Double d;
+        private Float f;
+        private Boolean b;
+        private Short s;
+        private Byte by;
+        private Character c;
+        private int pi;
+        private long pl;
+        private double pd;
+        private float pf;
+        private boolean pb;
+        private short ps;
+        private byte pby;
+        private char pc;
+
+        public Integer getI() {
+            return i;
+        }
+
+        public Long getL() {
+            return l;
+        }
+
+        public Double getD() {
+            return d;
+        }
+
+        public Float getF() {
+            return f;
+        }
+
+        public Boolean getB() {
+            return b;
+        }
+
+        public Short getS() {
+            return s;
+        }
+
+        public Byte getBy() {
+            return by;
+        }
+
+        public Character getC() {
+            return c;
+        }
+
+        public int getPi() {
+            return pi;
+        }
+
+        public long getPl() {
+            return pl;
+        }
+
+        public double getPd() {
+            return pd;
+        }
+
+        public float getPf() {
+            return pf;
+        }
+
+        public boolean isPb() {
+            return pb;
+        }
+
+        public short getPs() {
+            return ps;
+        }
+
+        public byte getPby() {
+            return pby;
+        }
+
+        public char getPc() {
+            return pc;
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

With `JSONWriter.Feature.NotWriteDefaultValue`, non-null wrapper fields that hold a primitive default value (e.g. Integer age = 0) were incorrectly omitted on the reflection writer path. This shows up when ASM falls back (for example, a foreign ClassLoader), and is inconsistent with the ASM path and with the intended semantics: only primitive defaults (and null wrappers) should be skipped. Fixes #7762.

### Summary of your change

Remove the zero/default-value skip from wrapper FieldWriter write helpers (Int32/Int64/Int16/Int8/Bool/Char/Float/Double); primitive *Value writers keep their own skip logic.
Add Issue7762 covering all 8 wrappers + 8 primitives, for both ASM and reflection creators, including null wrappers and feature-off baseline.

<details>

<summary>中文说明</summary>

### 这个 PR 做了什么 / 为什么需要它？

开启 NotWriteDefaultValue 时，反射路径会把包装类型的非 null 默认值（如 Integer age = 0）错误丢弃。自定义 ClassLoader 等场景回退到反射路径后即可复现，与 ASM 路径及预期语义不一致：应只跳过基本类型默认值（以及为 null 的包装类型）。修复 #7762。

### 改动摘要

从包装类型 FieldWriter 的写值方法中移除零值跳过；基本类型 *Value 子类仍保留自己的跳过逻辑。
新增 Issue7762：覆盖 8 种包装类型 + 8 种基本类型，ASM/反射双路径，并包含 null 包装与关闭 feature 的基线场景。

### 验证结果
mvn -pl core validate：通过
mvn -pl core test：7982 个测试全通过
mvn -pl fastjson1-compatible test：1355 个测试全通过

</details>

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
