### PR TITLE
fix: use createReadContext for string reparse in fastjson1-compatible, for issue #7765

### DIFF
--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSON.java
@@ -95,6 +95,10 @@ public abstract class JSON
         writerProvider.register(new Fastjson1xWriterModule(writerProvider));
     }
 
+    public static JSONReader.Context createReadContext(Feature... features) {
+        return createReadContext(JSONFactory.getDefaultObjectReaderProvider(), DEFAULT_PARSER_FEATURE, features);
+    }
+
     public static JSONReader.Context createReadContext(int featuresValue, Feature... features) {
         return createReadContext(JSONFactory.getDefaultObjectReaderProvider(), featuresValue, features);
     }

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -366,7 +366,7 @@ public class JSONArray
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext());
             if (objectReader == null) {
                 objectReader = reader.getObjectReader(JSONObject.class);
             }
@@ -794,7 +794,7 @@ public class JSONArray
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext());
             if (arrayReader == null) {
                 arrayReader = reader.getObjectReader(JSONArray.class);
             }
@@ -836,7 +836,7 @@ public class JSONArray
 
         String json = JSON.toJSONString(obj);
         ObjectReader objectReader = provider.getObjectReader(clazz);
-        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext());
 
         String defaultDateFormat = JSON.DEFAULT_DATE_FORMAT;
         if (!"yyyy-MM-dd HH:mm:ss".equals(defaultDateFormat)) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONArray.java
@@ -366,7 +366,7 @@ public class JSONArray
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str);
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
             if (objectReader == null) {
                 objectReader = reader.getObjectReader(JSONObject.class);
             }
@@ -794,7 +794,7 @@ public class JSONArray
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str);
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
             if (arrayReader == null) {
                 arrayReader = reader.getObjectReader(JSONArray.class);
             }
@@ -836,7 +836,7 @@ public class JSONArray
 
         String json = JSON.toJSONString(obj);
         ObjectReader objectReader = provider.getObjectReader(clazz);
-        JSONReader jsonReader = JSONReader.of(json);
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
 
         String defaultDateFormat = JSON.DEFAULT_DATE_FORMAT;
         if (!"yyyy-MM-dd HH:mm:ss".equals(defaultDateFormat)) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -144,7 +144,7 @@ public class JSONObject
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str);
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
             if (objectReader == null) {
                 objectReader = reader.getObjectReader(JSONObject.class);
             }
@@ -183,7 +183,7 @@ public class JSONObject
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str);
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
             if (arrayReader == null) {
                 arrayReader = reader.getObjectReader(JSONArray.class);
             }
@@ -280,7 +280,7 @@ public class JSONObject
 
         String json = JSON.toJSONString(obj);
         ObjectReader objectReader = provider.getObjectReader(type);
-        JSONReader jsonReader = JSONReader.of(json);
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
 
         String defaultDateFormat = JSON.DEFAULT_DATE_FORMAT;
         if (!"yyyy-MM-dd HH:mm:ss".equals(defaultDateFormat)) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONObject.java
@@ -144,7 +144,7 @@ public class JSONObject
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext());
             if (objectReader == null) {
                 objectReader = reader.getObjectReader(JSONObject.class);
             }
@@ -183,7 +183,7 @@ public class JSONObject
                 return null;
             }
 
-            JSONReader reader = JSONReader.of(str, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+            JSONReader reader = JSONReader.of(str, JSON.createReadContext());
             if (arrayReader == null) {
                 arrayReader = reader.getObjectReader(JSONArray.class);
             }
@@ -230,13 +230,7 @@ public class JSONObject
         }
 
         String json = JSON.toJSONString(obj);
-        JSONReader jsonReader = JSONReader.of(
-                json,
-                JSON.createReadContext(
-                        JSONFactory.getDefaultObjectReaderProvider(),
-                        JSON.DEFAULT_PARSER_FEATURE, features
-                )
-        );
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext(features));
 
         boolean fieldBased = jsonReader.getContext().isEnabled(JSONReader.Feature.FieldBased);
         ObjectReader objectReader = provider.getObjectReader(clazz, fieldBased);
