### PR TITLE
feat: add JSON.copyTo(Object, Object, JSONWriter.Feature...) for in-place property copy

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSON.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSON.java
@@ -4633,6 +4633,27 @@ public interface JSON {
     }
 
     /**
+     * Copies the properties of the specified source object into the given target object (in-place).
+     * No new instance is created; the target object is modified directly. Only fields with
+     * matching names between source and target are copied.
+     *
+     * @param object the source object whose properties will be copied
+     * @param targetObject the target object to receive the copied properties
+     * @param features the specified features are applied to serialization
+     * @param <T> the target type
+     * @return the target object after properties have been copied into it
+     * @since 2.0.65
+     */
+    @SuppressWarnings("unchecked")
+    static <T> T copyTo(Object object, Object targetObject, JSONWriter.Feature... features) {
+        if (object == null || targetObject == null) {
+            return (T) targetObject;
+        }
+        ((JSONObject) toJSON(object, features)).copyTo(targetObject);
+        return (T) targetObject;
+    }
+
+    /**
      * Configure the Enum classes as a JavaBean
      *
      * @param enumClasses the enum classes to configure as JavaBeans

--- a/core/src/test/java/com/alibaba/fastjson2/util/JSON_copyToObjectTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/util/JSON_copyToObjectTest.java
@@ -1,0 +1,177 @@
+package com.alibaba.fastjson2.util;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.annotation.JSONField;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@code JSON.copyTo(Object, Object, JSONWriter.Feature...)} — the in-place
+ * overload that copies properties from a source object into an existing target object.
+ *
+ * @since 2.0.65
+ */
+@Tag("util")
+public class JSON_copyToObjectTest {
+    @Test
+    public void copyTo_basic() {
+        Source source = new Source();
+        source.setId(101);
+        source.setName("fastjson");
+        source.setActive(true);
+
+        Target target = new Target();
+        Target result = JSON.copyTo(source, target);
+
+        assertSame(target, result, "copyTo should return the same target instance");
+        assertEquals(101, target.getId());
+        assertEquals("fastjson", target.getName());
+        assertTrue(target.isActive());
+    }
+
+    @Test
+    public void copyTo_nullEdgeCases() {
+        // null source: target unchanged
+        Target target = new Target();
+        target.setId(42);
+        target.setName("keep");
+        assertSame(target, JSON.copyTo(null, target));
+        assertEquals(42, target.getId());
+        assertEquals("keep", target.getName());
+
+        // null target: returns null (cast to Object to select the (Object, Object) overload)
+        assertNull(JSON.copyTo(new Source(), (Object) null));
+    }
+
+    /**
+     * Default: null source fields do NOT overwrite target (null excluded from JSONObject).
+     * WriteNulls: null source fields DO overwrite target.
+     */
+    @Test
+    public void copyTo_writeNulls() {
+        Source source = new Source();
+        source.setId(1);
+        source.setName(null);
+        source.setActive(true);
+
+        // default — null field skipped, target value preserved
+        Target target1 = new Target();
+        target1.setName("original");
+        JSON.copyTo(source, target1);
+        assertEquals("original", target1.getName());
+        assertEquals(1, target1.getId());
+
+        // WriteNulls — null field overwrites target
+        Target target2 = new Target();
+        target2.setName("original");
+        JSON.copyTo(source, target2, JSONWriter.Feature.WriteNulls);
+        assertNull(target2.getName());
+        assertEquals(1, target2.getId());
+    }
+
+    @Test
+    public void copyTo_typeConversion() {
+        BeanSource source = new BeanSource();
+        source.date = LocalDate.of(2012, 12, 13);
+
+        Bean1Target target1 = new Bean1Target();
+        JSON.copyTo(source, target1);
+        assertEquals("20121213", target1.date);
+
+        Bean2Target target2 = new Bean2Target();
+        JSON.copyTo(source, target2);
+        assertNotNull(target2.date);
+        assertEquals(
+                LocalDate.of(2012, 12, 13).atStartOfDay(DateUtils.DEFAULT_ZONE_ID).toInstant().toEpochMilli(),
+                target2.date.getTime()
+        );
+    }
+
+    @Test
+    public void copyTo_nestedObject() {
+        NestedSource source = new NestedSource();
+        source.setId(1);
+        Source inner = new Source();
+        inner.setId(100);
+        inner.setName("inner");
+        inner.setActive(true);
+        source.setInner(inner);
+
+        NestedTarget target = new NestedTarget();
+        JSON.copyTo(source, target);
+
+        assertEquals(1, target.getId());
+        assertNotNull(target.getInner());
+        assertEquals(100, target.getInner().getId());
+        assertEquals("inner", target.getInner().getName());
+        assertTrue(target.getInner().isActive());
+    }
+
+    // ==================== Test beans ====================
+
+    public static class Source {
+        private int id;
+        private String name;
+        private boolean active;
+
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public boolean isActive() { return active; }
+        public void setActive(boolean active) { this.active = active; }
+    }
+
+    public static class Target {
+        private int id;
+        private String name;
+        private boolean active;
+
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public boolean isActive() { return active; }
+        public void setActive(boolean active) { this.active = active; }
+    }
+
+    public static class NestedSource {
+        private int id;
+        private Source inner;
+
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+        public Source getInner() { return inner; }
+        public void setInner(Source inner) { this.inner = inner; }
+    }
+
+    public static class NestedTarget {
+        private int id;
+        private Target inner;
+
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+        public Target getInner() { return inner; }
+        public void setInner(Target inner) { this.inner = inner; }
+    }
+
+    public static class BeanSource {
+        @JSONField(format = "yyyyMMdd")
+        public LocalDate date;
+    }
+
+    public static class Bean1Target {
+        public String date;
+    }
+
+    public static class Bean2Target {
+        @JSONField(format = "yyyyMMdd")
+        public Date date;
+    }
+}


### PR DESCRIPTION
## Summary

The existing `JSON.copyTo(Object, Class<T>, JSONWriter.Feature...)` always creates a **new** target instance. This is not only unnecessary overhead when a target object already exists, but in some scenarios the target object simply **cannot be re-instantiated** (e.g. framework-managed beans, proxied objects, objects with complex lifecycle state).

This PR adds an overload that copies properties **in-place** into an existing target object:

```java
static <T> T copyTo(Object object, Object targetObject, JSONWriter.Feature... features)
```

This is especially handy for **Map → target object** incremental property setting — copy only the fields you need onto an existing object, no new instance required.

The implementation delegates to `toJSON` + `JSONObject.copyTo`, keeping the same null-field semantics (null skipped by default, `WriteNulls` to overwrite).

<details>
<summary>中文</summary>

## 概述

现有 `JSON.copyTo(Object, Class<T>, ...)` 每次都会创建**新**的目标实例。这在目标对象已存在时不仅是不必要的开销，更关键的是某些场景下目标对象**无法重新实例化**（如框架管理的 Bean、代理对象、带有复杂生命周期状态的对象）。

本 PR 新增一个重载方法，将属性**就地**拷贝到已存在的目标对象中：

```java
static <T> T copyTo(Object object, Object targetObject, JSONWriter.Feature... features)
```

特别是 **Map → 目标对象**的增量属性设置场景非常好用——只把需要的字段拷到已有对象上，无需重新实例化。

实现委托 `toJSON` + `JSONObject.copyTo`，null 字段语义保持一致（默认跳过 null，开启 `WriteNulls` 则覆盖）。
</details>