@@ -280,7 +274,7 @@ public class JSONObject
 
         String json = JSON.toJSONString(obj);
         ObjectReader objectReader = provider.getObjectReader(type);
-        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext());
 
         String defaultDateFormat = JSON.DEFAULT_DATE_FORMAT;
         if (!"yyyy-MM-dd HH:mm:ss".equals(defaultDateFormat)) {
@@ -388,14 +382,7 @@ public class JSONObject
         }
 
         String json = JSON.toJSONString(obj);
-        JSONReader jsonReader = JSONReader.of(
-                json,
-                JSON.createReadContext(
-                        JSONFactory.getDefaultObjectReaderProvider(),
-                        DEFAULT_PARSER_FEATURE,
-                        features
-                )
-        );
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext(features));
 
         boolean fieldBased = jsonReader.getContext().isEnabled(JSONReader.Feature.FieldBased);
         ObjectReader objectReader = provider.getObjectReader(type, fieldBased);

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONPath.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONPath.java
@@ -37,7 +37,7 @@ public class JSONPath {
 
     public static <T> T read(String json, String path, Type clazz, ParserConfig parserConfig) {
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
-        JSONReader.Context context = JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE);
+        JSONReader.Context context = JSON.createReadContext();
         JSONReader jsonReader = JSONReader.of(json, context);
         Object r = jsonPath.extract(jsonReader);
         return TypeUtils.cast(r, clazz, parserConfig);
@@ -45,7 +45,7 @@ public class JSONPath {
 
     public static <T> T read(String json, String path, Type clazz) {
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
-        Object r = jsonPath.extract(JSONReader.of(json));
+        Object r = jsonPath.extract(JSONReader.of(json, JSON.createReadContext()));
         return TypeUtils.cast(r, clazz, ParserConfig.global);
     }
 
@@ -59,7 +59,7 @@ public class JSONPath {
 
     public static boolean set(Object rootObject, String path, Object value) {
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
-        jsonPath.setReaderContext(JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE));
+        jsonPath.setReaderContext(JSON.createReadContext());
         jsonPath.set(rootObject, value);
         return true;
     }
@@ -75,7 +75,7 @@ public class JSONPath {
 
     public static Object extract(String json, String path) {
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
-        JSONReader.Context context = JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE);
+        JSONReader.Context context = JSON.createReadContext();
         JSONReader jsonReader = JSONReader.of(json, context);
         Object result = jsonPath.extract(jsonReader);
         return JSON.adaptResult(result);
@@ -96,7 +96,7 @@ public class JSONPath {
     }
 
     public static Object read(String json, String path) {
-        JSONReader.Context context = JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE);
+        JSONReader.Context context = JSON.createReadContext();
         JSONReader jsonReader = JSONReader.of(json, context);
         com.alibaba.fastjson2.JSONPath jsonPath = com.alibaba.fastjson2.JSONPath.of(path);
         return jsonPath.extract(jsonReader);

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONReader.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/JSONReader.java
@@ -18,7 +18,7 @@ public class JSONReader
     }
 
     public JSONReader(Reader input, Feature... features) {
-        com.alibaba.fastjson2.JSONReader.Context context = JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE, features);
+        com.alibaba.fastjson2.JSONReader.Context context = JSON.createReadContext(features);
         this.raw = com.alibaba.fastjson2.JSONReader.of(input, context);
         this.input = input;
         for (int i = 0; i < features.length; i++) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/DefaultJSONParser.java
@@ -1,5 +1,6 @@
 package com.alibaba.fastjson.parser;
 
+import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson2.JSONReader;
@@ -18,7 +19,7 @@ public class DefaultJSONParser
     private Object input;
 
     public DefaultJSONParser(String text) {
-        this(JSONReader.of(text), ParserConfig.global);
+        this(JSONReader.of(text, JSON.createReadContext()), ParserConfig.global);
         this.input = text;
     }
 
@@ -34,7 +35,7 @@ public class DefaultJSONParser
     }
 
     public DefaultJSONParser(String text, ParserConfig config) {
-        this(JSONReader.of(text), config);
+        this(JSONReader.of(text, JSON.createReadContext()), config);
     }
 
     public DefaultJSONParser(JSONReader reader, ParserConfig config) {

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/parser/JSONScanner.java
@@ -25,7 +25,7 @@ public class JSONScanner
     }
 
     public JSONScanner(String str) {
-        this.reader = JSONReader.of(str);
+        this.reader = JSONReader.of(str, JSON.createReadContext());
         this.str = str;
     }
 

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/support/hsf/HSFJSONUtils.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/support/hsf/HSFJSONUtils.java
@@ -17,7 +17,7 @@ public class HSFJSONUtils {
     static final long HASH_ARGS_OBJS = Fnv.hashCode64("argsObjs");
 
     public static Object[] parseInvocationArguments(String json, MethodLocator methodLocator) {
-        JSONReader jsonReader = JSONReader.of(json);
+        JSONReader jsonReader = JSONReader.of(json, JSON.createReadContext());
 
         Method method = null;
         Object[] values;

--- a/fastjson1-compatible/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
+++ b/fastjson1-compatible/src/main/java/com/alibaba/fastjson/support/spring/FastJsonHttpMessageConverter.java
@@ -3,7 +3,6 @@ package com.alibaba.fastjson.support.spring;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONException;
 import com.alibaba.fastjson.support.config.FastJsonConfig;
-import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONPObject;
 import com.alibaba.fastjson2.JSONReader;
 import org.springframework.core.ResolvableType;
@@ -22,8 +21,6 @@ import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-
-import static com.alibaba.fastjson.JSON.DEFAULT_PARSER_FEATURE;
 
 /**
  * Fastjson for Spring MVC Converter.
@@ -128,11 +125,7 @@ public class FastJsonHttpMessageConverter
             }
             byte[] bytes = baos.toByteArray();
 
-            JSONReader.Context context = JSON.createReadContext(
-                    JSONFactory.getDefaultObjectReaderProvider(),
-                    DEFAULT_PARSER_FEATURE,
-                    fastJsonConfig.getFeatures()
-            );
+            JSONReader.Context context = JSON.createReadContext(fastJsonConfig.getFeatures());
 
             String dateFormat = fastJsonConfig.getDateFormat();
             if (dateFormat != null) {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7765.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7765.java
@@ -7,6 +7,7 @@ import com.alibaba.fastjson.JSONPath;
 import com.alibaba.fastjson.TypeReference;
 import com.alibaba.fastjson.parser.DefaultJSONParser;
 import com.alibaba.fastjson.parser.JSONScanner;
+import com.alibaba.fastjson.parser.ParserConfig;
 import com.alibaba.fastjson.support.hsf.HSFJSONUtils;
 import org.junit.jupiter.api.Test;
 
@@ -91,6 +92,13 @@ public class Issue7765 {
     @Test
     public void testDefaultJSONParserNestedContainerType() {
         Object parsed = new DefaultJSONParser("{\"inner\":{\"name\":\"alpha\"}}").parse();
+        assertEquals(JSONObject.class, parsed.getClass());
+        assertEquals(JSONObject.class, ((JSONObject) parsed).get("inner").getClass());
+    }
+
+    @Test
+    public void testDefaultJSONParserWithConfigNestedContainerType() {
+        Object parsed = new DefaultJSONParser("{\"inner\":{\"name\":\"alpha\"}}", ParserConfig.global).parse();
         assertEquals(JSONObject.class, parsed.getClass());
         assertEquals(JSONObject.class, ((JSONObject) parsed).get("inner").getClass());
     }

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7765.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7765.java
@@ -3,7 +3,11 @@ package com.alibaba.fastjson.v2issues;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.JSONPath;
 import com.alibaba.fastjson.TypeReference;
+import com.alibaba.fastjson.parser.DefaultJSONParser;
+import com.alibaba.fastjson.parser.JSONScanner;
+import com.alibaba.fastjson.support.hsf.HSFJSONUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -49,11 +53,14 @@ public class Issue7765 {
     }
 
     @Test
-    public void testGetJSONArrayFromArray() {
-        String json = "{\"items\":[{\"name\":\"alpha\"},{\"name\":\"beta\"}]}";
-        JSONArray items = JSON.parseObject(json).getJSONArray("items");
+    public void testGetJSONArrayFromEncodedStringCast() {
+        // reproduces issue #7765: elements from string reparse must be castable to fastjson1 JSONObject
+        String json = "{\"items\":\"[{\\\"name\\\":\\\"alpha\\\"},{\\\"name\\\":\\\"beta\\\"}]\"}";
+        Object[] elements = JSON.parseObject(json).getJSONArray("items").toArray();
 
-        assertEquals(JSONObject.class, items.toArray()[0].getClass());
+        JSONObject first = (JSONObject) elements[0];
+        assertEquals("alpha", first.getString("name"));
+        assertEquals(JSONObject.class, elements[1].getClass());
     }
 
     @Test
@@ -72,6 +79,49 @@ public class Issue7765 {
         Bean bean = array.getObject(0, Bean.class);
         assertEquals(JSONObject.class, bean.inner.getClass());
         assertEquals(JSONObject.class, bean.list.get(0).getClass());
+    }
+
+    @Test
+    public void testJSONPathReadNestedContainerType() {
+        Object data = JSONPath.read("{\"data\":{\"inner\":{\"name\":\"alpha\"}}}", "$.data", Object.class);
+        assertEquals(JSONObject.class, data.getClass());
+        assertEquals(JSONObject.class, ((JSONObject) data).get("inner").getClass());
+    }
+
+    @Test
+    public void testDefaultJSONParserNestedContainerType() {
+        Object parsed = new DefaultJSONParser("{\"inner\":{\"name\":\"alpha\"}}").parse();
+        assertEquals(JSONObject.class, parsed.getClass());
+        assertEquals(JSONObject.class, ((JSONObject) parsed).get("inner").getClass());
+    }
+
+    @Test
+    public void testJSONScannerNestedContainerType() {
+        Object parsed = new JSONScanner("{\"inner\":{\"name\":\"alpha\"}}").getReader().read(Object.class);
+        assertEquals(JSONObject.class, parsed.getClass());
+        assertEquals(JSONObject.class, ((JSONObject) parsed).get("inner").getClass());
+    }
+
+    @Test
+    public void testHSFJSONUtilsNestedContainerType() throws Exception {
+        String json = "{"
+                + "\"argsTypes\":[\"java.util.Map\"],"
+                + "\"argsObjs\":[{\"inner\":{\"name\":\"alpha\"}}]"
+                + "}";
+        Object[] args = HSFJSONUtils.parseInvocationArguments(
+                json,
+                types -> {
+                    try {
+                        return Issue7765.class.getMethod("acceptMap", Map.class);
+                    } catch (NoSuchMethodException e) {
+                        throw new IllegalStateException(e);
+                    }
+                }
+        );
+        assertEquals(JSONObject.class, ((Map<?, ?>) args[0]).get("inner").getClass());
+    }
+
+    public static void acceptMap(Map map) {
     }
 
     public static class Bean {

--- a/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7765.java
+++ b/fastjson1-compatible/src/test/java/com/alibaba/fastjson/v2issues/Issue7765.java
@@ -1,0 +1,81 @@
+package com.alibaba.fastjson.v2issues;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONArray;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.fastjson.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7765 {
+    @Test
+    public void testGetJSONArrayFromString() {
+        String json = "{\"items\":\"[{\\\"name\\\":\\\"alpha\\\"},[1,2]]\"}";
+        JSONArray items = JSON.parseObject(json).getJSONArray("items");
+
+        Object[] elements = items.toArray();
+        assertEquals(JSONObject.class, elements[0].getClass());
+        assertEquals(JSONArray.class, elements[1].getClass());
+        assertEquals(JSONObject.class, items.iterator().next().getClass());
+    }
+
+    @Test
+    public void testGetJSONObjectFromString() {
+        String json = "{\"item\":\"{\\\"inner\\\":{\\\"name\\\":\\\"alpha\\\"},\\\"list\\\":[1]}\"}";
+        JSONObject item = JSON.parseObject(json).getJSONObject("item");
+
+        for (Map.Entry<String, Object> entry : item.entrySet()) {
+            Class<?> expected = "inner".equals(entry.getKey()) ? JSONObject.class : JSONArray.class;
+            assertEquals(expected, entry.getValue().getClass());
+        }
+    }
+
+    @Test
+    public void testArrayGetJSONArrayFromString() {
+        JSONArray array = JSON.parseArray("[\"[{\\\"name\\\":\\\"alpha\\\"}]\"]");
+
+        assertEquals(JSONObject.class, array.getJSONArray(0).toArray()[0].getClass());
+    }
+
+    @Test
+    public void testArrayGetJSONObjectFromString() {
+        JSONArray array = JSON.parseArray("[\"{\\\"inner\\\":{\\\"name\\\":\\\"alpha\\\"}}\"]");
+
+        assertEquals(JSONObject.class, array.getJSONObject(0).values().iterator().next().getClass());
+    }
+
+    @Test
+    public void testGetJSONArrayFromArray() {
+        String json = "{\"items\":[{\"name\":\"alpha\"},{\"name\":\"beta\"}]}";
+        JSONArray items = JSON.parseObject(json).getJSONArray("items");
+
+        assertEquals(JSONObject.class, items.toArray()[0].getClass());
+    }
+
+    @Test
+    public void testGetObjectByTypeReference() {
+        JSONObject root = JSON.parseObject("{\"v\":{\"inner\":{\"name\":\"alpha\"},\"list\":[1]}}");
+
+        Map<String, Object> value = root.getObject("v", new TypeReference<Map<String, Object>>() {});
+        assertEquals(JSONObject.class, value.get("inner").getClass());
+        assertEquals(JSONArray.class, value.get("list").getClass());
+    }
+
+    @Test
+    public void testArrayGetObjectByBeanClass() {
+        JSONArray array = JSON.parseArray("[{\"inner\":{\"name\":\"alpha\"},\"list\":[{\"name\":\"beta\"}]}]");
+
+        Bean bean = array.getObject(0, Bean.class);
+        assertEquals(JSONObject.class, bean.inner.getClass());
+        assertEquals(JSONObject.class, bean.list.get(0).getClass());
+    }
+
+    public static class Bean {
+        public Object inner;
+        public List<Object> list;
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes [#7765](https://github.com/alibaba/fastjson2/issues/7765).
In fastjson1-compatible mode, when a field value is a JSON string and is re-parsed by `getJSONArray` / `getJSONObject` / `getObject`, nested containers could become `com.alibaba.fastjson2.JSONObject` / `JSONArray`. Casting them to `com.alibaba.fastjson.JSONObject` then throws `ClassCastException`.
Root cause: those paths used bare `JSONReader.of(...)` and skipped `JSON.createReadContext(...)`, so `objectSupplier` / `arraySupplier` were not applied.


### Summary of your change

- Use `JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE)` for string reparse in:
  - `JSONObject.getJSONObject(String)` / `getJSONArray(String)` / `getObject(String, TypeReference)`
  - `JSONArray.getJSONObject(int)` / `getJSONArray(int)` / `getObject(int, Class)`

- Add regression tests in `Issue7765`.

<details>

<summary>中文说明</summary>

### 这个 PR 做了什么 / 为什么需要？

修复 [#7765](https://github.com/alibaba/fastjson2/issues/7765)。

fastjson1 兼容模式下，字段值是 JSON 字符串时，经 getJSONArray / getJSONObject / getObject 二次解析后，嵌套容器可能变成 com.alibaba.fastjson2.JSONObject / JSONArray，再强转为 com.alibaba.fastjson.JSONObject 会抛 ClassCastException。

根因：这些路径使用了裸的 JSONReader.of(...)，未走 JSON.createReadContext(...)，因此未注入 objectSupplier / arraySupplier。

### 变更摘要

上述 6 处二次解析改为使用 JSON.createReadContext(JSON.DEFAULT_PARSER_FEATURE)
新增 Issue7765 回归测试

</details>

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
