### PR TITLE
fix: prevent duplicate ObjectReader and ObjectWriter creation on concurrent cache misses

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -1,12 +1,13 @@
 package com.alibaba.fastjson2.internal;
 
 import java.lang.reflect.Type;
+import java.util.ArrayDeque;
 import java.util.IdentityHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -29,7 +30,7 @@ public final class CodecCreationCoordinator {
     public static final class LockEntry {
         final ReentrantLock lock = new ReentrantLock();
         final AtomicInteger references = new AtomicInteger();
-        final AtomicBoolean fallbackActive = new AtomicBoolean();
+        final AtomicReference<Context> fallbackOwner = new AtomicReference<>();
         final AtomicLong nextFallbackNanos = new AtomicLong();
         volatile Context owner;
         volatile Throwable failure;
@@ -49,7 +50,7 @@ public final class CodecCreationCoordinator {
         private final boolean outermost;
         private final boolean locked;
         private final boolean cycleDetected;
-        private final boolean fallbackReserved;
+        private final Context fallbackOwner;
         private boolean closed;
 
         private Scope(
@@ -59,7 +60,7 @@ public final class CodecCreationCoordinator {
                 boolean outermost,
                 boolean locked,
                 boolean cycleDetected,
-                boolean fallbackReserved
+                Context fallbackOwner
         ) {
             this.locks = locks;
             this.type = type;
@@ -67,7 +68,7 @@ public final class CodecCreationCoordinator {
             this.outermost = outermost;
             this.locked = locked;
             this.cycleDetected = cycleDetected;
-            this.fallbackReserved = fallbackReserved;
+            this.fallbackOwner = fallbackOwner;
         }
 
         public boolean isCycleDetected() {
@@ -117,8 +118,8 @@ public final class CodecCreationCoordinator {
                 try {
                     release(locks, type, createLock);
                 } finally {
-                    if (fallbackReserved) {
-                        createLock.fallbackActive.set(false);
+                    if (fallbackOwner != null) {
+                        createLock.fallbackOwner.compareAndSet(fallbackOwner, null);
                     }
                 }
             }
@@ -150,10 +151,11 @@ public final class CodecCreationCoordinator {
             CONTEXT.set(context);
         }
         boolean locked = false;
-        boolean fallbackReserved = false;
+        Context fallbackOwner = null;
         try {
-            if (!outermost && createLock.owner == context) {
-                return new Scope(locks, type, createLock, false, false, true, false);
+            if (!outermost
+                    && (createLock.owner == context || createLock.fallbackOwner.get() == context)) {
+                return new Scope(locks, type, createLock, false, false, true, null);
             }
             if (createLock.lock.tryLock()) {
                 locked = true;
@@ -161,27 +163,28 @@ public final class CodecCreationCoordinator {
                 context.waitingFor = createLock;
                 if (!outermost && hasDependencyCycle(createLock, context)) {
                     context.waitingFor = null;
-                    return new Scope(locks, type, createLock, false, false, true, false);
+                    return new Scope(locks, type, createLock, false, false, true, null);
                 }
                 try {
                     locked = lockOrReserveFallback(
                             createLock,
                             waitNanos,
-                            fallbackIntervalNanos
+                            fallbackIntervalNanos,
+                            context
                     );
                 } finally {
                     context.waitingFor = null;
                 }
                 if (!locked) {
-                    fallbackReserved = true;
-                    return new Scope(locks, type, createLock, outermost, false, false, true);
+                    fallbackOwner = context;
+                    return new Scope(locks, type, createLock, outermost, false, false, fallbackOwner);
                 }
             }
 
             if (createLock.lock.getHoldCount() == 1) {
                 createLock.owner = context;
             }
-            return new Scope(locks, type, createLock, outermost, true, false, false);
+            return new Scope(locks, type, createLock, outermost, true, false, null);
         } catch (Throwable error) {
             if (context != null) {
                 context.waitingFor = null;
@@ -189,8 +192,8 @@ public final class CodecCreationCoordinator {
             if (outermost) {
                 CONTEXT.remove();
             }
-            if (fallbackReserved) {
-                createLock.fallbackActive.set(false);
+            if (fallbackOwner != null) {
+                createLock.fallbackOwner.compareAndSet(fallbackOwner, null);
             }
             if (locked) {
                 if (createLock.lock.getHoldCount() == 1) {
@@ -223,7 +226,8 @@ public final class CodecCreationCoordinator {
     private static boolean lockOrReserveFallback(
             LockEntry createLock,
             long waitNanos,
-            long fallbackIntervalNanos
+            long fallbackIntervalNanos,
+            Context context
     ) {
         boolean interrupted = false;
         try {
@@ -251,7 +255,7 @@ public final class CodecCreationCoordinator {
                 long now = System.nanoTime();
                 long nextFallback = createLock.nextFallbackNanos.get();
                 if ((nextFallback == 0 || now - nextFallback >= 0)
-                        && createLock.fallbackActive.compareAndSet(false, true)) {
+                        && createLock.fallbackOwner.compareAndSet(null, context)) {
                     createLock.nextFallbackNanos.set(now + fallbackIntervalNanos);
                     return false;
                 }
@@ -265,14 +269,32 @@ public final class CodecCreationCoordinator {
 
     private static boolean hasDependencyCycle(LockEntry createLock, Context current) {
         IdentityHashMap<Context, Boolean> checked = new IdentityHashMap<>();
-        Context owner = createLock.owner;
-        while (owner != null && checked.put(owner, Boolean.TRUE) == null) {
+        ArrayDeque<Context> pending = new ArrayDeque<>();
+        addOwners(createLock, pending);
+        while (!pending.isEmpty()) {
+            Context owner = pending.removeLast();
             if (owner == current) {
                 return true;
             }
+            if (checked.put(owner, Boolean.TRUE) != null) {
+                continue;
+            }
             LockEntry waitingFor = owner.waitingFor;
-            owner = waitingFor == null ? null : waitingFor.owner;
+            if (waitingFor != null) {
+                addOwners(waitingFor, pending);
+            }
         }
         return false;
+    }
+
+    private static void addOwners(LockEntry createLock, ArrayDeque<Context> pending) {
+        Context owner = createLock.owner;
+        if (owner != null) {
+            pending.addLast(owner);
+        }
+        Context fallbackOwner = createLock.fallbackOwner.get();
+        if (fallbackOwner != null && fallbackOwner != owner) {
+            pending.addLast(fallbackOwner);
+        }
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -3,7 +3,9 @@ package com.alibaba.fastjson2.internal;
 import java.lang.reflect.Type;
 import java.util.IdentityHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -11,8 +13,12 @@ import java.util.concurrent.locks.ReentrantLock;
  * Lock entries are reference-counted so holders and queued callers always use the
  * same lock, and the entry can be removed without retaining the associated type.
  * A shared per-thread wait context detects dependency cycles across both providers.
+ * Waits that cross external synchronization, such as class initialization, are
+ * bounded; lock-free fallbacks are rate-limited per entry to avoid a creation burst.
  */
 public final class CodecCreationCoordinator {
+    private static final long WAIT_NANOS = TimeUnit.SECONDS.toNanos(5);
+    private static final long FALLBACK_INTERVAL_NANOS = WAIT_NANOS;
     private static final ThreadLocal<Context> CONTEXT = new ThreadLocal<>();
 
     private CodecCreationCoordinator() {
@@ -21,6 +27,7 @@ public final class CodecCreationCoordinator {
     public static final class LockEntry {
         final ReentrantLock lock = new ReentrantLock();
         final AtomicInteger references = new AtomicInteger();
+        final AtomicLong nextFallbackNanos = new AtomicLong();
         volatile Context owner;
         volatile Throwable failure;
 
@@ -38,6 +45,7 @@ public final class CodecCreationCoordinator {
         private final LockEntry createLock;
         private final boolean outermost;
         private final boolean locked;
+        private final boolean cycleDetected;
         private boolean closed;
 
         private Scope(
@@ -45,16 +53,22 @@ public final class CodecCreationCoordinator {
                 Type type,
                 LockEntry createLock,
                 boolean outermost,
-                boolean locked
+                boolean locked,
+                boolean cycleDetected
         ) {
             this.locks = locks;
             this.type = type;
             this.createLock = createLock;
             this.outermost = outermost;
             this.locked = locked;
+            this.cycleDetected = cycleDetected;
         }
 
         public boolean isCycleDetected() {
+            return cycleDetected;
+        }
+
+        public boolean isLockFreeFallback() {
             return !locked;
         }
 
@@ -88,13 +102,24 @@ public final class CodecCreationCoordinator {
                 if (createLock.lock.getHoldCount() == 1) {
                     createLock.owner = null;
                 }
+                release(locks, type, createLock);
                 createLock.lock.unlock();
+            } else {
+                release(locks, type, createLock);
             }
-            release(locks, type, createLock);
         }
     }
 
     public static Scope acquire(ConcurrentMap<Type, LockEntry> locks, Type type) {
+        return acquire(locks, type, WAIT_NANOS, FALLBACK_INTERVAL_NANOS);
+    }
+
+    static Scope acquire(
+            ConcurrentMap<Type, LockEntry> locks,
+            Type type,
+            long waitNanos,
+            long fallbackIntervalNanos
+    ) {
         LockEntry createLock = locks.compute(type, (key, lock) -> {
             if (lock == null) {
                 lock = new LockEntry();
@@ -105,33 +130,38 @@ public final class CodecCreationCoordinator {
 
         Context context = CONTEXT.get();
         boolean outermost = context == null;
+        if (outermost) {
+            context = new Context();
+            CONTEXT.set(context);
+        }
         boolean locked = false;
         try {
-            if (outermost) {
-                createLock.lock.lock();
-                locked = true;
-                context = new Context();
-                CONTEXT.set(context);
-            } else if (createLock.lock.tryLock()) {
+            if (createLock.lock.tryLock()) {
                 locked = true;
             } else {
                 context.waitingFor = createLock;
-                if (hasDependencyCycle(createLock, context)) {
+                if (!outermost && hasDependencyCycle(createLock, context)) {
                     context.waitingFor = null;
-                    return new Scope(locks, type, createLock, false, false);
+                    return new Scope(locks, type, createLock, false, false, true);
                 }
                 try {
-                    createLock.lock.lock();
-                    locked = true;
+                    locked = lockOrReserveFallback(
+                            createLock,
+                            waitNanos,
+                            fallbackIntervalNanos
+                    );
                 } finally {
                     context.waitingFor = null;
+                }
+                if (!locked) {
+                    return new Scope(locks, type, createLock, outermost, false, false);
                 }
             }
 
             if (createLock.lock.getHoldCount() == 1) {
                 createLock.owner = context;
             }
-            return new Scope(locks, type, createLock, outermost, true);
+            return new Scope(locks, type, createLock, outermost, true, false);
         } catch (Throwable error) {
             if (context != null) {
                 context.waitingFor = null;
@@ -143,18 +173,69 @@ public final class CodecCreationCoordinator {
                 if (createLock.lock.getHoldCount() == 1) {
                     createLock.owner = null;
                 }
+                release(locks, type, createLock);
                 createLock.lock.unlock();
+            } else {
+                release(locks, type, createLock);
             }
-            release(locks, type, createLock);
             throw error;
         }
     }
 
+    public static <T> T publish(ConcurrentMap<Type, T> cache, Type type, T value) {
+        T previous = cache.putIfAbsent(type, value);
+        return previous != null ? previous : value;
+    }
+
     private static void release(ConcurrentMap<Type, LockEntry> locks, Type type, LockEntry createLock) {
-        if (createLock.references.decrementAndGet() == 0) {
-            locks.computeIfPresent(type, (key, current) ->
-                    current == createLock && createLock.references.get() == 0 ? null : current
-            );
+        locks.compute(type, (key, current) -> {
+            boolean alive = createLock.references.decrementAndGet() > 0;
+            return current == createLock && !alive ? null : current;
+        });
+    }
+
+    private static boolean lockOrReserveFallback(
+            LockEntry createLock,
+            long waitNanos,
+            long fallbackIntervalNanos
+    ) {
+        boolean interrupted = false;
+        try {
+            for (;;) {
+                long deadline = System.nanoTime() + waitNanos;
+                for (;;) {
+                    long remaining = deadline - System.nanoTime();
+                    if (remaining <= 0) {
+                        break;
+                    }
+                    try {
+                        if (createLock.lock.tryLock(remaining, TimeUnit.NANOSECONDS)) {
+                            return true;
+                        }
+                        break;
+                    } catch (InterruptedException ignored) {
+                        interrupted = true;
+                    }
+                }
+
+                if (createLock.lock.tryLock()) {
+                    return true;
+                }
+
+                long now = System.nanoTime();
+                long nextFallback = createLock.nextFallbackNanos.get();
+                if ((nextFallback == 0 || now - nextFallback >= 0)
+                        && createLock.nextFallbackNanos.compareAndSet(
+                                nextFallback,
+                                now + fallbackIntervalNanos
+                        )) {
+                    return false;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -27,13 +27,21 @@ public final class CodecCreationCoordinator {
     private CodecCreationCoordinator() {
     }
 
+    static final class FailureRecord {
+        final Throwable error;
+
+        FailureRecord(Throwable error) {
+            this.error = error;
+        }
+    }
+
     public static final class LockEntry {
         final ReentrantLock lock = new ReentrantLock();
         final AtomicInteger references = new AtomicInteger();
         final AtomicReference<Context> fallbackOwner = new AtomicReference<>();
         final AtomicLong nextFallbackNanos = new AtomicLong();
         volatile Context owner;
-        volatile Throwable failure;
+        volatile FailureRecord failure;
 
         private LockEntry() {
         }
@@ -51,6 +59,7 @@ public final class CodecCreationCoordinator {
         private final boolean locked;
         private final boolean cycleDetected;
         private final Context fallbackOwner;
+        private final FailureRecord observedFailure;
         private boolean closed;
 
         private Scope(
@@ -60,7 +69,8 @@ public final class CodecCreationCoordinator {
                 boolean outermost,
                 boolean locked,
                 boolean cycleDetected,
-                Context fallbackOwner
+                Context fallbackOwner,
+                FailureRecord observedFailure
         ) {
             this.locks = locks;
             this.type = type;
@@ -69,6 +79,7 @@ public final class CodecCreationCoordinator {
             this.locked = locked;
             this.cycleDetected = cycleDetected;
             this.fallbackOwner = fallbackOwner;
+            this.observedFailure = observedFailure;
         }
 
         public boolean isCycleDetected() {
@@ -80,18 +91,23 @@ public final class CodecCreationCoordinator {
         }
 
         public void throwIfFailed() {
-            Throwable failure = createLock.failure;
-            if (failure instanceof RuntimeException) {
-                throw (RuntimeException) failure;
+            FailureRecord current = createLock.failure;
+            if (current == null || current == observedFailure) {
+                return;
             }
-            if (failure instanceof Error) {
-                throw (Error) failure;
+
+            Throwable error = current.error;
+            if (error instanceof RuntimeException) {
+                throw (RuntimeException) error;
+            }
+            if (error instanceof Error) {
+                throw (Error) error;
             }
         }
 
         public void fail(Throwable failure) {
             if (locked) {
-                createLock.failure = failure;
+                createLock.failure = new FailureRecord(failure);
             }
         }
 
@@ -143,6 +159,7 @@ public final class CodecCreationCoordinator {
             lock.references.incrementAndGet();
             return lock;
         });
+        FailureRecord observedFailure = createLock.failure;
 
         Context context = CONTEXT.get();
         boolean outermost = context == null;
@@ -155,7 +172,7 @@ public final class CodecCreationCoordinator {
         try {
             if (!outermost
                     && (createLock.owner == context || createLock.fallbackOwner.get() == context)) {
-                return new Scope(locks, type, createLock, false, false, true, null);
+                return new Scope(locks, type, createLock, false, false, true, null, observedFailure);
             }
             if (createLock.lock.tryLock()) {
                 locked = true;
@@ -163,7 +180,7 @@ public final class CodecCreationCoordinator {
                 context.waitingFor = createLock;
                 if (!outermost && hasDependencyCycle(createLock, context)) {
                     context.waitingFor = null;
-                    return new Scope(locks, type, createLock, false, false, true, null);
+                    return new Scope(locks, type, createLock, false, false, true, null, observedFailure);
                 }
                 try {
                     locked = lockOrReserveFallback(
@@ -177,14 +194,23 @@ public final class CodecCreationCoordinator {
                 }
                 if (!locked) {
                     fallbackOwner = context;
-                    return new Scope(locks, type, createLock, outermost, false, false, fallbackOwner);
+                    return new Scope(
+                            locks,
+                            type,
+                            createLock,
+                            outermost,
+                            false,
+                            false,
+                            fallbackOwner,
+                            observedFailure
+                    );
                 }
             }
 
             if (createLock.lock.getHoldCount() == 1) {
                 createLock.owner = context;
             }
-            return new Scope(locks, type, createLock, outermost, true, false, null);
+            return new Scope(locks, type, createLock, outermost, true, false, null, observedFailure);
         } catch (Throwable error) {
             if (context != null) {
                 context.waitingFor = null;

--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -1,0 +1,173 @@
+package com.alibaba.fastjson2.internal;
+
+import java.lang.reflect.Type;
+import java.util.IdentityHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Coordinates synchronous reader and writer creation on concurrent cache misses.
+ * Lock entries are reference-counted so holders and queued callers always use the
+ * same lock, and the entry can be removed without retaining the associated type.
+ * A shared per-thread wait context detects dependency cycles across both providers.
+ */
+public final class CodecCreationCoordinator {
+    private static final ThreadLocal<Context> CONTEXT = new ThreadLocal<>();
+
+    private CodecCreationCoordinator() {
+    }
+
+    public static final class LockEntry {
+        final ReentrantLock lock = new ReentrantLock();
+        final AtomicInteger references = new AtomicInteger();
+        volatile Context owner;
+        volatile Throwable failure;
+
+        private LockEntry() {
+        }
+    }
+
+    private static final class Context {
+        volatile LockEntry waitingFor;
+    }
+
+    public static final class Scope implements AutoCloseable {
+        private final ConcurrentMap<Type, LockEntry> locks;
+        private final Type type;
+        private final LockEntry createLock;
+        private final boolean outermost;
+        private final boolean locked;
+        private boolean closed;
+
+        private Scope(
+                ConcurrentMap<Type, LockEntry> locks,
+                Type type,
+                LockEntry createLock,
+                boolean outermost,
+                boolean locked
+        ) {
+            this.locks = locks;
+            this.type = type;
+            this.createLock = createLock;
+            this.outermost = outermost;
+            this.locked = locked;
+        }
+
+        public boolean isCycleDetected() {
+            return !locked;
+        }
+
+        public void throwIfFailed() {
+            Throwable failure = createLock.failure;
+            if (failure instanceof RuntimeException) {
+                throw (RuntimeException) failure;
+            }
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+        }
+
+        public void fail(Throwable failure) {
+            if (locked) {
+                createLock.failure = failure;
+            }
+        }
+
+        @Override
+        public void close() {
+            if (closed) {
+                return;
+            }
+            closed = true;
+
+            if (outermost) {
+                CONTEXT.remove();
+            }
+            if (locked) {
+                if (createLock.lock.getHoldCount() == 1) {
+                    createLock.owner = null;
+                }
+                createLock.lock.unlock();
+            }
+            release(locks, type, createLock);
+        }
+    }
+
+    public static Scope acquire(ConcurrentMap<Type, LockEntry> locks, Type type) {
+        LockEntry createLock = locks.compute(type, (key, lock) -> {
+            if (lock == null) {
+                lock = new LockEntry();
+            }
+            lock.references.incrementAndGet();
+            return lock;
+        });
+
+        Context context = CONTEXT.get();
+        boolean outermost = context == null;
+        boolean locked = false;
+        try {
+            if (outermost) {
+                createLock.lock.lock();
+                locked = true;
+                context = new Context();
+                CONTEXT.set(context);
+            } else if (createLock.lock.tryLock()) {
+                locked = true;
+            } else {
+                context.waitingFor = createLock;
+                if (hasDependencyCycle(createLock, context)) {
+                    context.waitingFor = null;
+                    return new Scope(locks, type, createLock, false, false);
+                }
+                try {
+                    createLock.lock.lock();
+                    locked = true;
+                } finally {
+                    context.waitingFor = null;
+                }
+            }
+
+            if (createLock.lock.getHoldCount() == 1) {
+                createLock.owner = context;
+            }
+            return new Scope(locks, type, createLock, outermost, true);
+        } catch (Throwable error) {
+            if (context != null) {
+                context.waitingFor = null;
+            }
+            if (outermost) {
+                CONTEXT.remove();
+            }
+            if (locked) {
+                if (createLock.lock.getHoldCount() == 1) {
+                    createLock.owner = null;
+                }
+                createLock.lock.unlock();
+            }
+            release(locks, type, createLock);
+            throw error;
+        }
+    }
+
+    private static void release(ConcurrentMap<Type, LockEntry> locks, Type type, LockEntry createLock) {
+        if (createLock.references.decrementAndGet() == 0) {
+            locks.computeIfPresent(type, (key, current) ->
+                    current == createLock && createLock.references.get() == 0 ? null : current
+            );
+        }
+    }
+
+    private static boolean hasDependencyCycle(LockEntry createLock, Context current) {
+        IdentityHashMap<Context, Boolean> checked = new IdentityHashMap<>();
+        Context owner = createLock.owner;
+        while (owner != null && checked.put(owner, Boolean.TRUE) == null) {
+            if (owner == current) {
+                return true;
+            }
+            LockEntry waitingFor = owner.waitingFor;
+            owner = waitingFor == null ? null : waitingFor.owner;
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.util.IdentityHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -14,7 +15,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * same lock, and the entry can be removed without retaining the associated type.
  * A shared per-thread wait context detects dependency cycles across both providers.
  * Waits that cross external synchronization, such as class initialization, are
- * bounded; lock-free fallbacks are rate-limited per entry to avoid a creation burst.
+ * bounded; lock-free fallbacks are serialized and rate-limited per entry to avoid
+ * a creation burst.
  */
 public final class CodecCreationCoordinator {
     private static final long WAIT_NANOS = TimeUnit.SECONDS.toNanos(5);
@@ -27,6 +29,7 @@ public final class CodecCreationCoordinator {
     public static final class LockEntry {
         final ReentrantLock lock = new ReentrantLock();
         final AtomicInteger references = new AtomicInteger();
+        final AtomicBoolean fallbackActive = new AtomicBoolean();
         final AtomicLong nextFallbackNanos = new AtomicLong();
         volatile Context owner;
         volatile Throwable failure;
@@ -46,6 +49,7 @@ public final class CodecCreationCoordinator {
         private final boolean outermost;
         private final boolean locked;
         private final boolean cycleDetected;
+        private final boolean fallbackReserved;
         private boolean closed;
 
         private Scope(
@@ -54,7 +58,8 @@ public final class CodecCreationCoordinator {
                 LockEntry createLock,
                 boolean outermost,
                 boolean locked,
-                boolean cycleDetected
+                boolean cycleDetected,
+                boolean fallbackReserved
         ) {
             this.locks = locks;
             this.type = type;
@@ -62,6 +67,7 @@ public final class CodecCreationCoordinator {
             this.outermost = outermost;
             this.locked = locked;
             this.cycleDetected = cycleDetected;
+            this.fallbackReserved = fallbackReserved;
         }
 
         public boolean isCycleDetected() {
@@ -102,10 +108,19 @@ public final class CodecCreationCoordinator {
                 if (createLock.lock.getHoldCount() == 1) {
                     createLock.owner = null;
                 }
-                release(locks, type, createLock);
-                createLock.lock.unlock();
+                try {
+                    release(locks, type, createLock);
+                } finally {
+                    createLock.lock.unlock();
+                }
             } else {
-                release(locks, type, createLock);
+                try {
+                    release(locks, type, createLock);
+                } finally {
+                    if (fallbackReserved) {
+                        createLock.fallbackActive.set(false);
+                    }
+                }
             }
         }
     }
@@ -135,14 +150,18 @@ public final class CodecCreationCoordinator {
             CONTEXT.set(context);
         }
         boolean locked = false;
+        boolean fallbackReserved = false;
         try {
+            if (!outermost && createLock.owner == context) {
+                return new Scope(locks, type, createLock, false, false, true, false);
+            }
             if (createLock.lock.tryLock()) {
                 locked = true;
             } else {
                 context.waitingFor = createLock;
                 if (!outermost && hasDependencyCycle(createLock, context)) {
                     context.waitingFor = null;
-                    return new Scope(locks, type, createLock, false, false, true);
+                    return new Scope(locks, type, createLock, false, false, true, false);
                 }
                 try {
                     locked = lockOrReserveFallback(
@@ -154,14 +173,15 @@ public final class CodecCreationCoordinator {
                     context.waitingFor = null;
                 }
                 if (!locked) {
-                    return new Scope(locks, type, createLock, outermost, false, false);
+                    fallbackReserved = true;
+                    return new Scope(locks, type, createLock, outermost, false, false, true);
                 }
             }
 
             if (createLock.lock.getHoldCount() == 1) {
                 createLock.owner = context;
             }
-            return new Scope(locks, type, createLock, outermost, true, false);
+            return new Scope(locks, type, createLock, outermost, true, false, false);
         } catch (Throwable error) {
             if (context != null) {
                 context.waitingFor = null;
@@ -169,12 +189,18 @@ public final class CodecCreationCoordinator {
             if (outermost) {
                 CONTEXT.remove();
             }
+            if (fallbackReserved) {
+                createLock.fallbackActive.set(false);
+            }
             if (locked) {
                 if (createLock.lock.getHoldCount() == 1) {
                     createLock.owner = null;
                 }
-                release(locks, type, createLock);
-                createLock.lock.unlock();
+                try {
+                    release(locks, type, createLock);
+                } finally {
+                    createLock.lock.unlock();
+                }
             } else {
                 release(locks, type, createLock);
             }
@@ -225,10 +251,8 @@ public final class CodecCreationCoordinator {
                 long now = System.nanoTime();
                 long nextFallback = createLock.nextFallbackNanos.get();
                 if ((nextFallback == 0 || now - nextFallback >= 0)
-                        && createLock.nextFallbackNanos.compareAndSet(
-                                nextFallback,
-                                now + fallbackIntervalNanos
-                        )) {
+                        && createLock.fallbackActive.compareAndSet(false, true)) {
+                    createLock.nextFallbackNanos.set(now + fallbackIntervalNanos);
                     return false;
                 }
             }

--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -3,11 +3,11 @@ package com.alibaba.fastjson2.internal;
 import java.lang.reflect.Type;
 import java.util.ArrayDeque;
 import java.util.IdentityHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -15,13 +15,15 @@ import java.util.concurrent.locks.ReentrantLock;
  * Lock entries are reference-counted so holders and queued callers always use the
  * same lock, and the entry can be removed without retaining the associated type.
  * A shared per-thread wait context detects dependency cycles across both providers.
- * Waits that cross external synchronization, such as class initialization, are
- * bounded; lock-free fallbacks are serialized and rate-limited per entry to avoid
- * a creation burst.
+ * Timed fallback admissions are rate-limited per entry, but an older fallback
+ * must not prevent progress through external synchronization, such as class
+ * initialization. Waiters can reuse a published cache value without acquiring
+ * either the creation lock or a fallback admission.
  */
 public final class CodecCreationCoordinator {
     private static final long WAIT_NANOS = TimeUnit.SECONDS.toNanos(5);
     private static final long FALLBACK_INTERVAL_NANOS = WAIT_NANOS;
+    private static final long CACHE_CHECK_NANOS = TimeUnit.MILLISECONDS.toNanos(50);
     private static final ThreadLocal<Context> CONTEXT = new ThreadLocal<>();
 
     private CodecCreationCoordinator() {
@@ -38,7 +40,7 @@ public final class CodecCreationCoordinator {
     public static final class LockEntry {
         final ReentrantLock lock = new ReentrantLock();
         final AtomicInteger references = new AtomicInteger();
-        final AtomicReference<Context> fallbackOwner = new AtomicReference<>();
+        final ConcurrentMap<Context, Scope> fallbackOwners = new ConcurrentHashMap<>();
         final AtomicLong nextFallbackNanos = new AtomicLong();
         volatile Context owner;
         volatile FailureRecord failure;
@@ -55,30 +57,28 @@ public final class CodecCreationCoordinator {
         private final ConcurrentMap<Type, LockEntry> locks;
         private final Type type;
         private final LockEntry createLock;
+        private final Context context;
         private final boolean outermost;
-        private final boolean locked;
-        private final boolean cycleDetected;
-        private final Context fallbackOwner;
         private final FailureRecord observedFailure;
+        // Populated during acquire, before this thread-confined scope is returned.
+        private boolean locked;
+        private boolean cycleDetected;
+        private Object cachedValue;
         private boolean closed;
 
         private Scope(
                 ConcurrentMap<Type, LockEntry> locks,
                 Type type,
                 LockEntry createLock,
+                Context context,
                 boolean outermost,
-                boolean locked,
-                boolean cycleDetected,
-                Context fallbackOwner,
                 FailureRecord observedFailure
         ) {
             this.locks = locks;
             this.type = type;
             this.createLock = createLock;
+            this.context = context;
             this.outermost = outermost;
-            this.locked = locked;
-            this.cycleDetected = cycleDetected;
-            this.fallbackOwner = fallbackOwner;
             this.observedFailure = observedFailure;
         }
 
@@ -87,7 +87,15 @@ public final class CodecCreationCoordinator {
         }
 
         public boolean isLockFreeFallback() {
-            return !locked;
+            return !locked && cachedValue == null;
+        }
+
+        public Object getCachedValue() {
+            return cachedValue;
+        }
+
+        private void registerFallback() {
+            createLock.fallbackOwners.putIfAbsent(context, this);
         }
 
         public void throwIfFailed() {
@@ -143,21 +151,34 @@ public final class CodecCreationCoordinator {
                 try {
                     release(locks, type, createLock);
                 } finally {
-                    if (fallbackOwner != null) {
-                        createLock.fallbackOwner.compareAndSet(fallbackOwner, null);
-                    }
+                    // A reentrant scope must not remove its enclosing scope's registration.
+                    createLock.fallbackOwners.remove(context, this);
                 }
             }
         }
     }
 
     public static Scope acquire(ConcurrentMap<Type, LockEntry> locks, Type type) {
-        return acquire(locks, type, WAIT_NANOS, FALLBACK_INTERVAL_NANOS);
+        return acquire(locks, type, null);
+    }
+
+    public static Scope acquire(ConcurrentMap<Type, LockEntry> locks, Type type, ConcurrentMap<Type, ?> cache) {
+        return acquire(locks, type, cache, WAIT_NANOS, FALLBACK_INTERVAL_NANOS);
     }
 
     static Scope acquire(
             ConcurrentMap<Type, LockEntry> locks,
             Type type,
+            long waitNanos,
+            long fallbackIntervalNanos
+    ) {
+        return acquire(locks, type, null, waitNanos, fallbackIntervalNanos);
+    }
+
+    static Scope acquire(
+            ConcurrentMap<Type, LockEntry> locks,
+            Type type,
+            ConcurrentMap<Type, ?> cache,
             long waitNanos,
             long fallbackIntervalNanos
     ) {
@@ -176,72 +197,29 @@ public final class CodecCreationCoordinator {
             context = new Context();
             CONTEXT.set(context);
         }
-        boolean locked = false;
-        Context fallbackOwner = null;
+        Scope scope = new Scope(locks, type, createLock, context, outermost, observedFailure);
         try {
             if (!outermost
-                    && (createLock.owner == context || createLock.fallbackOwner.get() == context)) {
-                return new Scope(locks, type, createLock, false, false, true, null, observedFailure);
+                    && (createLock.owner == context || createLock.fallbackOwners.containsKey(context))) {
+                scope.cycleDetected = true;
+                return scope;
             }
-            if (createLock.lock.tryLock()) {
-                locked = true;
-            } else {
+            scope.locked = createLock.lock.tryLock();
+            if (!scope.locked) {
                 context.waitingFor = createLock;
-                if (!outermost && hasDependencyCycle(createLock, context)) {
-                    context.waitingFor = null;
-                    return new Scope(locks, type, createLock, false, false, true, null, observedFailure);
-                }
                 try {
-                    locked = lockOrReserveFallback(
-                            createLock,
-                            waitNanos,
-                            fallbackIntervalNanos,
-                            context
-                    );
+                    awaitCreation(scope, cache, waitNanos, fallbackIntervalNanos);
                 } finally {
                     context.waitingFor = null;
-                }
-                if (!locked) {
-                    fallbackOwner = context;
-                    return new Scope(
-                            locks,
-                            type,
-                            createLock,
-                            outermost,
-                            false,
-                            false,
-                            fallbackOwner,
-                            observedFailure
-                    );
                 }
             }
 
-            if (createLock.lock.getHoldCount() == 1) {
+            if (scope.locked && createLock.lock.getHoldCount() == 1) {
                 createLock.owner = context;
             }
-            return new Scope(locks, type, createLock, outermost, true, false, null, observedFailure);
+            return scope;
         } catch (Throwable error) {
-            if (context != null) {
-                context.waitingFor = null;
-            }
-            if (outermost) {
-                CONTEXT.remove();
-            }
-            if (fallbackOwner != null) {
-                createLock.fallbackOwner.compareAndSet(fallbackOwner, null);
-            }
-            if (locked) {
-                if (createLock.lock.getHoldCount() == 1) {
-                    createLock.owner = null;
-                }
-                try {
-                    release(locks, type, createLock);
-                } finally {
-                    createLock.lock.unlock();
-                }
-            } else {
-                release(locks, type, createLock);
-            }
+            scope.close();
             throw error;
         }
     }
@@ -258,41 +236,51 @@ public final class CodecCreationCoordinator {
         });
     }
 
-    private static boolean lockOrReserveFallback(
-            LockEntry createLock,
+    private static void awaitCreation(
+            Scope scope,
+            ConcurrentMap<Type, ?> cache,
             long waitNanos,
-            long fallbackIntervalNanos,
-            Context context
+            long fallbackIntervalNanos
     ) {
+        LockEntry createLock = scope.createLock;
+        long deadline = System.nanoTime() + waitNanos;
         boolean interrupted = false;
         try {
             for (;;) {
-                long deadline = System.nanoTime() + waitNanos;
-                for (;;) {
-                    long remaining = deadline - System.nanoTime();
-                    if (remaining <= 0) {
-                        break;
-                    }
-                    try {
-                        if (createLock.lock.tryLock(remaining, TimeUnit.NANOSECONDS)) {
-                            return true;
-                        }
-                        break;
-                    } catch (InterruptedException ignored) {
-                        interrupted = true;
+                if (cache != null) {
+                    scope.cachedValue = cache.get(scope.type);
+                    if (scope.cachedValue != null) {
+                        return;
                     }
                 }
-
-                if (createLock.lock.tryLock()) {
-                    return true;
+                scope.locked = createLock.lock.tryLock();
+                if (scope.locked) {
+                    return;
+                }
+                if (!scope.outermost && hasDependencyCycle(createLock, scope.context)) {
+                    scope.cycleDetected = true;
+                    scope.registerFallback();
+                    return;
                 }
 
                 long now = System.nanoTime();
-                long nextFallback = createLock.nextFallbackNanos.get();
-                if ((nextFallback == 0 || now - nextFallback >= 0)
-                        && createLock.fallbackOwner.compareAndSet(null, context)) {
-                    createLock.nextFallbackNanos.set(now + fallbackIntervalNanos);
-                    return false;
+                long remaining = deadline - now;
+                if (remaining <= 0) {
+                    long nextFallback = createLock.nextFallbackNanos.get();
+                    if (tryReserveFallback(createLock, nextFallback, now, fallbackIntervalNanos)) {
+                        scope.registerFallback();
+                        return;
+                    }
+                    remaining = CACHE_CHECK_NANOS;
+                }
+                try {
+                    scope.locked = createLock.lock.tryLock(
+                            Math.min(remaining, CACHE_CHECK_NANOS), TimeUnit.NANOSECONDS);
+                    if (scope.locked) {
+                        return;
+                    }
+                } catch (InterruptedException ignored) {
+                    interrupted = true;
                 }
             }
         } finally {
@@ -300,6 +288,11 @@ public final class CodecCreationCoordinator {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    static boolean tryReserveFallback(LockEntry createLock, long previous, long now, long interval) {
+        return (previous == 0 || now - previous >= 0)
+                && createLock.nextFallbackNanos.compareAndSet(previous, now + interval);
     }
 
     private static boolean hasDependencyCycle(LockEntry createLock, Context current) {
@@ -327,9 +320,10 @@ public final class CodecCreationCoordinator {
         if (owner != null) {
             pending.addLast(owner);
         }
-        Context fallbackOwner = createLock.fallbackOwner.get();
-        if (fallbackOwner != null && fallbackOwner != owner) {
-            pending.addLast(fallbackOwner);
+        for (Context fallbackOwner : createLock.fallbackOwners.keySet()) {
+            if (fallbackOwner != owner) {
+                pending.addLast(fallbackOwner);
+            }
         }
     }
 }

--- a/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/internal/CodecCreationCoordinator.java
@@ -111,6 +111,15 @@ public final class CodecCreationCoordinator {
             }
         }
 
+        /**
+         * Records a successful cache observation or publication. A success
+         * supersedes any earlier creation failure retained by this entry.
+         */
+        public <T> T complete(T value) {
+            createLock.failure = null;
+            return value;
+        }
+
         @Override
         public void close() {
             if (closed) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -20,7 +20,9 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -65,6 +67,7 @@ import static com.alibaba.fastjson2.util.TypeUtils.normalizeAcceptName;
  */
 public class ObjectReaderProvider
         implements ObjectCodecProvider {
+    static final long CREATE_LOCK_TIMEOUT_MILLIS = 1000;
     static final ClassLoader FASTJSON2_CLASS_LOADER = JSON.class.getClassLoader();
     public static final boolean SAFE_MODE;
     static final String[] DENYS;
@@ -181,12 +184,8 @@ public class ObjectReaderProvider
 
     final ConcurrentMap<Type, ObjectReader> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectReader> cacheFieldBased = new ConcurrentHashMap<>();
-    final ClassValue<Object> createLock = new ClassValue<Object>() {
-        @Override
-        protected Object computeValue(Class<?> type) {
-            return new Object();
-        }
-    };
+    final ConcurrentMap<Type, ReentrantLock> createLocks = new ConcurrentHashMap<>();
+    final ConcurrentMap<Type, ReentrantLock> createLocksFieldBased = new ConcurrentHashMap<>();
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, ObjectReader>> tclHashCaches = new ConcurrentHashMap<>();
     final ConcurrentMap<Long, ObjectReader> hashCache = new ConcurrentHashMap<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
@@ -1219,20 +1218,7 @@ public class ObjectReaderProvider
         }
 
         if (objectReader == null) {
-            ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
-            synchronized (createLock.get(objectClass)) {
-                objectReader = targetCache.get(objectType);
-                if (objectReader == null) {
-                    ObjectReaderCreator creator = getCreator();
-                    objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
-                    ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
-                    if (previous != null) {
-                        objectReader = previous;
-                    }
-                }
-            }
-
-            return objectReader;
+            return createObjectReader(objectClass, objectType, fieldBased);
         }
 
         ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, objectReader);
@@ -1241,6 +1227,35 @@ public class ObjectReaderProvider
         }
 
         return objectReader;
+    }
+
+    private ObjectReader createObjectReader(Class<?> objectClass, Type objectType, boolean fieldBased) {
+        ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
+        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
+        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
+        boolean locked = false;
+        try {
+            try {
+                locked = createLock.tryLock(CREATE_LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            ObjectReader objectReader = targetCache.get(objectType);
+            if (objectReader != null) {
+                return objectReader;
+            }
+
+            ObjectReaderCreator creator = getCreator();
+            objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
+            ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
+            return previous != null ? previous : objectReader;
+        } finally {
+            if (locked) {
+                createLock.unlock();
+                targetLocks.remove(objectType, createLock);
+            }
+        }
     }
 
     private ObjectReader getPreviousObjectReader(boolean fieldBased, Type objectType, ObjectReader boundObjectReader) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1144,7 +1144,11 @@ public class ObjectReaderProvider
                 fieldBased ? createLocksFieldBased : createLocks;
         try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
             if (scope.isLockFreeFallback()) {
-                ObjectReader objectReader = resolveObjectReader(objectType, fieldBased);
+                ObjectReader objectReader = targetCache.get(objectType);
+                if (objectReader != null) {
+                    return objectReader;
+                }
+                objectReader = resolveObjectReader(objectType, fieldBased);
                 return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
             }
             ObjectReader objectReader = targetCache.get(objectType);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -20,7 +20,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
@@ -67,7 +66,6 @@ import static com.alibaba.fastjson2.util.TypeUtils.normalizeAcceptName;
  */
 public class ObjectReaderProvider
         implements ObjectCodecProvider {
-    static final long CREATE_LOCK_TIMEOUT_MILLIS = 1000;
     static final ClassLoader FASTJSON2_CLASS_LOADER = JSON.class.getClassLoader();
     public static final boolean SAFE_MODE;
     static final String[] DENYS;
@@ -184,8 +182,10 @@ public class ObjectReaderProvider
 
     final ConcurrentMap<Type, ObjectReader> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectReader> cacheFieldBased = new ConcurrentHashMap<>();
+    // Keep lock entries stable while a Type can be cached or retried after a failed creation.
     final ConcurrentMap<Type, ReentrantLock> createLocks = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ReentrantLock> createLocksFieldBased = new ConcurrentHashMap<>();
+    final ThreadLocal<Boolean> creating = new ThreadLocal<>();
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, ObjectReader>> tclHashCaches = new ConcurrentHashMap<>();
     final ConcurrentMap<Long, ObjectReader> hashCache = new ConcurrentHashMap<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
@@ -540,6 +540,8 @@ public class ObjectReaderProvider
         mixInCache.remove(objectClass);
         cache.remove(objectClass);
         cacheFieldBased.remove(objectClass);
+        createLocks.remove(objectClass);
+        createLocksFieldBased.remove(objectClass);
         for (ConcurrentHashMap<Long, ObjectReader> tlc : tclHashCaches.values()) {
             for (Iterator<Map.Entry<Long, ObjectReader>> it = tlc.entrySet().iterator(); it.hasNext(); ) {
                 Map.Entry<Long, ObjectReader> entry = it.next();
@@ -561,6 +563,8 @@ public class ObjectReaderProvider
         mixInCache.clear();
         cache.clear();
         cacheFieldBased.clear();
+        createLocks.clear();
+        createLocksFieldBased.clear();
     }
 
     static boolean match(Type objectType, ObjectReader objectReader, ClassLoader classLoader) {
@@ -633,6 +637,14 @@ public class ObjectReaderProvider
 
         cacheFieldBased.entrySet().removeIf(
                 entry -> match(entry.getKey(), entry.getValue(), classLoader)
+        );
+
+        createLocks.keySet().removeIf(
+                type -> match(type, null, classLoader)
+        );
+
+        createLocksFieldBased.keySet().removeIf(
+                type -> match(type, null, classLoader)
         );
 
         int tclHash = System.identityHashCode(classLoader);
@@ -1141,6 +1153,34 @@ public class ObjectReaderProvider
     }
 
     private ObjectReader getObjectReaderInternal(Type objectType, boolean fieldBased) {
+        ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
+        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
+        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
+        boolean outermost = creating.get() == null;
+
+        if (outermost) {
+            createLock.lock();
+            creating.set(Boolean.TRUE);
+        } else if (!createLock.tryLock()) {
+            // Do not wait while creating another type. Two creators can depend on each
+            // other from different threads, so waiting here could deadlock.
+            return resolveObjectReader(objectType, fieldBased);
+        }
+
+        try {
+            ObjectReader objectReader = targetCache.get(objectType);
+            return objectReader != null
+                    ? objectReader
+                    : resolveObjectReader(objectType, fieldBased);
+        } finally {
+            if (outermost) {
+                creating.remove();
+            }
+            createLock.unlock();
+        }
+    }
+
+    private ObjectReader resolveObjectReader(Type objectType, boolean fieldBased) {
         ObjectReader objectReader = null;
 
         for (ObjectReaderModule module : modules) {
@@ -1231,31 +1271,10 @@ public class ObjectReaderProvider
 
     private ObjectReader createObjectReader(Class<?> objectClass, Type objectType, boolean fieldBased) {
         ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
-        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
-        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
-        boolean locked = false;
-        try {
-            try {
-                locked = createLock.tryLock(CREATE_LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-
-            ObjectReader objectReader = targetCache.get(objectType);
-            if (objectReader != null) {
-                return objectReader;
-            }
-
-            ObjectReaderCreator creator = getCreator();
-            objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
-            ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
-            return previous != null ? previous : objectReader;
-        } finally {
-            if (locked) {
-                createLock.unlock();
-                targetLocks.remove(objectType, createLock);
-            }
-        }
+        ObjectReaderCreator creator = getCreator();
+        ObjectReader objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
+        ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
+        return previous != null ? previous : objectReader;
     }
 
     private ObjectReader getPreviousObjectReader(boolean fieldBased, Type objectType, ObjectReader boundObjectReader) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -6,6 +6,7 @@ import com.alibaba.fastjson2.codec.BeanInfo;
 import com.alibaba.fastjson2.codec.FieldInfo;
 import com.alibaba.fastjson2.function.FieldBiConsumer;
 import com.alibaba.fastjson2.function.FieldConsumer;
+import com.alibaba.fastjson2.internal.CodecCreationCoordinator;
 import com.alibaba.fastjson2.modules.ObjectCodecProvider;
 import com.alibaba.fastjson2.modules.ObjectReaderAnnotationProcessor;
 import com.alibaba.fastjson2.modules.ObjectReaderModule;
@@ -21,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -182,10 +182,8 @@ public class ObjectReaderProvider
 
     final ConcurrentMap<Type, ObjectReader> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectReader> cacheFieldBased = new ConcurrentHashMap<>();
-    // Keep lock entries stable while a Type can be cached or retried after a failed creation.
-    final ConcurrentMap<Type, ReentrantLock> createLocks = new ConcurrentHashMap<>();
-    final ConcurrentMap<Type, ReentrantLock> createLocksFieldBased = new ConcurrentHashMap<>();
-    final ThreadLocal<Boolean> creating = new ThreadLocal<>();
+    final ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> createLocks = new ConcurrentHashMap<>();
+    final ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> createLocksFieldBased = new ConcurrentHashMap<>();
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, ObjectReader>> tclHashCaches = new ConcurrentHashMap<>();
     final ConcurrentMap<Long, ObjectReader> hashCache = new ConcurrentHashMap<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
@@ -540,8 +538,6 @@ public class ObjectReaderProvider
         mixInCache.remove(objectClass);
         cache.remove(objectClass);
         cacheFieldBased.remove(objectClass);
-        createLocks.remove(objectClass);
-        createLocksFieldBased.remove(objectClass);
         for (ConcurrentHashMap<Long, ObjectReader> tlc : tclHashCaches.values()) {
             for (Iterator<Map.Entry<Long, ObjectReader>> it = tlc.entrySet().iterator(); it.hasNext(); ) {
                 Map.Entry<Long, ObjectReader> entry = it.next();
@@ -563,8 +559,6 @@ public class ObjectReaderProvider
         mixInCache.clear();
         cache.clear();
         cacheFieldBased.clear();
-        createLocks.clear();
-        createLocksFieldBased.clear();
     }
 
     static boolean match(Type objectType, ObjectReader objectReader, ClassLoader classLoader) {
@@ -637,14 +631,6 @@ public class ObjectReaderProvider
 
         cacheFieldBased.entrySet().removeIf(
                 entry -> match(entry.getKey(), entry.getValue(), classLoader)
-        );
-
-        createLocks.keySet().removeIf(
-                type -> match(type, null, classLoader)
-        );
-
-        createLocksFieldBased.keySet().removeIf(
-                type -> match(type, null, classLoader)
         );
 
         int tclHash = System.identityHashCode(classLoader);
@@ -1154,29 +1140,27 @@ public class ObjectReaderProvider
 
     private ObjectReader getObjectReaderInternal(Type objectType, boolean fieldBased) {
         ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
-        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
-        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
-        boolean outermost = creating.get() == null;
-
-        if (outermost) {
-            createLock.lock();
-            creating.set(Boolean.TRUE);
-        } else if (!createLock.tryLock()) {
-            // Do not wait while creating another type. Two creators can depend on each
-            // other from different threads, so waiting here could deadlock.
-            return resolveObjectReader(objectType, fieldBased);
-        }
-
-        try {
-            ObjectReader objectReader = targetCache.get(objectType);
-            return objectReader != null
-                    ? objectReader
-                    : resolveObjectReader(objectType, fieldBased);
-        } finally {
-            if (outermost) {
-                creating.remove();
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> targetLocks =
+                fieldBased ? createLocksFieldBased : createLocks;
+        try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
+            if (scope.isCycleDetected()) {
+                ObjectReader objectReader = resolveObjectReader(objectType, fieldBased);
+                ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
+                return previous != null ? previous : objectReader;
             }
-            createLock.unlock();
+            ObjectReader objectReader = targetCache.get(objectType);
+            if (objectReader != null) {
+                return objectReader;
+            }
+            scope.throwIfFailed();
+            try {
+                objectReader = resolveObjectReader(objectType, fieldBased);
+                ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
+                return previous != null ? previous : objectReader;
+            } catch (RuntimeException | Error error) {
+                scope.fail(error);
+                throw error;
+            }
         }
     }
 

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1143,10 +1143,9 @@ public class ObjectReaderProvider
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> targetLocks =
                 fieldBased ? createLocksFieldBased : createLocks;
         try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
-            if (scope.isCycleDetected()) {
+            if (scope.isLockFreeFallback()) {
                 ObjectReader objectReader = resolveObjectReader(objectType, fieldBased);
-                ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
-                return previous != null ? previous : objectReader;
+                return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
             }
             ObjectReader objectReader = targetCache.get(objectType);
             if (objectReader != null) {
@@ -1155,8 +1154,7 @@ public class ObjectReaderProvider
             scope.throwIfFailed();
             try {
                 objectReader = resolveObjectReader(objectType, fieldBased);
-                ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
-                return previous != null ? previous : objectReader;
+                return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
             } catch (RuntimeException | Error error) {
                 scope.fail(error);
                 throw error;
@@ -1166,18 +1164,12 @@ public class ObjectReaderProvider
 
     private ObjectReader resolveObjectReader(Type objectType, boolean fieldBased) {
         ObjectReader objectReader = null;
+        ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
 
         for (ObjectReaderModule module : modules) {
             objectReader = module.getObjectReader(this, objectType);
             if (objectReader != null) {
-                ObjectReader previous = fieldBased
-                        ? cacheFieldBased.putIfAbsent(objectType, objectReader)
-                        : cache.putIfAbsent(objectType, objectReader);
-
-                if (previous != null) {
-                    objectReader = previous;
-                }
-                return objectReader;
+                return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
             }
         }
 
@@ -1188,11 +1180,7 @@ public class ObjectReaderProvider
                 if (bound instanceof Class) {
                     ObjectReader boundObjectReader = getObjectReader(bound, fieldBased);
                     if (boundObjectReader != null) {
-                        ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, boundObjectReader);
-                        if (previous != null) {
-                            boundObjectReader = previous;
-                        }
-                        return boundObjectReader;
+                        return CodecCreationCoordinator.publish(targetCache, objectType, boundObjectReader);
                     }
                 }
             }
@@ -1215,11 +1203,7 @@ public class ObjectReaderProvider
                 if (typeArguments.length == 0 || !generic) {
                     ObjectReader rawClassReader = getObjectReader(rawClass, fieldBased);
                     if (rawClassReader != null) {
-                        ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, rawClassReader);
-                        if (previous != null) {
-                            rawClassReader = previous;
-                        }
-                        return rawClassReader;
+                        return CodecCreationCoordinator.publish(targetCache, objectType, rawClassReader);
                     }
                 }
                 if (typeArguments.length == 1 && ArrayList.class.isAssignableFrom(rawClass)) {
@@ -1245,26 +1229,14 @@ public class ObjectReaderProvider
             return createObjectReader(objectClass, objectType, fieldBased);
         }
 
-        ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, objectReader);
-        if (previous != null) {
-            objectReader = previous;
-        }
-
-        return objectReader;
+        return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
     }
 
     private ObjectReader createObjectReader(Class<?> objectClass, Type objectType, boolean fieldBased) {
         ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
         ObjectReaderCreator creator = getCreator();
         ObjectReader objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
-        ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
-        return previous != null ? previous : objectReader;
-    }
-
-    private ObjectReader getPreviousObjectReader(boolean fieldBased, Type objectType, ObjectReader boundObjectReader) {
-        return fieldBased
-                ? cacheFieldBased.putIfAbsent(objectType, boundObjectReader)
-                : cache.putIfAbsent(objectType, boundObjectReader);
+        return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -181,6 +181,12 @@ public class ObjectReaderProvider
 
     final ConcurrentMap<Type, ObjectReader> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectReader> cacheFieldBased = new ConcurrentHashMap<>();
+    final ClassValue<Object> createLock = new ClassValue<Object>() {
+        @Override
+        protected Object computeValue(Class<?> type) {
+            return new Object();
+        }
+    };
     final ConcurrentMap<Integer, ConcurrentHashMap<Long, ObjectReader>> tclHashCaches = new ConcurrentHashMap<>();
     final ConcurrentMap<Long, ObjectReader> hashCache = new ConcurrentHashMap<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
@@ -1213,8 +1219,20 @@ public class ObjectReaderProvider
         }
 
         if (objectReader == null) {
-            ObjectReaderCreator creator = getCreator();
-            objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
+            ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
+            synchronized (createLock.get(objectClass)) {
+                objectReader = targetCache.get(objectType);
+                if (objectReader == null) {
+                    ObjectReaderCreator creator = getCreator();
+                    objectReader = creator.createObjectReader(objectClass, objectType, fieldBased, this);
+                    ObjectReader previous = targetCache.putIfAbsent(objectType, objectReader);
+                    if (previous != null) {
+                        objectReader = previous;
+                    }
+                }
+            }
+
+            return objectReader;
         }
 
         ObjectReader previous = getPreviousObjectReader(fieldBased, objectType, objectReader);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1142,20 +1142,19 @@ public class ObjectReaderProvider
         ConcurrentMap<Type, ObjectReader> targetCache = fieldBased ? cacheFieldBased : cache;
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> targetLocks =
                 fieldBased ? createLocksFieldBased : createLocks;
-        try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
+        try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType, targetCache)) {
+            ObjectReader objectReader = (ObjectReader) scope.getCachedValue();
+            if (objectReader == null) {
+                objectReader = targetCache.get(objectType);
+            }
+            if (objectReader != null) {
+                return scope.complete(objectReader);
+            }
             if (scope.isLockFreeFallback()) {
-                ObjectReader objectReader = targetCache.get(objectType);
-                if (objectReader != null) {
-                    return scope.complete(objectReader);
-                }
                 objectReader = resolveObjectReader(objectType, fieldBased);
                 return scope.complete(
                         CodecCreationCoordinator.publish(targetCache, objectType, objectReader)
                 );
-            }
-            ObjectReader objectReader = targetCache.get(objectType);
-            if (objectReader != null) {
-                return scope.complete(objectReader);
             }
             scope.throwIfFailed();
             try {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderProvider.java
@@ -1146,19 +1146,23 @@ public class ObjectReaderProvider
             if (scope.isLockFreeFallback()) {
                 ObjectReader objectReader = targetCache.get(objectType);
                 if (objectReader != null) {
-                    return objectReader;
+                    return scope.complete(objectReader);
                 }
                 objectReader = resolveObjectReader(objectType, fieldBased);
-                return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
+                return scope.complete(
+                        CodecCreationCoordinator.publish(targetCache, objectType, objectReader)
+                );
             }
             ObjectReader objectReader = targetCache.get(objectType);
             if (objectReader != null) {
-                return objectReader;
+                return scope.complete(objectReader);
             }
             scope.throwIfFailed();
             try {
                 objectReader = resolveObjectReader(objectType, fieldBased);
-                return CodecCreationCoordinator.publish(targetCache, objectType, objectReader);
+                return scope.complete(
+                        CodecCreationCoordinator.publish(targetCache, objectType, objectReader)
+                );
             } catch (RuntimeException | Error error) {
                 scope.fail(error);
                 throw error;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -20,7 +20,6 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -59,7 +58,6 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class ObjectWriterProvider
         implements ObjectCodecProvider {
-    static final long CREATE_LOCK_TIMEOUT_MILLIS = 1000;
     static final int TYPE_INT32_MASK = 1 << 1;
     static final int TYPE_INT64_MASK = 1 << 2;
     static final int TYPE_DECIMAL_MASK = 1 << 3;
@@ -69,8 +67,10 @@ public class ObjectWriterProvider
 
     final ConcurrentMap<Type, ObjectWriter> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectWriter> cacheFieldBased = new ConcurrentHashMap<>();
+    // Keep lock entries stable while a Type can be cached or retried after a failed creation.
     final ConcurrentMap<Type, ReentrantLock> createLocks = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ReentrantLock> createLocksFieldBased = new ConcurrentHashMap<>();
+    final ThreadLocal<Boolean> creating = new ThreadLocal<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
     final ObjectWriterCreator creator;
     final List<ObjectWriterModule> modules = new ArrayList<>();
@@ -659,6 +659,40 @@ public class ObjectWriterProvider
             }
         }
 
+        return getObjectWriterWithLock(objectType, objectClass, fieldBased);
+    }
+
+    private ObjectWriter getObjectWriterWithLock(Type objectType, Class objectClass, boolean fieldBased) {
+        ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
+        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
+        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
+        boolean outermost = creating.get() == null;
+
+        if (outermost) {
+            createLock.lock();
+            creating.set(Boolean.TRUE);
+        } else if (!createLock.tryLock()) {
+            // Do not wait while creating another type. Two creators can depend on each
+            // other from different threads, so waiting here could deadlock.
+            return resolveObjectWriter(objectType, objectClass, fieldBased);
+        }
+
+        try {
+            ObjectWriter objectWriter = targetCache.get(objectType);
+            return objectWriter != null
+                    ? objectWriter
+                    : resolveObjectWriter(objectType, objectClass, fieldBased);
+        } finally {
+            if (outermost) {
+                creating.remove();
+            }
+            createLock.unlock();
+        }
+    }
+
+    private ObjectWriter resolveObjectWriter(Type objectType, Class objectClass, boolean fieldBased) {
+        ObjectWriter objectWriter = null;
+        String className = objectClass.getName();
         boolean useModules = true;
         if (fieldBased) {
             if (Iterable.class.isAssignableFrom(objectClass)
@@ -738,35 +772,14 @@ public class ObjectWriterProvider
 
     private ObjectWriter createObjectWriter(Class objectClass, Type objectType, boolean fieldBased) {
         ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
-        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
-        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
-        boolean locked = false;
-        try {
-            try {
-                locked = createLock.tryLock(CREATE_LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-
-            ObjectWriter objectWriter = targetCache.get(objectType);
-            if (objectWriter != null) {
-                return objectWriter;
-            }
-
-            ObjectWriterCreator creator = getCreator();
-            objectWriter = creator.createObjectWriter(
-                    objectClass,
-                    fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
-                    this
-            );
-            ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
-            return previous != null ? previous : objectWriter;
-        } finally {
-            if (locked) {
-                createLock.unlock();
-                targetLocks.remove(objectType, createLock);
-            }
-        }
+        ObjectWriterCreator creator = getCreator();
+        ObjectWriter objectWriter = creator.createObjectWriter(
+                objectClass,
+                fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
+                this
+        );
+        ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
+        return previous != null ? previous : objectWriter;
     }
 
     static final int ENUM = 0x00004000;
@@ -862,6 +875,8 @@ public class ObjectWriterProvider
         mixInCache.clear();
         cache.clear();
         cacheFieldBased.clear();
+        createLocks.clear();
+        createLocksFieldBased.clear();
     }
 
     /**
@@ -873,6 +888,8 @@ public class ObjectWriterProvider
         mixInCache.remove(objectClass);
         cache.remove(objectClass);
         cacheFieldBased.remove(objectClass);
+        createLocks.remove(objectClass);
+        createLocksFieldBased.remove(objectClass);
 
         BeanUtils.cleanupCache(objectClass);
     }
@@ -938,6 +955,14 @@ public class ObjectWriterProvider
 
         cacheFieldBased.entrySet().removeIf(
                 entry -> match(entry.getKey(), entry.getValue(), classLoader, checkedMap)
+        );
+
+        createLocks.keySet().removeIf(
+                type -> match(type, null, classLoader, checkedMap)
+        );
+
+        createLocksFieldBased.keySet().removeIf(
+                type -> match(type, null, classLoader, checkedMap)
         );
 
         BeanUtils.cleanupCache(classLoader);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -667,7 +667,11 @@ public class ObjectWriterProvider
                 fieldBased ? createLocksFieldBased : createLocks;
         try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
             if (scope.isLockFreeFallback()) {
-                ObjectWriter objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
+                ObjectWriter objectWriter = targetCache.get(objectType);
+                if (objectWriter != null) {
+                    return objectWriter;
+                }
+                objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
                 return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
             }
             ObjectWriter objectWriter = targetCache.get(objectType);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.PropertyNamingStrategy;
 import com.alibaba.fastjson2.codec.BeanInfo;
 import com.alibaba.fastjson2.codec.FieldInfo;
+import com.alibaba.fastjson2.internal.CodecCreationCoordinator;
 import com.alibaba.fastjson2.modules.ObjectCodecProvider;
 import com.alibaba.fastjson2.modules.ObjectWriterAnnotationProcessor;
 import com.alibaba.fastjson2.modules.ObjectWriterModule;
@@ -22,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * ObjectWriterProvider is responsible for providing and managing ObjectWriter instances
@@ -67,13 +67,12 @@ public class ObjectWriterProvider
 
     final ConcurrentMap<Type, ObjectWriter> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectWriter> cacheFieldBased = new ConcurrentHashMap<>();
-    // Keep lock entries stable while a Type can be cached or retried after a failed creation.
-    final ConcurrentMap<Type, ReentrantLock> createLocks = new ConcurrentHashMap<>();
-    final ConcurrentMap<Type, ReentrantLock> createLocksFieldBased = new ConcurrentHashMap<>();
-    final ThreadLocal<Boolean> creating = new ThreadLocal<>();
+    final ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> createLocks = new ConcurrentHashMap<>();
+    final ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> createLocksFieldBased = new ConcurrentHashMap<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
     final ObjectWriterCreator creator;
     final List<ObjectWriterModule> modules = new ArrayList<>();
+
     PropertyNamingStrategy namingStrategy;
 
     boolean disableReferenceDetect = JSONFactory.isDisableReferenceDetect();
@@ -664,29 +663,27 @@ public class ObjectWriterProvider
 
     private ObjectWriter getObjectWriterWithLock(Type objectType, Class objectClass, boolean fieldBased) {
         ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
-        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
-        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
-        boolean outermost = creating.get() == null;
-
-        if (outermost) {
-            createLock.lock();
-            creating.set(Boolean.TRUE);
-        } else if (!createLock.tryLock()) {
-            // Do not wait while creating another type. Two creators can depend on each
-            // other from different threads, so waiting here could deadlock.
-            return resolveObjectWriter(objectType, objectClass, fieldBased);
-        }
-
-        try {
-            ObjectWriter objectWriter = targetCache.get(objectType);
-            return objectWriter != null
-                    ? objectWriter
-                    : resolveObjectWriter(objectType, objectClass, fieldBased);
-        } finally {
-            if (outermost) {
-                creating.remove();
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> targetLocks =
+                fieldBased ? createLocksFieldBased : createLocks;
+        try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
+            if (scope.isCycleDetected()) {
+                ObjectWriter objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
+                ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
+                return previous != null ? previous : objectWriter;
             }
-            createLock.unlock();
+            ObjectWriter objectWriter = targetCache.get(objectType);
+            if (objectWriter != null) {
+                return objectWriter;
+            }
+            scope.throwIfFailed();
+            try {
+                objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
+                ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
+                return previous != null ? previous : objectWriter;
+            } catch (RuntimeException | Error error) {
+                scope.fail(error);
+                throw error;
+            }
         }
     }
 
@@ -875,8 +872,6 @@ public class ObjectWriterProvider
         mixInCache.clear();
         cache.clear();
         cacheFieldBased.clear();
-        createLocks.clear();
-        createLocksFieldBased.clear();
     }
 
     /**
@@ -888,8 +883,6 @@ public class ObjectWriterProvider
         mixInCache.remove(objectClass);
         cache.remove(objectClass);
         cacheFieldBased.remove(objectClass);
-        createLocks.remove(objectClass);
-        createLocksFieldBased.remove(objectClass);
 
         BeanUtils.cleanupCache(objectClass);
     }
@@ -955,14 +948,6 @@ public class ObjectWriterProvider
 
         cacheFieldBased.entrySet().removeIf(
                 entry -> match(entry.getKey(), entry.getValue(), classLoader, checkedMap)
-        );
-
-        createLocks.keySet().removeIf(
-                type -> match(type, null, classLoader, checkedMap)
-        );
-
-        createLocksFieldBased.keySet().removeIf(
-                type -> match(type, null, classLoader, checkedMap)
         );
 
         BeanUtils.cleanupCache(classLoader);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -666,10 +666,9 @@ public class ObjectWriterProvider
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> targetLocks =
                 fieldBased ? createLocksFieldBased : createLocks;
         try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
-            if (scope.isCycleDetected()) {
+            if (scope.isLockFreeFallback()) {
                 ObjectWriter objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
-                ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
-                return previous != null ? previous : objectWriter;
+                return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
             }
             ObjectWriter objectWriter = targetCache.get(objectType);
             if (objectWriter != null) {
@@ -678,8 +677,7 @@ public class ObjectWriterProvider
             scope.throwIfFailed();
             try {
                 objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
-                ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
-                return previous != null ? previous : objectWriter;
+                return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
             } catch (RuntimeException | Error error) {
                 scope.fail(error);
                 throw error;
@@ -689,6 +687,7 @@ public class ObjectWriterProvider
 
     private ObjectWriter resolveObjectWriter(Type objectType, Class objectClass, boolean fieldBased) {
         ObjectWriter objectWriter = null;
+        ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
         String className = objectClass.getName();
         boolean useModules = true;
         if (fieldBased) {
@@ -703,14 +702,7 @@ public class ObjectWriterProvider
                 ObjectWriterModule module = modules.get(i);
                 objectWriter = module.getObjectWriter(objectType, objectClass);
                 if (objectWriter != null) {
-                    ObjectWriter previous = fieldBased
-                            ? cacheFieldBased.putIfAbsent(objectType, objectWriter)
-                            : cache.putIfAbsent(objectType, objectWriter);
-
-                    if (previous != null) {
-                        objectWriter = previous;
-                    }
-                    return objectWriter;
+                    return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
                 }
             }
         }
@@ -745,26 +737,16 @@ public class ObjectWriterProvider
         }
 
         if (objectWriter != null) {
-            ObjectWriter previous = fieldBased
-                    ? cacheFieldBased.putIfAbsent(objectType, objectWriter)
-                    : cache.putIfAbsent(objectType, objectWriter);
-            if (previous != null) {
-                objectWriter = previous;
-            }
-            return objectWriter;
+            return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
         }
 
-        if (objectWriter == null
-                && (!fieldBased)
+        if (!fieldBased
                 && Map.class.isAssignableFrom(objectClass)
                 && BeanUtils.isExtendedMap(objectClass)) {
             return ObjectWriterImplMap.of(objectClass);
         }
 
-        if (objectWriter == null) {
-            return createObjectWriter(objectClass, objectType, fieldBased);
-        }
-        return objectWriter;
+        return createObjectWriter(objectClass, objectType, fieldBased);
     }
 
     private ObjectWriter createObjectWriter(Class objectClass, Type objectType, boolean fieldBased) {
@@ -775,8 +757,7 @@ public class ObjectWriterProvider
                 fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
                 this
         );
-        ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
-        return previous != null ? previous : objectWriter;
+        return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
     }
 
     static final int ENUM = 0x00004000;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -66,6 +66,12 @@ public class ObjectWriterProvider
 
     final ConcurrentMap<Type, ObjectWriter> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectWriter> cacheFieldBased = new ConcurrentHashMap<>();
+    final ClassValue<Object> createLock = new ClassValue<Object>() {
+        @Override
+        protected Object computeValue(Class<?> type) {
+            return new Object();
+        }
+    };
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
     final ObjectWriterCreator creator;
     final List<ObjectWriterModule> modules = new ArrayList<>();
@@ -726,18 +732,21 @@ public class ObjectWriterProvider
         }
 
         if (objectWriter == null) {
-            ObjectWriterCreator creator = getCreator();
-            objectWriter = creator.createObjectWriter(
-                    objectClass,
-                    fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
-                    this
-            );
-            ObjectWriter previous = fieldBased
-                    ? cacheFieldBased.putIfAbsent(objectType, objectWriter)
-                    : cache.putIfAbsent(objectType, objectWriter);
-
-            if (previous != null) {
-                objectWriter = previous;
+            ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
+            synchronized (createLock.get(objectClass)) {
+                objectWriter = targetCache.get(objectType);
+                if (objectWriter == null) {
+                    ObjectWriterCreator creator = getCreator();
+                    objectWriter = creator.createObjectWriter(
+                            objectClass,
+                            fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
+                            this
+                    );
+                    ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
+                    if (previous != null) {
+                        objectWriter = previous;
+                    }
+                }
             }
         }
         return objectWriter;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -20,8 +20,10 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * ObjectWriterProvider is responsible for providing and managing ObjectWriter instances
@@ -57,6 +59,7 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class ObjectWriterProvider
         implements ObjectCodecProvider {
+    static final long CREATE_LOCK_TIMEOUT_MILLIS = 1000;
     static final int TYPE_INT32_MASK = 1 << 1;
     static final int TYPE_INT64_MASK = 1 << 2;
     static final int TYPE_DECIMAL_MASK = 1 << 3;
@@ -66,12 +69,8 @@ public class ObjectWriterProvider
 
     final ConcurrentMap<Type, ObjectWriter> cache = new ConcurrentHashMap<>();
     final ConcurrentMap<Type, ObjectWriter> cacheFieldBased = new ConcurrentHashMap<>();
-    final ClassValue<Object> createLock = new ClassValue<Object>() {
-        @Override
-        protected Object computeValue(Class<?> type) {
-            return new Object();
-        }
-    };
+    final ConcurrentMap<Type, ReentrantLock> createLocks = new ConcurrentHashMap<>();
+    final ConcurrentMap<Type, ReentrantLock> createLocksFieldBased = new ConcurrentHashMap<>();
     final ConcurrentMap<Class, Class> mixInCache = new ConcurrentHashMap<>();
     final ObjectWriterCreator creator;
     final List<ObjectWriterModule> modules = new ArrayList<>();
@@ -732,24 +731,42 @@ public class ObjectWriterProvider
         }
 
         if (objectWriter == null) {
-            ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
-            synchronized (createLock.get(objectClass)) {
-                objectWriter = targetCache.get(objectType);
-                if (objectWriter == null) {
-                    ObjectWriterCreator creator = getCreator();
-                    objectWriter = creator.createObjectWriter(
-                            objectClass,
-                            fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
-                            this
-                    );
-                    ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
-                    if (previous != null) {
-                        objectWriter = previous;
-                    }
-                }
-            }
+            return createObjectWriter(objectClass, objectType, fieldBased);
         }
         return objectWriter;
+    }
+
+    private ObjectWriter createObjectWriter(Class objectClass, Type objectType, boolean fieldBased) {
+        ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
+        ConcurrentMap<Type, ReentrantLock> targetLocks = fieldBased ? createLocksFieldBased : createLocks;
+        ReentrantLock createLock = targetLocks.computeIfAbsent(objectType, type -> new ReentrantLock());
+        boolean locked = false;
+        try {
+            try {
+                locked = createLock.tryLock(CREATE_LOCK_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            ObjectWriter objectWriter = targetCache.get(objectType);
+            if (objectWriter != null) {
+                return objectWriter;
+            }
+
+            ObjectWriterCreator creator = getCreator();
+            objectWriter = creator.createObjectWriter(
+                    objectClass,
+                    fieldBased ? JSONWriter.Feature.FieldBased.mask : 0,
+                    this
+            );
+            ObjectWriter previous = targetCache.putIfAbsent(objectType, objectWriter);
+            return previous != null ? previous : objectWriter;
+        } finally {
+            if (locked) {
+                createLock.unlock();
+                targetLocks.remove(objectType, createLock);
+            }
+        }
     }
 
     static final int ENUM = 0x00004000;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -665,20 +665,19 @@ public class ObjectWriterProvider
         ConcurrentMap<Type, ObjectWriter> targetCache = fieldBased ? cacheFieldBased : cache;
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> targetLocks =
                 fieldBased ? createLocksFieldBased : createLocks;
-        try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType)) {
+        try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(targetLocks, objectType, targetCache)) {
+            ObjectWriter objectWriter = (ObjectWriter) scope.getCachedValue();
+            if (objectWriter == null) {
+                objectWriter = targetCache.get(objectType);
+            }
+            if (objectWriter != null) {
+                return scope.complete(objectWriter);
+            }
             if (scope.isLockFreeFallback()) {
-                ObjectWriter objectWriter = targetCache.get(objectType);
-                if (objectWriter != null) {
-                    return scope.complete(objectWriter);
-                }
                 objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
                 return scope.complete(
                         CodecCreationCoordinator.publish(targetCache, objectType, objectWriter)
                 );
-            }
-            ObjectWriter objectWriter = targetCache.get(objectType);
-            if (objectWriter != null) {
-                return scope.complete(objectWriter);
             }
             scope.throwIfFailed();
             try {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -669,19 +669,23 @@ public class ObjectWriterProvider
             if (scope.isLockFreeFallback()) {
                 ObjectWriter objectWriter = targetCache.get(objectType);
                 if (objectWriter != null) {
-                    return objectWriter;
+                    return scope.complete(objectWriter);
                 }
                 objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
-                return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
+                return scope.complete(
+                        CodecCreationCoordinator.publish(targetCache, objectType, objectWriter)
+                );
             }
             ObjectWriter objectWriter = targetCache.get(objectType);
             if (objectWriter != null) {
-                return objectWriter;
+                return scope.complete(objectWriter);
             }
             scope.throwIfFailed();
             try {
                 objectWriter = resolveObjectWriter(objectType, objectClass, fieldBased);
-                return CodecCreationCoordinator.publish(targetCache, objectType, objectWriter);
+                return scope.complete(
+                        CodecCreationCoordinator.publish(targetCache, objectType, objectWriter)
+                );
             } catch (RuntimeException | Error error) {
                 scope.fail(error);
                 throw error;

--- a/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderConcurrentTest.java
@@ -1,0 +1,120 @@
+package com.alibaba.fastjson2;
+
+import com.alibaba.fastjson2.reader.ObjectReader;
+import com.alibaba.fastjson2.reader.ObjectReaderCreator;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import com.alibaba.fastjson2.writer.ObjectWriterCreator;
+import com.alibaba.fastjson2.writer.ObjectWriterProvider;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ObjectCodecProviderConcurrentTest {
+    @Test
+    public void testCrossProviderNestedCreationDoesNotDeadlock() throws InterruptedException {
+        CountDownLatch creating = new CountDownLatch(2);
+        ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        AtomicReference<ObjectReaderProvider> readerProviderRef = new AtomicReference<>();
+        AtomicReference<ObjectWriterProvider> writerProviderRef = new AtomicReference<>();
+
+        ObjectReaderCreator readerCreator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (objectClass == ReaderBean.class && nested.get() == null) {
+                    nested.set(Boolean.TRUE);
+                    try {
+                        awaitConcurrentCreation(creating);
+                        writerProviderRef.get().getObjectWriter(WriterBean.class);
+                    } finally {
+                        nested.remove();
+                    }
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectWriterCreator writerCreator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (objectClass == WriterBean.class && nested.get() == null) {
+                    nested.set(Boolean.TRUE);
+                    try {
+                        awaitConcurrentCreation(creating);
+                        readerProviderRef.get().getObjectReader(ReaderBean.class);
+                    } finally {
+                        nested.remove();
+                    }
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+
+        ObjectReaderProvider readerProvider = new ObjectReaderProvider(readerCreator);
+        ObjectWriterProvider writerProvider = new ObjectWriterProvider(writerCreator);
+        readerProviderRef.set(readerProvider);
+        writerProviderRef.set(writerProvider);
+
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+        startDaemonThread(() -> {
+            try {
+                readerProvider.getObjectReader(ReaderBean.class);
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                done.countDown();
+            }
+        });
+        startDaemonThread(() -> {
+            try {
+                writerProvider.getObjectWriter(WriterBean.class);
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                done.countDown();
+            }
+        });
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+    }
+
+    private static void awaitConcurrentCreation(CountDownLatch creating) {
+        creating.countDown();
+        try {
+            if (!creating.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("reader and writer were not created concurrently");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void startDaemonThread(Runnable task) {
+        Thread thread = new Thread(task);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    public static class ReaderBean {
+    }
+
+    public static class WriterBean {
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderConcurrentTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ObjectCodecProviderConcurrentTest {
@@ -23,6 +24,8 @@ public class ObjectCodecProviderConcurrentTest {
         ThreadLocal<Boolean> nested = new ThreadLocal<>();
         AtomicReference<ObjectReaderProvider> readerProviderRef = new AtomicReference<>();
         AtomicReference<ObjectWriterProvider> writerProviderRef = new AtomicReference<>();
+        AtomicReference<ObjectReader> nestedReader = new AtomicReference<>();
+        AtomicReference<ObjectWriter> nestedWriter = new AtomicReference<>();
 
         ObjectReaderCreator readerCreator = new ObjectReaderCreator() {
             @Override
@@ -36,7 +39,7 @@ public class ObjectCodecProviderConcurrentTest {
                     nested.set(Boolean.TRUE);
                     try {
                         awaitConcurrentCreation(creating);
-                        writerProviderRef.get().getObjectWriter(WriterBean.class);
+                        nestedWriter.set(writerProviderRef.get().getObjectWriter(WriterBean.class));
                     } finally {
                         nested.remove();
                     }
@@ -55,7 +58,7 @@ public class ObjectCodecProviderConcurrentTest {
                     nested.set(Boolean.TRUE);
                     try {
                         awaitConcurrentCreation(creating);
-                        readerProviderRef.get().getObjectReader(ReaderBean.class);
+                        nestedReader.set(readerProviderRef.get().getObjectReader(ReaderBean.class));
                     } finally {
                         nested.remove();
                     }
@@ -70,10 +73,12 @@ public class ObjectCodecProviderConcurrentTest {
         writerProviderRef.set(writerProvider);
 
         AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<ObjectReader> reader = new AtomicReference<>();
+        AtomicReference<ObjectWriter> writer = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(2);
         startDaemonThread(() -> {
             try {
-                readerProvider.getObjectReader(ReaderBean.class);
+                reader.set(readerProvider.getObjectReader(ReaderBean.class));
             } catch (Throwable e) {
                 error.compareAndSet(null, e);
             } finally {
@@ -82,7 +87,7 @@ public class ObjectCodecProviderConcurrentTest {
         });
         startDaemonThread(() -> {
             try {
-                writerProvider.getObjectWriter(WriterBean.class);
+                writer.set(writerProvider.getObjectWriter(WriterBean.class));
             } catch (Throwable e) {
                 error.compareAndSet(null, e);
             } finally {
@@ -92,6 +97,10 @@ public class ObjectCodecProviderConcurrentTest {
 
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
+        assertSame(readerProvider.getObjectReader(ReaderBean.class), reader.get());
+        assertSame(readerProvider.getObjectReader(ReaderBean.class), nestedReader.get());
+        assertSame(writerProvider.getObjectWriter(WriterBean.class), writer.get());
+        assertSame(writerProvider.getObjectWriter(WriterBean.class), nestedWriter.get());
     }
 
     private static void awaitConcurrentCreation(CountDownLatch creating) {

--- a/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderConcurrentTest.java
@@ -95,7 +95,8 @@ public class ObjectCodecProviderConcurrentTest {
             }
         });
 
-        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertTrue(creating.await(5, TimeUnit.SECONDS));
+        assertTrue(done.await(4, TimeUnit.SECONDS));
         assertNull(error.get());
         assertSame(readerProvider.getObjectReader(ReaderBean.class), reader.get());
         assertSame(readerProvider.getObjectReader(ReaderBean.class), nestedReader.get());

--- a/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderLivenessTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/ObjectCodecProviderLivenessTest.java
@@ -1,0 +1,152 @@
+package com.alibaba.fastjson2;
+
+import com.alibaba.fastjson2.reader.ObjectReader;
+import com.alibaba.fastjson2.reader.ObjectReaderCreator;
+import com.alibaba.fastjson2.reader.ObjectReaderProvider;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import com.alibaba.fastjson2.writer.ObjectWriterCreator;
+import com.alibaba.fastjson2.writer.ObjectWriterProvider;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ObjectCodecProviderLivenessTest {
+    @Test
+    public void testReaderExternalDependencyThroughTwoCreators() throws InterruptedException {
+        ExternalDependency dependency = new ExternalDependency();
+        ObjectReaderProvider provider = new ObjectReaderProvider(new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (objectClass == Bean.class) {
+                    dependency.enter();
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        });
+        dependency.check(() -> provider.getObjectReader(Bean.class));
+    }
+
+    @Test
+    public void testWriterExternalDependencyThroughTwoCreators() throws InterruptedException {
+        ExternalDependency dependency = new ExternalDependency();
+        ObjectWriterProvider provider = new ObjectWriterProvider(new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (objectClass == Bean.class) {
+                    dependency.enter();
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        });
+        dependency.check(() -> provider.getObjectWriter(Bean.class));
+    }
+
+    private static class ExternalDependency {
+        final AtomicInteger creates = new AtomicInteger();
+        final CountDownLatch firstEntered = new CountDownLatch(1);
+        final CountDownLatch secondEntered = new CountDownLatch(1);
+        final CountDownLatch dependencyResolved = new CountDownLatch(1);
+
+        void enter() {
+            int count = creates.incrementAndGet();
+            if (count == 1) {
+                firstEntered.countDown();
+            } else if (count == 2) {
+                secondEntered.countDown();
+            }
+            if (count <= 2) {
+                try {
+                    assertTrue(dependencyResolved.await(30, TimeUnit.SECONDS));
+                } catch (InterruptedException error) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(error);
+                }
+            }
+        }
+
+        void check(Supplier<Object> lookup) throws InterruptedException {
+            AtomicReference<Throwable> error = new AtomicReference<>();
+            AtomicReference<Object> firstResult = new AtomicReference<>();
+            AtomicReference<Object> secondResult = new AtomicReference<>();
+            AtomicReference<Object> thirdResult = new AtomicReference<>();
+            CountDownLatch firstDone = new CountDownLatch(1);
+            CountDownLatch secondDone = new CountDownLatch(1);
+            CountDownLatch thirdDone = new CountDownLatch(1);
+            boolean secondStarted = false;
+            boolean thirdStarted = false;
+            startLookup(lookup, firstResult, error, firstDone, false);
+            try {
+                assertTrue(firstEntered.await(5, TimeUnit.SECONDS));
+                startLookup(lookup, secondResult, error, secondDone, false);
+                secondStarted = true;
+                assertTrue(secondEntered.await(10, TimeUnit.SECONDS));
+                startLookup(lookup, thirdResult, error, thirdDone, true);
+                thirdStarted = true;
+                // Both creators are waiting for this lookup, not for a test-thread release.
+                assertTrue(thirdDone.await(10, TimeUnit.SECONDS));
+                assertNull(error.get());
+                assertEquals(0, dependencyResolved.getCount());
+            } finally {
+                dependencyResolved.countDown();
+                assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+                if (secondStarted) {
+                    assertTrue(secondDone.await(5, TimeUnit.SECONDS));
+                }
+                if (thirdStarted) {
+                    assertTrue(thirdDone.await(5, TimeUnit.SECONDS));
+                }
+            }
+            assertNull(error.get());
+            assertEquals(3, creates.get());
+            assertSame(thirdResult.get(), firstResult.get());
+            assertSame(thirdResult.get(), secondResult.get());
+            assertSame(thirdResult.get(), lookup.get());
+        }
+
+        void startLookup(
+                Supplier<Object> lookup,
+                AtomicReference<Object> result,
+                AtomicReference<Throwable> error,
+                CountDownLatch done,
+                boolean resolvesDependency
+        ) {
+            Thread thread = new Thread(() -> {
+                try {
+                    result.set(lookup.get());
+                    if (resolvesDependency) {
+                        dependencyResolved.countDown();
+                    }
+                } catch (Throwable failure) {
+                    error.compareAndSet(null, failure);
+                } finally {
+                    done.countDown();
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    public static class Bean {
+        public int id;
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -111,6 +112,114 @@ public class CodecCreationCoordinatorTest {
         assertTrue(locks.isEmpty());
     }
 
+    @Test
+    public void testFailureDoesNotLeakAcrossLockGenerations() throws InterruptedException {
+        ReleaseRaceMap locks = new ReleaseRaceMap();
+        IllegalStateException expectedError = new IllegalStateException("first creation failed");
+        CountDownLatch firstAcquired = new CountDownLatch(1);
+        CountDownLatch startRelease = new CountDownLatch(1);
+        CountDownLatch firstDone = new CountDownLatch(1);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+
+        Thread first = startDaemonThread(() -> {
+            locks.releaseThread = Thread.currentThread();
+            try {
+                CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(locks, Bean.class);
+                scope.fail(expectedError);
+                locks.coordinateRelease = true;
+                firstAcquired.countDown();
+                await(startRelease);
+                scope.close();
+            } catch (Throwable error) {
+                firstError.set(error);
+            } finally {
+                firstDone.countDown();
+            }
+        });
+
+        assertTrue(firstAcquired.await(5, TimeUnit.SECONDS));
+        startRelease.countDown();
+        assertTrue(locks.releaseLinearized.await(5, TimeUnit.SECONDS));
+
+        CountDownLatch retryDone = new CountDownLatch(1);
+        AtomicReference<Throwable> retryError = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope scope =
+                         CodecCreationCoordinator.acquire(locks, Bean.class)) {
+                scope.throwIfFailed();
+            } catch (Throwable error) {
+                retryError.set(error);
+            } finally {
+                retryDone.countDown();
+            }
+        });
+
+        assertTrue(locks.freshComputeStarted.await(5, TimeUnit.SECONDS));
+        locks.continueRelease.countDown();
+        assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+        assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+        first.join(1000);
+
+        assertNull(firstError.get());
+        assertNull(retryError.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testExternalWaitUsesSingleRateLimitedFallback() throws InterruptedException {
+        int threadCount = 8;
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(100);
+        long fallbackIntervalNanos = TimeUnit.SECONDS.toNanos(1);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(
+                locks,
+                Bean.class,
+                waitNanos,
+                fallbackIntervalNanos
+        );
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        AtomicInteger fallbacks = new AtomicInteger();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            startDaemonThread(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(
+                            locks,
+                            Bean.class,
+                            waitNanos,
+                            fallbackIntervalNanos
+                    )) {
+                        if (scope.isLockFreeFallback()) {
+                            assertFalse(scope.isCycleDetected());
+                            fallbacks.incrementAndGet();
+                            fallbackEntered.countDown();
+                        }
+                    }
+                } catch (Throwable e) {
+                    error.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        assertTrue(ready.await(5, TimeUnit.SECONDS));
+        start.countDown();
+        assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+        first.close();
+
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(1, fallbacks.get());
+        assertTrue(locks.isEmpty());
+    }
+
     private static void startCycleThread(
             ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks,
             Type first,
@@ -142,10 +251,24 @@ public class CodecCreationCoordinatorTest {
 
     private static void awaitWaiting(Thread thread) throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+        while (!isWaiting(thread) && System.nanoTime() < deadline) {
             TimeUnit.MILLISECONDS.sleep(1);
         }
-        assertEquals(Thread.State.WAITING, thread.getState());
+        assertTrue(isWaiting(thread));
+    }
+
+    private static boolean isWaiting(Thread thread) {
+        Thread.State state = thread.getState();
+        return state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING;
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(error);
+        }
     }
 
     private static Thread startDaemonThread(Runnable task) {
@@ -165,5 +288,53 @@ public class CodecCreationCoordinatorTest {
     }
 
     public static class BeanC {
+    }
+
+    static final class ReleaseRaceMap
+            extends ConcurrentHashMap<Type, CodecCreationCoordinator.LockEntry> {
+        final CountDownLatch releaseLinearized = new CountDownLatch(1);
+        final CountDownLatch freshComputeStarted = new CountDownLatch(1);
+        final CountDownLatch freshComputed = new CountDownLatch(1);
+        final CountDownLatch continueRelease = new CountDownLatch(1);
+        volatile Thread releaseThread;
+        volatile boolean coordinateRelease;
+
+        @Override
+        public CodecCreationCoordinator.LockEntry compute(
+                Type key,
+                BiFunction<? super Type, ? super CodecCreationCoordinator.LockEntry,
+                        ? extends CodecCreationCoordinator.LockEntry> remappingFunction
+        ) {
+            if (coordinateRelease && Thread.currentThread() == releaseThread) {
+                return super.compute(key, (type, current) -> {
+                    CodecCreationCoordinator.LockEntry result = remappingFunction.apply(type, current);
+                    releaseLinearized.countDown();
+                    await(continueRelease);
+                    return result;
+                });
+            }
+
+            if (coordinateRelease) {
+                freshComputeStarted.countDown();
+            }
+            CodecCreationCoordinator.LockEntry result = super.compute(key, remappingFunction);
+            if (coordinateRelease) {
+                freshComputed.countDown();
+            }
+            return result;
+        }
+
+        @Override
+        public CodecCreationCoordinator.LockEntry computeIfPresent(
+                Type key,
+                BiFunction<? super Type, ? super CodecCreationCoordinator.LockEntry,
+                        ? extends CodecCreationCoordinator.LockEntry> remappingFunction
+        ) {
+            if (coordinateRelease && Thread.currentThread() == releaseThread) {
+                releaseLinearized.countDown();
+                await(freshComputed);
+            }
+            return super.computeIfPresent(key, remappingFunction);
+        }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -1,0 +1,169 @@
+package com.alibaba.fastjson2.internal;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CodecCreationCoordinatorTest {
+    @Test
+    public void testSameTypeIsSerializedAndLockIsReleased() throws InterruptedException {
+        int threadCount = 64;
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        AtomicInteger active = new AtomicInteger();
+        AtomicInteger maxActive = new AtomicInteger();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            startDaemonThread(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    try (CodecCreationCoordinator.Scope scope =
+                                 CodecCreationCoordinator.acquire(locks, Bean.class)) {
+                        assertFalse(scope.isCycleDetected());
+                        int count = active.incrementAndGet();
+                        maxActive.accumulateAndGet(count, Math::max);
+                        TimeUnit.MILLISECONDS.sleep(2);
+                        active.decrementAndGet();
+                    }
+                } catch (Throwable e) {
+                    error.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        assertTrue(ready.await(5, TimeUnit.SECONDS));
+        start.countDown();
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(1, maxActive.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testThreeThreadDependencyCycleTerminates() throws InterruptedException {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CountDownLatch outerLocksAcquired = new CountDownLatch(3);
+        CountDownLatch done = new CountDownLatch(3);
+        AtomicInteger cycles = new AtomicInteger();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        startCycleThread(locks, BeanA.class, BeanB.class, outerLocksAcquired, done, cycles, error);
+        startCycleThread(locks, BeanB.class, BeanC.class, outerLocksAcquired, done, cycles, error);
+        startCycleThread(locks, BeanC.class, BeanA.class, outerLocksAcquired, done, cycles, error);
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertTrue(cycles.get() >= 1);
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testScopeCloseIsIdempotent() {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(locks, Bean.class);
+
+        scope.close();
+        scope.close();
+
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testPreInterruptedWaiterReleasesLockEntry() throws InterruptedException {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(locks, Bean.class);
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<Boolean> interrupted = new AtomicReference<>();
+
+        Thread waiter = startDaemonThread(() -> {
+            Thread.currentThread().interrupt();
+            try (CodecCreationCoordinator.Scope ignored =
+                         CodecCreationCoordinator.acquire(locks, Bean.class)) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable e) {
+                error.set(e);
+            } finally {
+                done.countDown();
+            }
+        });
+
+        awaitWaiting(waiter);
+        first.close();
+
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(Boolean.TRUE, interrupted.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    private static void startCycleThread(
+            ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks,
+            Type first,
+            Type second,
+            CountDownLatch outerLocksAcquired,
+            CountDownLatch done,
+            AtomicInteger cycles,
+            AtomicReference<Throwable> error
+    ) {
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope outer = CodecCreationCoordinator.acquire(locks, first)) {
+                assertFalse(outer.isCycleDetected());
+                outerLocksAcquired.countDown();
+                if (!outerLocksAcquired.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("outer creation locks were not acquired concurrently");
+                }
+                try (CodecCreationCoordinator.Scope inner = CodecCreationCoordinator.acquire(locks, second)) {
+                    if (inner.isCycleDetected()) {
+                        cycles.incrementAndGet();
+                    }
+                }
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                done.countDown();
+            }
+        });
+    }
+
+    private static void awaitWaiting(Thread thread) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(1);
+        }
+        assertEquals(Thread.State.WAITING, thread.getState());
+    }
+
+    private static Thread startDaemonThread(Runnable task) {
+        Thread thread = new Thread(task);
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+
+    public static class Bean {
+    }
+
+    public static class BeanA {
+    }
+
+    public static class BeanB {
+    }
+
+    public static class BeanC {
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -73,6 +73,50 @@ public class CodecCreationCoordinatorTest {
     }
 
     @Test
+    public void testDependencyCycleAcrossLockMapsIsDetected() throws InterruptedException {
+        long waitNanos = TimeUnit.SECONDS.toNanos(2);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> readerLocks = new ConcurrentHashMap<>();
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> writerLocks = new ConcurrentHashMap<>();
+        CountDownLatch outerLocksAcquired = new CountDownLatch(2);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicInteger cycles = new AtomicInteger();
+        AtomicInteger timedFallbacks = new AtomicInteger();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        startCrossMapCycleThread(
+                readerLocks,
+                BeanA.class,
+                writerLocks,
+                BeanB.class,
+                waitNanos,
+                outerLocksAcquired,
+                done,
+                cycles,
+                timedFallbacks,
+                error
+        );
+        startCrossMapCycleThread(
+                writerLocks,
+                BeanB.class,
+                readerLocks,
+                BeanA.class,
+                waitNanos,
+                outerLocksAcquired,
+                done,
+                cycles,
+                timedFallbacks,
+                error
+        );
+
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertTrue(cycles.get() >= 1);
+        assertEquals(0, timedFallbacks.get());
+        assertTrue(readerLocks.isEmpty());
+        assertTrue(writerLocks.isEmpty());
+    }
+
+    @Test
     public void testScopeCloseIsIdempotent() {
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
         CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(locks, Bean.class);
@@ -298,6 +342,145 @@ public class CodecCreationCoordinatorTest {
         assertTrue(locks.isEmpty());
     }
 
+    @Test
+    public void testFallbackOwnerSameThreadReentryIsCycle() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(
+                locks,
+                Bean.class,
+                waitNanos,
+                0
+        );
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<Boolean> cycleDetected = new AtomicReference<>();
+
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope fallback = CodecCreationCoordinator.acquire(
+                    locks,
+                    Bean.class,
+                    waitNanos,
+                    0
+            )) {
+                assertTrue(fallback.isLockFreeFallback());
+                assertFalse(fallback.isCycleDetected());
+                fallbackEntered.countDown();
+                try (CodecCreationCoordinator.Scope nested = CodecCreationCoordinator.acquire(
+                        locks,
+                        Bean.class,
+                        waitNanos,
+                        0
+                )) {
+                    cycleDetected.set(nested.isCycleDetected());
+                }
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                done.countDown();
+            }
+        });
+
+        boolean fallbackSeen;
+        boolean completedWhileFirstHeld;
+        try {
+            fallbackSeen = fallbackEntered.await(5, TimeUnit.SECONDS);
+            completedWhileFirstHeld = fallbackSeen
+                    && done.await(2, TimeUnit.SECONDS);
+        } finally {
+            first.close();
+        }
+
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertTrue(fallbackSeen);
+        assertTrue(completedWhileFirstHeld);
+        assertNull(error.get());
+        assertEquals(Boolean.TRUE, cycleDetected.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testDependencyCycleThroughFallbackOwnerIsDetected() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(
+                locks,
+                BeanA.class,
+                waitNanos,
+                0
+        );
+        CountDownLatch secondLockAcquired = new CountDownLatch(1);
+        CountDownLatch checkCycle = new CountDownLatch(1);
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+        CountDownLatch secondDone = new CountDownLatch(1);
+        AtomicReference<Boolean> cycleDetected = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope second =
+                         CodecCreationCoordinator.acquire(locks, BeanB.class)) {
+                secondLockAcquired.countDown();
+                await(checkCycle);
+                try (CodecCreationCoordinator.Scope nested = CodecCreationCoordinator.acquire(
+                        locks,
+                        BeanA.class,
+                        waitNanos,
+                        0
+                )) {
+                    cycleDetected.set(nested.isCycleDetected());
+                }
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                secondDone.countDown();
+            }
+        });
+
+        Thread fallbackThread = startDaemonThread(() -> {
+            try {
+                assertTrue(secondLockAcquired.await(5, TimeUnit.SECONDS));
+                try (CodecCreationCoordinator.Scope fallback = CodecCreationCoordinator.acquire(
+                        locks,
+                        BeanA.class,
+                        waitNanos,
+                        0
+                )) {
+                    assertTrue(fallback.isLockFreeFallback());
+                    assertFalse(fallback.isCycleDetected());
+                    fallbackEntered.countDown();
+                    try (CodecCreationCoordinator.Scope ignored =
+                                 CodecCreationCoordinator.acquire(locks, BeanB.class)) {
+                        // The second lock owner must detect the cycle through this fallback owner.
+                    }
+                }
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                fallbackDone.countDown();
+            }
+        });
+
+        boolean completedWhileFirstHeld;
+        try {
+            assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            awaitWaiting(fallbackThread);
+            checkCycle.countDown();
+            completedWhileFirstHeld = secondDone.await(2, TimeUnit.SECONDS);
+        } finally {
+            checkCycle.countDown();
+            first.close();
+        }
+
+        assertTrue(secondDone.await(5, TimeUnit.SECONDS));
+        assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        assertTrue(completedWhileFirstHeld);
+        assertNull(error.get());
+        assertEquals(Boolean.TRUE, cycleDetected.get());
+        assertTrue(locks.isEmpty());
+    }
+
     private static void startCycleThread(
             ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks,
             Type first,
@@ -317,6 +500,45 @@ public class CodecCreationCoordinatorTest {
                 try (CodecCreationCoordinator.Scope inner = CodecCreationCoordinator.acquire(locks, second)) {
                     if (inner.isCycleDetected()) {
                         cycles.incrementAndGet();
+                    }
+                }
+            } catch (Throwable e) {
+                error.compareAndSet(null, e);
+            } finally {
+                done.countDown();
+            }
+        });
+    }
+
+    private static void startCrossMapCycleThread(
+            ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> firstLocks,
+            Type first,
+            ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> secondLocks,
+            Type second,
+            long waitNanos,
+            CountDownLatch outerLocksAcquired,
+            CountDownLatch done,
+            AtomicInteger cycles,
+            AtomicInteger timedFallbacks,
+            AtomicReference<Throwable> error
+    ) {
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope outer = CodecCreationCoordinator.acquire(firstLocks, first)) {
+                assertFalse(outer.isCycleDetected());
+                outerLocksAcquired.countDown();
+                if (!outerLocksAcquired.await(5, TimeUnit.SECONDS)) {
+                    throw new IllegalStateException("outer creation locks were not acquired concurrently");
+                }
+                try (CodecCreationCoordinator.Scope inner = CodecCreationCoordinator.acquire(
+                        secondLocks,
+                        second,
+                        waitNanos,
+                        0
+                )) {
+                    if (inner.isCycleDetected()) {
+                        cycles.incrementAndGet();
+                    } else if (inner.isLockFreeFallback()) {
+                        timedFallbacks.incrementAndGet();
                     }
                 }
             } catch (Throwable e) {

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -113,6 +113,27 @@ public class CodecCreationCoordinatorTest {
     }
 
     @Test
+    public void testSameThreadDependencyCycleDoesNotReenterLock() {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+
+        try (CodecCreationCoordinator.Scope outer =
+                     CodecCreationCoordinator.acquire(locks, Bean.class)) {
+            assertFalse(outer.isCycleDetected());
+            CodecCreationCoordinator.LockEntry lockEntry = locks.get(Bean.class);
+            assertEquals(1, lockEntry.lock.getHoldCount());
+
+            try (CodecCreationCoordinator.Scope nested =
+                         CodecCreationCoordinator.acquire(locks, Bean.class)) {
+                assertTrue(nested.isCycleDetected());
+                assertTrue(nested.isLockFreeFallback());
+                assertEquals(1, lockEntry.lock.getHoldCount());
+            }
+        }
+
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
     public void testFailureDoesNotLeakAcrossLockGenerations() throws InterruptedException {
         ReleaseRaceMap locks = new ReleaseRaceMap();
         IllegalStateException expectedError = new IllegalStateException("first creation failed");
@@ -166,10 +187,10 @@ public class CodecCreationCoordinatorTest {
     }
 
     @Test
-    public void testExternalWaitUsesSingleRateLimitedFallback() throws InterruptedException {
+    public void testExternalWaitUsesSingleActiveFallback() throws InterruptedException {
         int threadCount = 8;
-        long waitNanos = TimeUnit.MILLISECONDS.toNanos(100);
-        long fallbackIntervalNanos = TimeUnit.SECONDS.toNanos(1);
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(50);
+        long fallbackIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
         CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(
                 locks,
@@ -180,6 +201,7 @@ public class CodecCreationCoordinatorTest {
         CountDownLatch ready = new CountDownLatch(threadCount);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch continueFallback = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(threadCount);
         AtomicInteger fallbacks = new AtomicInteger();
         AtomicReference<Throwable> error = new AtomicReference<>();
@@ -199,6 +221,7 @@ public class CodecCreationCoordinatorTest {
                             assertFalse(scope.isCycleDetected());
                             fallbacks.incrementAndGet();
                             fallbackEntered.countDown();
+                            assertTrue(continueFallback.await(5, TimeUnit.SECONDS));
                         }
                     }
                 } catch (Throwable e) {
@@ -209,14 +232,69 @@ public class CodecCreationCoordinatorTest {
             });
         }
 
-        assertTrue(ready.await(5, TimeUnit.SECONDS));
-        start.countDown();
-        assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
-        first.close();
+        try {
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (locks.get(Bean.class).references.get() < threadCount + 1
+                    && System.nanoTime() < deadline) {
+                TimeUnit.MILLISECONDS.sleep(1);
+            }
+            assertEquals(threadCount + 1, locks.get(Bean.class).references.get());
+            assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            TimeUnit.MILLISECONDS.sleep(350);
+            assertEquals(1, fallbacks.get());
+        } finally {
+            start.countDown();
+            first.close();
+            continueFallback.countDown();
+        }
 
         assertTrue(done.await(5, TimeUnit.SECONDS));
         assertNull(error.get());
         assertEquals(1, fallbacks.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testFallbackReservationIsReleasedWithScope() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(
+                locks,
+                Bean.class,
+                waitNanos,
+                0
+        );
+        AtomicInteger fallbacks = new AtomicInteger();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        try {
+            for (int i = 0; i < 2; i++) {
+                CountDownLatch done = new CountDownLatch(1);
+                startDaemonThread(() -> {
+                    try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(
+                            locks,
+                            Bean.class,
+                            waitNanos,
+                            0
+                    )) {
+                        assertTrue(scope.isLockFreeFallback());
+                        fallbacks.incrementAndGet();
+                    } catch (Throwable e) {
+                        error.compareAndSet(null, e);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                assertTrue(done.await(5, TimeUnit.SECONDS));
+                assertNull(error.get());
+            }
+        } finally {
+            first.close();
+        }
+
+        assertEquals(2, fallbacks.get());
         assertTrue(locks.isEmpty());
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -231,6 +231,65 @@ public class CodecCreationCoordinatorTest {
     }
 
     @Test
+    public void testFailureDoesNotLeakWhileFallbackRetainsLockEntry() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        IllegalStateException expectedError = new IllegalStateException("first creation failed");
+        CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(
+                locks,
+                Bean.class,
+                waitNanos,
+                0
+        );
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch releaseFallback = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+        AtomicReference<Throwable> fallbackError = new AtomicReference<>();
+
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope fallback = CodecCreationCoordinator.acquire(
+                    locks,
+                    Bean.class,
+                    waitNanos,
+                    0
+            )) {
+                assertTrue(fallback.isLockFreeFallback());
+                fallbackEntered.countDown();
+                await(releaseFallback);
+            } catch (Throwable error) {
+                fallbackError.set(error);
+            } finally {
+                fallbackDone.countDown();
+            }
+        });
+
+        AtomicInteger retryCreateCount = new AtomicInteger();
+        try {
+            assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            owner.fail(expectedError);
+            owner.close();
+
+            try (CodecCreationCoordinator.Scope retry = CodecCreationCoordinator.acquire(
+                    locks,
+                    Bean.class,
+                    waitNanos,
+                    0
+            )) {
+                retry.throwIfFailed();
+                retryCreateCount.incrementAndGet();
+            }
+        } finally {
+            owner.close();
+            releaseFallback.countDown();
+        }
+
+        assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        assertNull(fallbackError.get());
+        assertEquals(1, retryCreateCount.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
     public void testExternalWaitUsesSingleActiveFallback() throws InterruptedException {
         int threadCount = 8;
         long waitNanos = TimeUnit.MILLISECONDS.toNanos(50);
@@ -339,6 +398,67 @@ public class CodecCreationCoordinatorTest {
         }
 
         assertEquals(2, fallbacks.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testFallbackReservationRemainsRateLimitedAfterScopeClose() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        long fallbackIntervalNanos = TimeUnit.SECONDS.toNanos(30);
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope first = CodecCreationCoordinator.acquire(
+                locks,
+                Bean.class,
+                waitNanos,
+                fallbackIntervalNanos
+        );
+        CountDownLatch firstFallbackDone = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope fallback = CodecCreationCoordinator.acquire(
+                    locks,
+                    Bean.class,
+                    waitNanos,
+                    fallbackIntervalNanos
+            )) {
+                assertTrue(fallback.isLockFreeFallback());
+            } catch (Throwable throwable) {
+                error.compareAndSet(null, throwable);
+            } finally {
+                firstFallbackDone.countDown();
+            }
+        });
+
+        assertTrue(firstFallbackDone.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+
+        CountDownLatch secondDone = new CountDownLatch(1);
+        AtomicReference<Boolean> secondWasFallback = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(
+                    locks,
+                    Bean.class,
+                    waitNanos,
+                    fallbackIntervalNanos
+            )) {
+                secondWasFallback.set(scope.isLockFreeFallback());
+            } catch (Throwable throwable) {
+                error.compareAndSet(null, throwable);
+            } finally {
+                secondDone.countDown();
+            }
+        });
+
+        try {
+            assertFalse(secondDone.await(100, TimeUnit.MILLISECONDS));
+        } finally {
+            first.close();
+        }
+
+        assertTrue(secondDone.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(Boolean.FALSE, secondWasFallback.get());
         assertTrue(locks.isEmpty());
     }
 
@@ -594,7 +714,6 @@ public class CodecCreationCoordinatorTest {
             extends ConcurrentHashMap<Type, CodecCreationCoordinator.LockEntry> {
         final CountDownLatch releaseLinearized = new CountDownLatch(1);
         final CountDownLatch freshComputeStarted = new CountDownLatch(1);
-        final CountDownLatch freshComputed = new CountDownLatch(1);
         final CountDownLatch continueRelease = new CountDownLatch(1);
         volatile Thread releaseThread;
         volatile boolean coordinateRelease;
@@ -617,24 +736,7 @@ public class CodecCreationCoordinatorTest {
             if (coordinateRelease) {
                 freshComputeStarted.countDown();
             }
-            CodecCreationCoordinator.LockEntry result = super.compute(key, remappingFunction);
-            if (coordinateRelease) {
-                freshComputed.countDown();
-            }
-            return result;
-        }
-
-        @Override
-        public CodecCreationCoordinator.LockEntry computeIfPresent(
-                Type key,
-                BiFunction<? super Type, ? super CodecCreationCoordinator.LockEntry,
-                        ? extends CodecCreationCoordinator.LockEntry> remappingFunction
-        ) {
-            if (coordinateRelease && Thread.currentThread() == releaseThread) {
-                releaseLinearized.countDown();
-                await(freshComputed);
-            }
-            return super.computeIfPresent(key, remappingFunction);
+            return super.compute(key, remappingFunction);
         }
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -231,7 +231,7 @@ public class CodecCreationCoordinatorTest {
     }
 
     @Test
-    public void testFailureDoesNotLeakWhileFallbackRetainsLockEntry() throws InterruptedException {
+    public void testSuccessfulRetryClearsFailureWhileFallbackRetainsLockEntry() throws InterruptedException {
         long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
         ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
         IllegalStateException expectedError = new IllegalStateException("first creation failed");
@@ -241,6 +241,8 @@ public class CodecCreationCoordinatorTest {
                 waitNanos,
                 0
         );
+        CodecCreationCoordinator.LockEntry retainedLock = locks.get(Bean.class);
+        assertNotNull(retainedLock);
         CountDownLatch fallbackEntered = new CountDownLatch(1);
         CountDownLatch releaseFallback = new CountDownLatch(1);
         CountDownLatch fallbackDone = new CountDownLatch(1);
@@ -256,6 +258,7 @@ public class CodecCreationCoordinatorTest {
                 assertTrue(fallback.isLockFreeFallback());
                 fallbackEntered.countDown();
                 await(releaseFallback);
+                fallback.throwIfFailed();
             } catch (Throwable error) {
                 fallbackError.set(error);
             } finally {
@@ -266,8 +269,10 @@ public class CodecCreationCoordinatorTest {
         AtomicInteger retryCreateCount = new AtomicInteger();
         try {
             assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            assertSame(retainedLock, locks.get(Bean.class));
             owner.fail(expectedError);
             owner.close();
+            assertSame(retainedLock, locks.get(Bean.class));
 
             try (CodecCreationCoordinator.Scope retry = CodecCreationCoordinator.acquire(
                     locks,
@@ -277,7 +282,9 @@ public class CodecCreationCoordinatorTest {
             )) {
                 retry.throwIfFailed();
                 retryCreateCount.incrementAndGet();
+                assertTrue(retry.complete(Boolean.TRUE));
             }
+            assertSame(retainedLock, locks.get(Bean.class));
         } finally {
             owner.close();
             releaseFallback.countDown();

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTest.java
@@ -297,7 +297,7 @@ public class CodecCreationCoordinatorTest {
     }
 
     @Test
-    public void testExternalWaitUsesSingleActiveFallback() throws InterruptedException {
+    public void testExternalWaitAllowsProgressWhileEarlierFallbacksAreActive() throws InterruptedException {
         int threadCount = 8;
         long waitNanos = TimeUnit.MILLISECONDS.toNanos(50);
         long fallbackIntervalNanos = TimeUnit.MILLISECONDS.toNanos(100);
@@ -310,7 +310,7 @@ public class CodecCreationCoordinatorTest {
         );
         CountDownLatch ready = new CountDownLatch(threadCount);
         CountDownLatch start = new CountDownLatch(1);
-        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch fallbackEntered = new CountDownLatch(threadCount);
         CountDownLatch continueFallback = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(threadCount);
         AtomicInteger fallbacks = new AtomicInteger();
@@ -329,6 +329,10 @@ public class CodecCreationCoordinatorTest {
                     )) {
                         if (scope.isLockFreeFallback()) {
                             assertFalse(scope.isCycleDetected());
+                            try (CodecCreationCoordinator.Scope nested = CodecCreationCoordinator.acquire(locks, Bean.class)) {
+                                assertTrue(nested.isCycleDetected());
+                            }
+                            assertTrue(locks.get(Bean.class).fallbackOwners.containsValue(scope));
                             fallbacks.incrementAndGet();
                             fallbackEntered.countDown();
                             assertTrue(continueFallback.await(5, TimeUnit.SECONDS));
@@ -345,15 +349,10 @@ public class CodecCreationCoordinatorTest {
         try {
             assertTrue(ready.await(5, TimeUnit.SECONDS));
             start.countDown();
-            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-            while (locks.get(Bean.class).references.get() < threadCount + 1
-                    && System.nanoTime() < deadline) {
-                TimeUnit.MILLISECONDS.sleep(1);
-            }
-            assertEquals(threadCount + 1, locks.get(Bean.class).references.get());
             assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
-            TimeUnit.MILLISECONDS.sleep(350);
-            assertEquals(1, fallbacks.get());
+            assertEquals(threadCount, fallbacks.get());
+            assertEquals(threadCount, locks.get(Bean.class).fallbackOwners.size());
+            assertEquals(threadCount + 1, locks.get(Bean.class).references.get());
         } finally {
             start.countDown();
             first.close();
@@ -362,7 +361,103 @@ public class CodecCreationCoordinatorTest {
 
         assertTrue(done.await(5, TimeUnit.SECONDS));
         assertNull(error.get());
-        assertEquals(1, fallbacks.get());
+        assertEquals(threadCount, fallbacks.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testStaleFallbackAdmissionCannotOverwriteNewDeadline() {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        try (CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(locks, Bean.class)) {
+            CodecCreationCoordinator.LockEntry entry = locks.get(Bean.class);
+            long staleDeadline = entry.nextFallbackNanos.get();
+            assertTrue(CodecCreationCoordinator.tryReserveFallback(entry, staleDeadline, 100, 1000));
+            // Resume a caller that read the old deadline before the winning reservation.
+            assertFalse(CodecCreationCoordinator.tryReserveFallback(entry, staleDeadline, 101, 1000));
+            assertEquals(1100, entry.nextFallbackNanos.get());
+            assertFalse(CodecCreationCoordinator.tryReserveFallback(entry, 1100, 1099, 1000));
+            assertTrue(CodecCreationCoordinator.tryReserveFallback(entry, 1100, 1100, 1000));
+            assertEquals(2100, entry.nextFallbackNanos.get());
+        }
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testFallbackAdmissionAcrossNanoTimeWraparound() {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        try (CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(locks, Bean.class)) {
+            CodecCreationCoordinator.LockEntry entry = locks.get(Bean.class);
+            assertTrue(CodecCreationCoordinator.tryReserveFallback(entry, 0, Long.MAX_VALUE - 10, 20));
+            long next = entry.nextFallbackNanos.get();
+            assertFalse(CodecCreationCoordinator.tryReserveFallback(entry, next, Long.MAX_VALUE - 5, 20));
+            assertTrue(CodecCreationCoordinator.tryReserveFallback(entry, next, next, 20));
+        }
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testCachePublicationReleasesAllWaitersWhileFallbackIsActive() throws InterruptedException {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        ConcurrentMap<Type, Object> cache = new ConcurrentHashMap<>();
+        Object canonical = new Object();
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        long interval = TimeUnit.SECONDS.toNanos(30);
+        CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(locks, Bean.class);
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch releaseFallback = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope fallback = CodecCreationCoordinator.acquire(locks, Bean.class, waitNanos, interval)) {
+                assertTrue(fallback.isLockFreeFallback());
+                fallbackEntered.countDown();
+                await(releaseFallback);
+            } catch (Throwable failure) {
+                error.compareAndSet(null, failure);
+            } finally {
+                fallbackDone.countDown();
+            }
+        });
+
+        int count = 8;
+        Thread[] waiters = new Thread[count];
+        CountDownLatch done = new CountDownLatch(count);
+        try {
+            assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            for (int i = 0; i < count; i++) {
+                waiters[i] = startDaemonThread(() -> {
+                    Thread.currentThread().interrupt();
+                    try (CodecCreationCoordinator.Scope scope = CodecCreationCoordinator.acquire(locks, Bean.class, cache, waitNanos, interval)) {
+                        assertSame(canonical, scope.getCachedValue());
+                        assertFalse(scope.isLockFreeFallback());
+                        assertTrue(Thread.currentThread().isInterrupted());
+                    } catch (Throwable failure) {
+                        error.compareAndSet(null, failure);
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            for (Thread waiter : waiters) {
+                awaitWaiting(waiter);
+            }
+            cache.put(Bean.class, canonical);
+            assertTrue(done.await(2, TimeUnit.SECONDS));
+            assertNull(error.get());
+            assertEquals(1, locks.get(Bean.class).fallbackOwners.size());
+            assertEquals(2, locks.get(Bean.class).references.get());
+        } finally {
+            owner.close();
+            releaseFallback.countDown();
+            for (Thread waiter : waiters) {
+                if (waiter != null) {
+                    waiter.join(5000);
+                    assertFalse(waiter.isAlive());
+                }
+            }
+            assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        }
+        assertNull(error.get());
         assertTrue(locks.isEmpty());
     }
 
@@ -605,6 +700,104 @@ public class CodecCreationCoordinatorTest {
         assertTrue(completedWhileFirstHeld);
         assertNull(error.get());
         assertEquals(Boolean.TRUE, cycleDetected.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testCycleDetectionIncludesEveryActiveFallback() throws InterruptedException {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(locks, BeanA.class);
+        CountDownLatch ownersAcquired = new CountDownLatch(2);
+        CountDownLatch checkCycles = new CountDownLatch(1);
+        CountDownLatch ownersDone = new CountDownLatch(2);
+        CountDownLatch releaseFallbacks = new CountDownLatch(1);
+        CountDownLatch fallbacksDone = new CountDownLatch(2);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        Thread[] fallbacks = new Thread[2];
+        Type[] dependencies = {BeanB.class, BeanC.class};
+        for (Type dependency : dependencies) {
+            startDaemonThread(() -> {
+                try (CodecCreationCoordinator.Scope outer = CodecCreationCoordinator.acquire(locks, dependency)) {
+                    ownersAcquired.countDown();
+                    await(checkCycles);
+                    try (CodecCreationCoordinator.Scope nested = CodecCreationCoordinator.acquire(
+                            locks, BeanA.class, TimeUnit.SECONDS.toNanos(30), 0)) {
+                        assertTrue(nested.isCycleDetected());
+                    }
+                } catch (Throwable failure) {
+                    error.compareAndSet(null, failure);
+                } finally {
+                    ownersDone.countDown();
+                }
+            });
+        }
+        try {
+            assertTrue(ownersAcquired.await(5, TimeUnit.SECONDS));
+            for (int i = 0; i < dependencies.length; i++) {
+                Type dependency = dependencies[i];
+                fallbacks[i] = startDaemonThread(() -> {
+                    try (CodecCreationCoordinator.Scope fallback = CodecCreationCoordinator.acquire(locks, BeanA.class, 0, 0)) {
+                        assertTrue(fallback.isLockFreeFallback());
+                        try (CodecCreationCoordinator.Scope inner = CodecCreationCoordinator.acquire(locks, dependency)) {
+                            await(releaseFallbacks);
+                        }
+                    } catch (Throwable failure) {
+                        error.compareAndSet(null, failure);
+                    } finally {
+                        fallbacksDone.countDown();
+                    }
+                });
+            }
+            for (Thread fallback : fallbacks) {
+                awaitWaiting(fallback);
+            }
+            assertEquals(2, locks.get(BeanA.class).fallbackOwners.size());
+            checkCycles.countDown();
+            assertTrue(ownersDone.await(5, TimeUnit.SECONDS));
+            assertNull(error.get());
+        } finally {
+            checkCycles.countDown();
+            owner.close();
+            releaseFallbacks.countDown();
+            assertTrue(ownersDone.await(5, TimeUnit.SECONDS));
+            for (Thread fallback : fallbacks) {
+                if (fallback != null) {
+                    fallback.join(5000);
+                    assertFalse(fallback.isAlive());
+                }
+            }
+        }
+        assertEquals(0, fallbacksDone.getCount());
+        assertNull(error.get());
+        assertTrue(locks.isEmpty());
+    }
+
+    @Test
+    public void testCachedScopeRetainsObservedValueAfterEviction() throws InterruptedException {
+        ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks = new ConcurrentHashMap<>();
+        ConcurrentMap<Type, Object> cache = new ConcurrentHashMap<>();
+        Object canonical = new Object();
+        cache.put(Bean.class, canonical);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        try (CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(locks, Bean.class)) {
+            startDaemonThread(() -> {
+                try (CodecCreationCoordinator.Scope cached = CodecCreationCoordinator.acquire(locks, Bean.class, cache)) {
+                    cache.remove(Bean.class);
+                    assertSame(canonical, cached.getCachedValue());
+                    assertFalse(cached.isLockFreeFallback());
+                    assertEquals(0, locks.get(Bean.class).nextFallbackNanos.get());
+                    assertTrue(locks.get(Bean.class).fallbackOwners.isEmpty());
+                } catch (Throwable failure) {
+                    error.set(failure);
+                } finally {
+                    done.countDown();
+                }
+            });
+            assertTrue(done.await(5, TimeUnit.SECONDS));
+        }
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
         assertTrue(locks.isEmpty());
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTestSupport.java
+++ b/core/src/test/java/com/alibaba/fastjson2/internal/CodecCreationCoordinatorTestSupport.java
@@ -1,0 +1,18 @@
+package com.alibaba.fastjson2.internal;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.ConcurrentMap;
+
+public final class CodecCreationCoordinatorTestSupport {
+    private CodecCreationCoordinatorTestSupport() {
+    }
+
+    public static CodecCreationCoordinator.Scope acquire(
+            ConcurrentMap<Type, CodecCreationCoordinator.LockEntry> locks,
+            Type type,
+            long waitNanos,
+            long fallbackIntervalNanos
+    ) {
+        return CodecCreationCoordinator.acquire(locks, type, waitNanos, fallbackIntervalNanos);
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -168,7 +168,12 @@ public class ObjectReaderProviderConcurrentTest {
     @Test
     public void testNestedCreationDoesNotDeadlock() throws InterruptedException {
         CountDownLatch creating = new CountDownLatch(2);
+        CountDownLatch fallbackStarted = new CountDownLatch(1);
+        CountDownLatch continueFallback = new CountDownLatch(1);
         ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        AtomicReference<Class<?>> fallbackType = new AtomicReference<>();
+        AtomicReference<ObjectReader> nestedReaderA = new AtomicReference<>();
+        AtomicReference<ObjectReader> nestedReaderB = new AtomicReference<>();
         ObjectReaderCreator creator = new ObjectReaderCreator() {
             @Override
             public <T> ObjectReader<T> createObjectReader(
@@ -184,26 +189,48 @@ public class ObjectReaderProviderConcurrentTest {
                         if (!creating.await(5, TimeUnit.SECONDS)) {
                             throw new IllegalStateException("object readers were not created concurrently");
                         }
-                        provider.getObjectReader(objectClass == BeanA.class ? BeanB.class : BeanA.class);
+                        Class<?> nestedType = objectClass == BeanA.class ? BeanB.class : BeanA.class;
+                        ObjectReader nestedReader = provider.getObjectReader(nestedType);
+                        if (nestedType == BeanA.class) {
+                            nestedReaderA.set(nestedReader);
+                        } else {
+                            nestedReaderB.set(nestedReader);
+                        }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     } finally {
                         nested.remove();
                     }
+                } else if ((objectClass == BeanA.class || objectClass == BeanB.class)
+                        && fallbackType.compareAndSet(null, objectClass)) {
+                    fallbackStarted.countDown();
+                    await(continueFallback);
                 }
                 return super.createObjectReader(objectClass, objectType, fieldBased, provider);
             }
         };
         ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        ObjectReader canonical = ObjectReaderImplString.INSTANCE;
         AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<ObjectReader> readerA = new AtomicReference<>();
+        AtomicReference<ObjectReader> readerB = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(2);
 
-        startDaemonThread(() -> getObjectReader(provider, BeanA.class, error, done));
-        startDaemonThread(() -> getObjectReader(provider, BeanB.class, error, done));
+        startDaemonThread(() -> getObjectReader(provider, BeanA.class, readerA, error, done));
+        startDaemonThread(() -> getObjectReader(provider, BeanB.class, readerB, error, done));
 
+        assertTrue(fallbackStarted.await(5, TimeUnit.SECONDS));
+        assertNotNull(fallbackType.get());
+        provider.register(fallbackType.get(), canonical);
+        continueFallback.countDown();
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
+        assertSame(canonical, provider.getObjectReader(fallbackType.get()));
+        assertSame(provider.getObjectReader(BeanA.class), readerA.get());
+        assertSame(provider.getObjectReader(BeanB.class), readerB.get());
+        assertSame(provider.getObjectReader(BeanA.class), nestedReaderA.get());
+        assertSame(provider.getObjectReader(BeanB.class), nestedReaderB.get());
         assertNoCreateLocks(provider);
     }
 
@@ -337,8 +364,21 @@ public class ObjectReaderProviderConcurrentTest {
             AtomicReference<Throwable> error,
             CountDownLatch done
     ) {
+        getObjectReader(provider, type, null, error, done);
+    }
+
+    private static void getObjectReader(
+            ObjectReaderProvider provider,
+            Type type,
+            AtomicReference<ObjectReader> result,
+            AtomicReference<Throwable> error,
+            CountDownLatch done
+    ) {
         try {
-            provider.getObjectReader(type);
+            ObjectReader objectReader = provider.getObjectReader(type);
+            if (result != null) {
+                result.set(objectReader);
+            }
         } catch (Throwable e) {
             error.compareAndSet(null, e);
         } finally {
@@ -348,10 +388,15 @@ public class ObjectReaderProviderConcurrentTest {
 
     private static void awaitWaiting(Thread thread) throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+        while (!isWaiting(thread) && System.nanoTime() < deadline) {
             TimeUnit.MILLISECONDS.sleep(1);
         }
-        assertEquals(Thread.State.WAITING, thread.getState());
+        assertTrue(isWaiting(thread));
+    }
+
+    private static boolean isWaiting(Thread thread) {
+        Thread.State state = thread.getState();
+        return state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING;
     }
 
     private static Thread startDaemonThread(Runnable task) {

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -103,7 +103,23 @@ public class ObjectReaderProviderConcurrentTest {
         assertSame(expectedError, firstError.get());
         assertSame(expectedError, secondError.get());
         assertEquals(1, createCount.get());
-        assertNotNull(provider.getObjectReader(FailureBean.class));
+
+        CountDownLatch retryDone = new CountDownLatch(1);
+        AtomicReference<ObjectReader> retryReader = new AtomicReference<>();
+        AtomicReference<Throwable> retryError = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try {
+                retryReader.set(provider.getObjectReader(FailureBean.class));
+            } catch (Throwable e) {
+                retryError.set(e);
+            } finally {
+                retryDone.countDown();
+            }
+        });
+
+        assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+        assertNull(retryError.get());
+        assertNotNull(retryReader.get());
         assertEquals(2, createCount.get());
         assertNoCreateLocks(provider);
     }

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.modules.ObjectReaderModule;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
@@ -26,7 +27,86 @@ public class ObjectReaderProviderConcurrentTest {
         ObjectReader methodBasedReader = result.provider.getObjectReader(Bean.class, false);
 
         assertNotSame(fieldBasedReader, methodBasedReader);
-        assertEquals(2, result.createCount.get());
+    }
+
+    @Test
+    public void testCreateModuleObjectReaderOnce() throws InterruptedException {
+        AtomicInteger moduleCount = new AtomicInteger();
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.register(new ObjectReaderModule() {
+            @Override
+            public ObjectReader getObjectReader(ObjectReaderProvider provider, Type type) {
+                if (type != ModuleBean.class) {
+                    return null;
+                }
+
+                moduleCount.incrementAndGet();
+                sleep(100);
+                return ObjectReaderImplString.INSTANCE;
+            }
+        });
+
+        Set<ObjectReader> readers = getReaders(provider, ModuleBean.class, false, 32);
+        assertEquals(1, readers.size());
+        assertEquals(1, moduleCount.get());
+    }
+
+    @Test
+    public void testCreatorFailureDoesNotReplaceLiveLock() throws InterruptedException {
+        AtomicInteger createCount = new AtomicInteger();
+        AtomicInteger concurrentCount = new AtomicInteger();
+        AtomicInteger maxConcurrentCount = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch failFirst = new CountDownLatch(1);
+        CountDownLatch secondStarted = new CountDownLatch(1);
+        CountDownLatch finishSecond = new CountDownLatch(1);
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                int concurrent = concurrentCount.incrementAndGet();
+                maxConcurrentCount.accumulateAndGet(concurrent, Math::max);
+                try {
+                    int count = createCount.incrementAndGet();
+                    if (count == 1) {
+                        firstStarted.countDown();
+                        await(failFirst);
+                        throw new IllegalStateException("first creation failed");
+                    }
+                    if (count == 2) {
+                        secondStarted.countDown();
+                        await(finishSecond);
+                    }
+                    return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+                } finally {
+                    concurrentCount.decrementAndGet();
+                }
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        CountDownLatch done = new CountDownLatch(3);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, new AtomicReference<>(), done));
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, error, done));
+        sleep(100);
+        failFirst.countDown();
+        assertTrue(secondStarted.await(5, TimeUnit.SECONDS));
+        sleep(100);
+        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, error, done));
+        sleep(200);
+
+        assertEquals(2, createCount.get());
+        assertEquals(1, maxConcurrentCount.get());
+        finishSecond.countDown();
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(2, createCount.get());
     }
 
     @Test
@@ -123,16 +203,24 @@ public class ObjectReaderProviderConcurrentTest {
                     ObjectReaderProvider provider
             ) {
                 createCount.incrementAndGet();
-                try {
-                    TimeUnit.MILLISECONDS.sleep(100);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
+                sleep(1200);
                 return super.createObjectReader(objectClass, objectType, fieldBased, provider);
             }
         };
         ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        Set<ObjectReader> readers = getReaders(provider, Bean.class, fieldBased, 32);
+
+        assertEquals(1, readers.size());
+        assertEquals(1, createCount.get());
+        return new ObjectReaderTestResult(provider, readers, createCount);
+    }
+
+    private static Set<ObjectReader> getReaders(
+            ObjectReaderProvider provider,
+            Type type,
+            boolean fieldBased,
+            int threadCount
+    ) throws InterruptedException {
         CountDownLatch ready = new CountDownLatch(threadCount);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(threadCount);
@@ -144,7 +232,7 @@ public class ObjectReaderProviderConcurrentTest {
                 ready.countDown();
                 try {
                     start.await();
-                    readers.add(provider.getObjectReader(Bean.class, fieldBased));
+                    readers.add(provider.getObjectReader(type, fieldBased));
                 } catch (Throwable e) {
                     error.compareAndSet(null, e);
                 } finally {
@@ -158,9 +246,25 @@ public class ObjectReaderProviderConcurrentTest {
         assertTrue(allReady);
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
-        assertEquals(1, readers.size());
-        assertEquals(1, createCount.get());
-        return new ObjectReaderTestResult(provider, readers, createCount);
+        return readers;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     private static void getObjectReader(
@@ -225,6 +329,12 @@ public class ObjectReaderProviderConcurrentTest {
     }
 
     public static class BeanB {
+    }
+
+    public static class ModuleBean {
+    }
+
+    public static class FailureBean {
     }
 
     public static class GenericBean<T> {

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -235,6 +235,73 @@ public class ObjectReaderProviderConcurrentTest {
     }
 
     @Test
+    public void testFallbackOwnerSameTypeReentryDoesNotDeadlock() throws InterruptedException {
+        AtomicInteger createCount = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch fallbackStarted = new CountDownLatch(1);
+        ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        AtomicReference<ObjectReader> nestedReader = new AtomicReference<>();
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (objectClass == Bean.class) {
+                    int count = createCount.incrementAndGet();
+                    if (count == 1) {
+                        firstStarted.countDown();
+                        await(releaseFirst);
+                    } else if (nested.get() == null) {
+                        nested.set(Boolean.TRUE);
+                        try {
+                            fallbackStarted.countDown();
+                            nestedReader.set(provider.getObjectReader(Bean.class));
+                        } finally {
+                            nested.remove();
+                        }
+                    }
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        AtomicReference<ObjectReader> firstReader = new AtomicReference<>();
+        AtomicReference<ObjectReader> fallbackReader = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch firstDone = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+
+        startDaemonThread(() -> getObjectReader(provider, Bean.class, firstReader, error, firstDone));
+        boolean fallbackEntered;
+        boolean completedWhileFirstHeld;
+        try {
+            assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+            startDaemonThread(() -> getObjectReader(provider, Bean.class, fallbackReader, error, fallbackDone));
+            fallbackEntered = fallbackStarted.await(10, TimeUnit.SECONDS);
+            completedWhileFirstHeld = fallbackEntered
+                    && fallbackDone.await(5, TimeUnit.SECONDS);
+        } finally {
+            releaseFirst.countDown();
+        }
+
+        assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+        assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        assertTrue(fallbackEntered);
+        assertTrue(completedWhileFirstHeld);
+        assertNull(error.get());
+        assertEquals(3, createCount.get());
+        ObjectReader canonical = provider.getObjectReader(Bean.class);
+        assertSame(canonical, firstReader.get());
+        assertSame(canonical, fallbackReader.get());
+        assertSame(canonical, nestedReader.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
     public void testParameterizedTypesCreateConcurrently() throws InterruptedException {
         CountDownLatch creating = new CountDownLatch(2);
         AtomicInteger createCount = new AtomicInteger();

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -1,0 +1,88 @@
+package com.alibaba.fastjson2.reader;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Type;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObjectReaderProviderConcurrentTest {
+    @Test
+    public void testCreateObjectReaderOnce() throws InterruptedException {
+        int threadCount = 32;
+        AtomicInteger createCount = new AtomicInteger();
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                createCount.incrementAndGet();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        Set<ObjectReader> readers = ConcurrentHashMap.newKeySet();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    readers.add(provider.getObjectReader(Bean.class));
+                } catch (Throwable e) {
+                    error.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+
+        boolean allReady = ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+        assertTrue(allReady);
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(1, readers.size());
+        assertEquals(1, createCount.get());
+    }
+
+    public static class Bean {
+        private String id;
+        private String name;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson2.modules.ObjectReaderModule;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -27,6 +28,7 @@ public class ObjectReaderProviderConcurrentTest {
         ObjectReader methodBasedReader = result.provider.getObjectReader(Bean.class, false);
 
         assertNotSame(fieldBasedReader, methodBasedReader);
+        assertNoCreateLocks(result.provider);
     }
 
     @Test
@@ -49,17 +51,27 @@ public class ObjectReaderProviderConcurrentTest {
         Set<ObjectReader> readers = getReaders(provider, ModuleBean.class, false, 32);
         assertEquals(1, readers.size());
         assertEquals(1, moduleCount.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testSpecializedObjectReaderIsPublished() throws InterruptedException {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        Type type = new TypeReference<ArrayList<ValueA>>() { }.getType();
+
+        Set<ObjectReader> readers = getReaders(provider, type, false, 32);
+
+        assertEquals(1, readers.size());
+        assertSame(readers.iterator().next(), provider.cache.get(type));
+        assertNoCreateLocks(provider);
     }
 
     @Test
     public void testCreatorFailureDoesNotReplaceLiveLock() throws InterruptedException {
         AtomicInteger createCount = new AtomicInteger();
-        AtomicInteger concurrentCount = new AtomicInteger();
-        AtomicInteger maxConcurrentCount = new AtomicInteger();
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch failFirst = new CountDownLatch(1);
-        CountDownLatch secondStarted = new CountDownLatch(1);
-        CountDownLatch finishSecond = new CountDownLatch(1);
+        IllegalStateException expectedError = new IllegalStateException("first creation failed");
         ObjectReaderCreator creator = new ObjectReaderCreator() {
             @Override
             public <T> ObjectReader<T> createObjectReader(
@@ -68,45 +80,73 @@ public class ObjectReaderProviderConcurrentTest {
                     boolean fieldBased,
                     ObjectReaderProvider provider
             ) {
-                int concurrent = concurrentCount.incrementAndGet();
-                maxConcurrentCount.accumulateAndGet(concurrent, Math::max);
-                try {
-                    int count = createCount.incrementAndGet();
-                    if (count == 1) {
-                        firstStarted.countDown();
-                        await(failFirst);
-                        throw new IllegalStateException("first creation failed");
-                    }
-                    if (count == 2) {
-                        secondStarted.countDown();
-                        await(finishSecond);
-                    }
-                    return super.createObjectReader(objectClass, objectType, fieldBased, provider);
-                } finally {
-                    concurrentCount.decrementAndGet();
+                if (createCount.incrementAndGet() == 1) {
+                    firstStarted.countDown();
+                    await(failFirst);
+                    throw expectedError;
                 }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
             }
         };
         ObjectReaderProvider provider = new ObjectReaderProvider(creator);
-        CountDownLatch done = new CountDownLatch(3);
-        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+        AtomicReference<Throwable> secondError = new AtomicReference<>();
 
-        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, new AtomicReference<>(), done));
+        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, firstError, done));
         assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
-        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, error, done));
-        sleep(100);
+        Thread second = startDaemonThread(() -> getObjectReader(provider, FailureBean.class, secondError, done));
+        awaitWaiting(second);
         failFirst.countDown();
-        assertTrue(secondStarted.await(5, TimeUnit.SECONDS));
-        sleep(100);
-        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, error, done));
-        sleep(200);
+        assertTrue(done.await(5, TimeUnit.SECONDS));
 
+        assertSame(expectedError, firstError.get());
+        assertSame(expectedError, secondError.get());
+        assertEquals(1, createCount.get());
+        assertNotNull(provider.getObjectReader(FailureBean.class));
         assertEquals(2, createCount.get());
-        assertEquals(1, maxConcurrentCount.get());
-        finishSecond.countDown();
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testNestedCreationWaitsWhenThereIsNoCycle() throws InterruptedException {
+        AtomicInteger beanBCreateCount = new AtomicInteger();
+        CountDownLatch beanBStarted = new CountDownLatch(1);
+        CountDownLatch finishBeanB = new CountDownLatch(1);
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (objectClass == BeanB.class) {
+                    beanBCreateCount.incrementAndGet();
+                    beanBStarted.countDown();
+                    await(finishBeanB);
+                } else if (objectClass == BeanA.class) {
+                    await(beanBStarted);
+                    provider.getObjectReader(BeanB.class);
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+
+        startDaemonThread(() -> getObjectReader(provider, BeanB.class, error, done));
+        assertTrue(beanBStarted.await(5, TimeUnit.SECONDS));
+        Thread beanAThread = startDaemonThread(() -> getObjectReader(provider, BeanA.class, error, done));
+        awaitWaiting(beanAThread);
+
+        assertEquals(1, beanBCreateCount.get());
+        finishBeanB.countDown();
         assertTrue(done.await(5, TimeUnit.SECONDS));
         assertNull(error.get());
-        assertEquals(2, createCount.get());
+        assertEquals(1, beanBCreateCount.get());
+        assertNoCreateLocks(provider);
     }
 
     @Test
@@ -148,6 +188,7 @@ public class ObjectReaderProviderConcurrentTest {
 
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
+        assertNoCreateLocks(provider);
     }
 
     @Test
@@ -189,6 +230,7 @@ public class ObjectReaderProviderConcurrentTest {
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
         assertEquals(2, createCount.get());
+        assertNoCreateLocks(provider);
     }
 
     private ObjectReaderTestResult assertCreateObjectReaderOnce(boolean fieldBased) throws InterruptedException {
@@ -212,7 +254,13 @@ public class ObjectReaderProviderConcurrentTest {
 
         assertEquals(1, readers.size());
         assertEquals(1, createCount.get());
+        assertNoCreateLocks(provider);
         return new ObjectReaderTestResult(provider, readers, createCount);
+    }
+
+    private static void assertNoCreateLocks(ObjectReaderProvider provider) {
+        assertTrue(provider.createLocks.isEmpty());
+        assertTrue(provider.createLocksFieldBased.isEmpty());
     }
 
     private static Set<ObjectReader> getReaders(
@@ -282,10 +330,19 @@ public class ObjectReaderProviderConcurrentTest {
         }
     }
 
-    private static void startDaemonThread(Runnable task) {
+    private static void awaitWaiting(Thread thread) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(1);
+        }
+        assertEquals(Thread.State.WAITING, thread.getState());
+    }
+
+    private static Thread startDaemonThread(Runnable task) {
         Thread thread = new Thread(task);
         thread.setDaemon(true);
         thread.start();
+        return thread;
     }
 
     static final class ObjectReaderTestResult {

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -1,5 +1,6 @@
 package com.alibaba.fastjson2.reader;
 
+import com.alibaba.fastjson2.TypeReference;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
@@ -15,6 +16,102 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ObjectReaderProviderConcurrentTest {
     @Test
     public void testCreateObjectReaderOnce() throws InterruptedException {
+        assertCreateObjectReaderOnce(false);
+    }
+
+    @Test
+    public void testCreateFieldBasedObjectReaderOnce() throws InterruptedException {
+        ObjectReaderTestResult result = assertCreateObjectReaderOnce(true);
+        ObjectReader fieldBasedReader = result.readers.iterator().next();
+        ObjectReader methodBasedReader = result.provider.getObjectReader(Bean.class, false);
+
+        assertNotSame(fieldBasedReader, methodBasedReader);
+        assertEquals(2, result.createCount.get());
+    }
+
+    @Test
+    public void testNestedCreationDoesNotDeadlock() throws InterruptedException {
+        CountDownLatch creating = new CountDownLatch(2);
+        ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if ((objectClass == BeanA.class || objectClass == BeanB.class) && nested.get() == null) {
+                    nested.set(Boolean.TRUE);
+                    try {
+                        creating.countDown();
+                        if (!creating.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("object readers were not created concurrently");
+                        }
+                        provider.getObjectReader(objectClass == BeanA.class ? BeanB.class : BeanA.class);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    } finally {
+                        nested.remove();
+                    }
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+
+        startDaemonThread(() -> getObjectReader(provider, BeanA.class, error, done));
+        startDaemonThread(() -> getObjectReader(provider, BeanB.class, error, done));
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+    }
+
+    @Test
+    public void testParameterizedTypesCreateConcurrently() throws InterruptedException {
+        CountDownLatch creating = new CountDownLatch(2);
+        AtomicInteger createCount = new AtomicInteger();
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (objectClass == GenericBean.class) {
+                    createCount.incrementAndGet();
+                    creating.countDown();
+                    try {
+                        if (!creating.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("parameterized readers were serialized");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        Type typeA = new TypeReference<GenericBean<ValueA>>() { }.getType();
+        Type typeB = new TypeReference<GenericBean<ValueB>>() { }.getType();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+
+        startDaemonThread(() -> getObjectReader(provider, typeA, error, done));
+        startDaemonThread(() -> getObjectReader(provider, typeB, error, done));
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(2, createCount.get());
+    }
+
+    private ObjectReaderTestResult assertCreateObjectReaderOnce(boolean fieldBased) throws InterruptedException {
         int threadCount = 32;
         AtomicInteger createCount = new AtomicInteger();
         ObjectReaderCreator creator = new ObjectReaderCreator() {
@@ -43,17 +140,17 @@ public class ObjectReaderProviderConcurrentTest {
         AtomicReference<Throwable> error = new AtomicReference<>();
 
         for (int i = 0; i < threadCount; i++) {
-            new Thread(() -> {
+            startDaemonThread(() -> {
                 ready.countDown();
                 try {
                     start.await();
-                    readers.add(provider.getObjectReader(Bean.class));
+                    readers.add(provider.getObjectReader(Bean.class, fieldBased));
                 } catch (Throwable e) {
                     error.compareAndSet(null, e);
                 } finally {
                     done.countDown();
                 }
-            }).start();
+            });
         }
 
         boolean allReady = ready.await(5, TimeUnit.SECONDS);
@@ -63,6 +160,44 @@ public class ObjectReaderProviderConcurrentTest {
         assertNull(error.get());
         assertEquals(1, readers.size());
         assertEquals(1, createCount.get());
+        return new ObjectReaderTestResult(provider, readers, createCount);
+    }
+
+    private static void getObjectReader(
+            ObjectReaderProvider provider,
+            Type type,
+            AtomicReference<Throwable> error,
+            CountDownLatch done
+    ) {
+        try {
+            provider.getObjectReader(type);
+        } catch (Throwable e) {
+            error.compareAndSet(null, e);
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private static void startDaemonThread(Runnable task) {
+        Thread thread = new Thread(task);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    static final class ObjectReaderTestResult {
+        final ObjectReaderProvider provider;
+        final Set<ObjectReader> readers;
+        final AtomicInteger createCount;
+
+        ObjectReaderTestResult(
+                ObjectReaderProvider provider,
+                Set<ObjectReader> readers,
+                AtomicInteger createCount
+        ) {
+            this.provider = provider;
+            this.readers = readers;
+            this.createCount = createCount;
+        }
     }
 
     public static class Bean {
@@ -84,5 +219,21 @@ public class ObjectReaderProviderConcurrentTest {
         public void setName(String name) {
             this.name = name;
         }
+    }
+
+    public static class BeanA {
+    }
+
+    public static class BeanB {
+    }
+
+    public static class GenericBean<T> {
+        public T value;
+    }
+
+    public static class ValueA {
+    }
+
+    public static class ValueB {
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -1,6 +1,8 @@
 package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.internal.CodecCreationCoordinator;
+import com.alibaba.fastjson2.internal.CodecCreationCoordinatorTestSupport;
 import com.alibaba.fastjson2.modules.ObjectReaderModule;
 import org.junit.jupiter.api.Test;
 
@@ -57,11 +59,13 @@ public class ObjectReaderProviderConcurrentTest {
     @Test
     public void testSpecializedObjectReaderIsPublished() throws InterruptedException {
         ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.modules.clear();
         Type type = new TypeReference<ArrayList<ValueA>>() { }.getType();
 
         Set<ObjectReader> readers = getReaders(provider, type, false, 32);
 
         assertEquals(1, readers.size());
+        assertTrue(readers.iterator().next() instanceof ObjectReaderImplList);
         assertSame(readers.iterator().next(), provider.cache.get(type));
         assertNoCreateLocks(provider);
     }
@@ -118,6 +122,89 @@ public class ObjectReaderProviderConcurrentTest {
         });
 
         assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+        assertNull(retryError.get());
+        assertNotNull(retryReader.get());
+        assertEquals(2, createCount.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testCreatorFailureDoesNotLeakWhileFallbackRetainsLockEntry() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        AtomicInteger createCount = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch failFirst = new CountDownLatch(1);
+        IllegalStateException expectedError = new IllegalStateException("first creation failed");
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (createCount.incrementAndGet() == 1) {
+                    firstStarted.countDown();
+                    await(failFirst);
+                    throw expectedError;
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        CountDownLatch firstDone = new CountDownLatch(1);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+        startDaemonThread(() -> getObjectReader(provider, FailureBean.class, firstError, firstDone));
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch releaseFallback = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+        AtomicReference<Throwable> fallbackError = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope fallback =
+                         CodecCreationCoordinatorTestSupport.acquire(
+                                 provider.createLocks,
+                                 FailureBean.class,
+                                 waitNanos,
+                                 0
+                         )) {
+                assertTrue(fallback.isLockFreeFallback());
+                fallbackEntered.countDown();
+                await(releaseFallback);
+            } catch (Throwable error) {
+                fallbackError.set(error);
+            } finally {
+                fallbackDone.countDown();
+            }
+        });
+
+        AtomicReference<ObjectReader> retryReader = new AtomicReference<>();
+        AtomicReference<Throwable> retryError = new AtomicReference<>();
+        CountDownLatch retryDone = new CountDownLatch(1);
+        try {
+            assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            failFirst.countDown();
+            assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+
+            startDaemonThread(() -> {
+                try {
+                    retryReader.set(provider.getObjectReader(FailureBean.class));
+                } catch (Throwable error) {
+                    retryError.set(error);
+                } finally {
+                    retryDone.countDown();
+                }
+            });
+            assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+        } finally {
+            failFirst.countDown();
+            releaseFallback.countDown();
+        }
+
+        assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        assertSame(expectedError, firstError.get());
+        assertNull(fallbackError.get());
         assertNull(retryError.get());
         assertNotNull(retryReader.get());
         assertEquals(2, createCount.get());
@@ -202,9 +289,10 @@ public class ObjectReaderProviderConcurrentTest {
                     } finally {
                         nested.remove();
                     }
-                } else if ((objectClass == BeanA.class || objectClass == BeanB.class)
-                        && fallbackType.compareAndSet(null, objectClass)) {
-                    fallbackStarted.countDown();
+                } else if (objectClass == BeanA.class || objectClass == BeanB.class) {
+                    if (fallbackType.compareAndSet(null, objectClass)) {
+                        fallbackStarted.countDown();
+                    }
                     await(continueFallback);
                 }
                 return super.createObjectReader(objectClass, objectType, fieldBased, provider);
@@ -220,10 +308,13 @@ public class ObjectReaderProviderConcurrentTest {
         startDaemonThread(() -> getObjectReader(provider, BeanA.class, readerA, error, done));
         startDaemonThread(() -> getObjectReader(provider, BeanB.class, readerB, error, done));
 
-        assertTrue(fallbackStarted.await(5, TimeUnit.SECONDS));
-        assertNotNull(fallbackType.get());
-        provider.register(fallbackType.get(), canonical);
-        continueFallback.countDown();
+        try {
+            assertTrue(fallbackStarted.await(5, TimeUnit.SECONDS));
+            assertNotNull(fallbackType.get());
+            provider.register(fallbackType.get(), canonical);
+        } finally {
+            continueFallback.countDown();
+        }
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
         assertSame(canonical, provider.getObjectReader(fallbackType.get()));

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -239,20 +239,26 @@ public class ObjectReaderProviderConcurrentTest {
         CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(provider.createLocks, Bean.class);
         ObjectReader canonical = ObjectReaderImplString.INSTANCE;
         AtomicReference<ObjectReader> result = new AtomicReference<>();
+        AtomicReference<ObjectReader> secondResult = new AtomicReference<>();
         AtomicReference<Throwable> error = new AtomicReference<>();
-        CountDownLatch done = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
         Thread waiter = startDaemonThread(() -> getObjectReader(provider, Bean.class, result, error, done));
+        Thread second = startDaemonThread(() -> getObjectReader(provider, Bean.class, secondResult, error, done));
 
         try {
             awaitWaiting(waiter);
+            awaitWaiting(second);
             provider.register(Bean.class, canonical);
-            assertTrue(done.await(10, TimeUnit.SECONDS));
+            // Cache hits must not wait for the five-second creation fallback budget.
+            assertTrue(done.await(2, TimeUnit.SECONDS));
         } finally {
             owner.close();
+            assertTrue(done.await(5, TimeUnit.SECONDS));
         }
 
         assertNull(error.get());
         assertSame(canonical, result.get());
+        assertSame(canonical, secondResult.get());
         assertEquals(0, createCount.get());
         assertNoCreateLocks(provider);
     }

--- a/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/reader/ObjectReaderProviderConcurrentTest.java
@@ -75,7 +75,7 @@ public class ObjectReaderProviderConcurrentTest {
         AtomicInteger createCount = new AtomicInteger();
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch failFirst = new CountDownLatch(1);
-        IllegalStateException expectedError = new IllegalStateException("first creation failed");
+        AssertionError expectedError = new AssertionError("first creation failed");
         ObjectReaderCreator creator = new ObjectReaderCreator() {
             @Override
             public <T> ObjectReader<T> createObjectReader(
@@ -156,6 +156,8 @@ public class ObjectReaderProviderConcurrentTest {
         AtomicReference<Throwable> firstError = new AtomicReference<>();
         startDaemonThread(() -> getObjectReader(provider, FailureBean.class, firstError, firstDone));
         assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+        CodecCreationCoordinator.LockEntry retainedLock = provider.createLocks.get(FailureBean.class);
+        assertNotNull(retainedLock);
 
         CountDownLatch fallbackEntered = new CountDownLatch(1);
         CountDownLatch releaseFallback = new CountDownLatch(1);
@@ -172,6 +174,7 @@ public class ObjectReaderProviderConcurrentTest {
                 assertTrue(fallback.isLockFreeFallback());
                 fallbackEntered.countDown();
                 await(releaseFallback);
+                fallback.throwIfFailed();
             } catch (Throwable error) {
                 fallbackError.set(error);
             } finally {
@@ -184,8 +187,10 @@ public class ObjectReaderProviderConcurrentTest {
         CountDownLatch retryDone = new CountDownLatch(1);
         try {
             assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            assertSame(retainedLock, provider.createLocks.get(FailureBean.class));
             failFirst.countDown();
             assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+            assertSame(retainedLock, provider.createLocks.get(FailureBean.class));
 
             startDaemonThread(() -> {
                 try {
@@ -197,6 +202,10 @@ public class ObjectReaderProviderConcurrentTest {
                 }
             });
             assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+            assertNull(retryError.get());
+            assertNotNull(retryReader.get());
+            assertSame(retainedLock, provider.createLocks.get(FailureBean.class));
+            assertSame(retryReader.get(), provider.unregisterObjectReader(FailureBean.class));
         } finally {
             failFirst.countDown();
             releaseFallback.countDown();
@@ -205,9 +214,46 @@ public class ObjectReaderProviderConcurrentTest {
         assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
         assertSame(expectedError, firstError.get());
         assertNull(fallbackError.get());
-        assertNull(retryError.get());
-        assertNotNull(retryReader.get());
         assertEquals(2, createCount.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testFallbackRechecksCacheBeforeCreating() throws InterruptedException {
+        AtomicInteger createCount = new AtomicInteger();
+        ObjectReaderCreator creator = new ObjectReaderCreator() {
+            @Override
+            public <T> ObjectReader<T> createObjectReader(
+                    Class<T> objectClass,
+                    Type objectType,
+                    boolean fieldBased,
+                    ObjectReaderProvider provider
+            ) {
+                if (objectClass == Bean.class) {
+                    createCount.incrementAndGet();
+                }
+                return super.createObjectReader(objectClass, objectType, fieldBased, provider);
+            }
+        };
+        ObjectReaderProvider provider = new ObjectReaderProvider(creator);
+        CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(provider.createLocks, Bean.class);
+        ObjectReader canonical = ObjectReaderImplString.INSTANCE;
+        AtomicReference<ObjectReader> result = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        Thread waiter = startDaemonThread(() -> getObjectReader(provider, Bean.class, result, error, done));
+
+        try {
+            awaitWaiting(waiter);
+            provider.register(Bean.class, canonical);
+            assertTrue(done.await(10, TimeUnit.SECONDS));
+        } finally {
+            owner.close();
+        }
+
+        assertNull(error.get());
+        assertSame(canonical, result.get());
+        assertEquals(0, createCount.get());
         assertNoCreateLocks(provider);
     }
 
@@ -422,15 +468,22 @@ public class ObjectReaderProviderConcurrentTest {
         ObjectReaderProvider provider = new ObjectReaderProvider(creator);
         Type typeA = new TypeReference<GenericBean<ValueA>>() { }.getType();
         Type typeB = new TypeReference<GenericBean<ValueB>>() { }.getType();
+        AtomicReference<ObjectReader> readerA = new AtomicReference<>();
+        AtomicReference<ObjectReader> readerB = new AtomicReference<>();
         AtomicReference<Throwable> error = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(2);
 
-        startDaemonThread(() -> getObjectReader(provider, typeA, error, done));
-        startDaemonThread(() -> getObjectReader(provider, typeB, error, done));
+        startDaemonThread(() -> getObjectReader(provider, typeA, readerA, error, done));
+        startDaemonThread(() -> getObjectReader(provider, typeB, readerB, error, done));
 
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
         assertEquals(2, createCount.get());
+        assertNotNull(readerA.get());
+        assertNotNull(readerB.get());
+        assertNotSame(readerA.get(), readerB.get());
+        assertSame(readerA.get(), provider.cache.get(typeA));
+        assertSame(readerB.get(), provider.cache.get(typeB));
         assertNoCreateLocks(provider);
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -1,6 +1,8 @@
 package com.alibaba.fastjson2.writer;
 
 import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.internal.CodecCreationCoordinator;
+import com.alibaba.fastjson2.internal.CodecCreationCoordinatorTestSupport;
 import com.alibaba.fastjson2.modules.ObjectWriterModule;
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +125,88 @@ public class ObjectWriterProviderConcurrentTest {
     }
 
     @Test
+    public void testCreatorFailureDoesNotLeakWhileFallbackRetainsLockEntry() throws InterruptedException {
+        long waitNanos = TimeUnit.MILLISECONDS.toNanos(10);
+        AtomicInteger createCount = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch failFirst = new CountDownLatch(1);
+        IllegalStateException expectedError = new IllegalStateException("first creation failed");
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (createCount.incrementAndGet() == 1) {
+                    firstStarted.countDown();
+                    await(failFirst);
+                    throw expectedError;
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        CountDownLatch firstDone = new CountDownLatch(1);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, firstError, firstDone));
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+
+        CountDownLatch fallbackEntered = new CountDownLatch(1);
+        CountDownLatch releaseFallback = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+        AtomicReference<Throwable> fallbackError = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try (CodecCreationCoordinator.Scope fallback =
+                         CodecCreationCoordinatorTestSupport.acquire(
+                                 provider.createLocks,
+                                 FailureBean.class,
+                                 waitNanos,
+                                 0
+                         )) {
+                assertTrue(fallback.isLockFreeFallback());
+                fallbackEntered.countDown();
+                await(releaseFallback);
+            } catch (Throwable error) {
+                fallbackError.set(error);
+            } finally {
+                fallbackDone.countDown();
+            }
+        });
+
+        AtomicReference<ObjectWriter> retryWriter = new AtomicReference<>();
+        AtomicReference<Throwable> retryError = new AtomicReference<>();
+        CountDownLatch retryDone = new CountDownLatch(1);
+        try {
+            assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            failFirst.countDown();
+            assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+
+            startDaemonThread(() -> {
+                try {
+                    retryWriter.set(provider.getObjectWriter(FailureBean.class));
+                } catch (Throwable error) {
+                    retryError.set(error);
+                } finally {
+                    retryDone.countDown();
+                }
+            });
+            assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+        } finally {
+            failFirst.countDown();
+            releaseFallback.countDown();
+        }
+
+        assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        assertSame(expectedError, firstError.get());
+        assertNull(fallbackError.get());
+        assertNull(retryError.get());
+        assertNotNull(retryWriter.get());
+        assertEquals(2, createCount.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
     public void testNestedCreationWaitsWhenThereIsNoCycle() throws InterruptedException {
         AtomicInteger beanBCreateCount = new AtomicInteger();
         CountDownLatch beanBStarted = new CountDownLatch(1);
@@ -198,9 +282,10 @@ public class ObjectWriterProviderConcurrentTest {
                     } finally {
                         nested.remove();
                     }
-                } else if ((objectClass == BeanA.class || objectClass == BeanB.class)
-                        && fallbackType.compareAndSet(null, objectClass)) {
-                    fallbackStarted.countDown();
+                } else if (objectClass == BeanA.class || objectClass == BeanB.class) {
+                    if (fallbackType.compareAndSet(null, objectClass)) {
+                        fallbackStarted.countDown();
+                    }
                     await(continueFallback);
                 }
                 return super.createObjectWriter(objectClass, features, provider);
@@ -216,10 +301,13 @@ public class ObjectWriterProviderConcurrentTest {
         startDaemonThread(() -> getObjectWriter(provider, BeanA.class, writerA, error, done));
         startDaemonThread(() -> getObjectWriter(provider, BeanB.class, writerB, error, done));
 
-        assertTrue(fallbackStarted.await(5, TimeUnit.SECONDS));
-        assertNotNull(fallbackType.get());
-        provider.register(fallbackType.get(), canonical);
-        continueFallback.countDown();
+        try {
+            assertTrue(fallbackStarted.await(5, TimeUnit.SECONDS));
+            assertNotNull(fallbackType.get());
+            provider.register(fallbackType.get(), canonical);
+        } finally {
+            continueFallback.countDown();
+        }
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
         assertSame(canonical, provider.getObjectWriter(fallbackType.get()));
@@ -516,7 +604,14 @@ public class ObjectWriterProviderConcurrentTest {
     }
 
     public static class ExtendedMap extends HashMap<String, String> {
+        private final String name;
+
         public ExtendedMap(String ignored) {
+            this.name = ignored;
+        }
+
+        public String getName() {
+            return name;
         }
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -1,7 +1,9 @@
 package com.alibaba.fastjson2.writer;
 
+import com.alibaba.fastjson2.TypeReference;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -14,6 +16,100 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ObjectWriterProviderConcurrentTest {
     @Test
     public void testCreateObjectWriterOnce() throws InterruptedException {
+        assertCreateObjectWriterOnce(false);
+    }
+
+    @Test
+    public void testCreateFieldBasedObjectWriterOnce() throws InterruptedException {
+        ObjectWriterTestResult result = assertCreateObjectWriterOnce(true);
+        ObjectWriter fieldBasedWriter = result.writers.iterator().next();
+        ObjectWriter methodBasedWriter = result.provider.getObjectWriter(Bean.class, Bean.class, false);
+
+        assertNotSame(fieldBasedWriter, methodBasedWriter);
+        assertEquals(2, result.createCount.get());
+    }
+
+    @Test
+    public void testNestedCreationDoesNotDeadlock() throws InterruptedException {
+        CountDownLatch creating = new CountDownLatch(2);
+        ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if ((objectClass == BeanA.class || objectClass == BeanB.class) && nested.get() == null) {
+                    nested.set(Boolean.TRUE);
+                    try {
+                        creating.countDown();
+                        if (!creating.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("object writers were not created concurrently");
+                        }
+                        provider.getObjectWriter(objectClass == BeanA.class ? BeanB.class : BeanA.class);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    } finally {
+                        nested.remove();
+                    }
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+
+        startDaemonThread(() -> getObjectWriter(provider, BeanA.class, error, done));
+        startDaemonThread(() -> getObjectWriter(provider, BeanB.class, error, done));
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+    }
+
+    @Test
+    public void testParameterizedTypesCreateConcurrently() throws InterruptedException {
+        CountDownLatch creating = new CountDownLatch(2);
+        AtomicInteger createCount = new AtomicInteger();
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (objectClass == GenericBean.class) {
+                    createCount.incrementAndGet();
+                    creating.countDown();
+                    try {
+                        if (!creating.await(5, TimeUnit.SECONDS)) {
+                            throw new IllegalStateException("parameterized writers were serialized");
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        Type typeA = new TypeReference<GenericBean<ValueA>>() { }.getType();
+        Type typeB = new TypeReference<GenericBean<ValueB>>() { }.getType();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+
+        startDaemonThread(() -> getObjectWriter(provider, typeA, error, done));
+        startDaemonThread(() -> getObjectWriter(provider, typeB, error, done));
+
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(2, createCount.get());
+    }
+
+    private ObjectWriterTestResult assertCreateObjectWriterOnce(boolean fieldBased) throws InterruptedException {
         int threadCount = 32;
         AtomicInteger createCount = new AtomicInteger();
         ObjectWriterCreator creator = new ObjectWriterCreator() {
@@ -41,17 +137,17 @@ public class ObjectWriterProviderConcurrentTest {
         AtomicReference<Throwable> error = new AtomicReference<>();
 
         for (int i = 0; i < threadCount; i++) {
-            new Thread(() -> {
+            startDaemonThread(() -> {
                 ready.countDown();
                 try {
                     start.await();
-                    writers.add(provider.getObjectWriter(Bean.class));
+                    writers.add(provider.getObjectWriter(Bean.class, Bean.class, fieldBased));
                 } catch (Throwable e) {
                     error.compareAndSet(null, e);
                 } finally {
                     done.countDown();
                 }
-            }).start();
+            });
         }
 
         boolean allReady = ready.await(5, TimeUnit.SECONDS);
@@ -61,6 +157,44 @@ public class ObjectWriterProviderConcurrentTest {
         assertNull(error.get());
         assertEquals(1, writers.size());
         assertEquals(1, createCount.get());
+        return new ObjectWriterTestResult(provider, writers, createCount);
+    }
+
+    private static void getObjectWriter(
+            ObjectWriterProvider provider,
+            Type type,
+            AtomicReference<Throwable> error,
+            CountDownLatch done
+    ) {
+        try {
+            provider.getObjectWriter(type);
+        } catch (Throwable e) {
+            error.compareAndSet(null, e);
+        } finally {
+            done.countDown();
+        }
+    }
+
+    private static void startDaemonThread(Runnable task) {
+        Thread thread = new Thread(task);
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    static final class ObjectWriterTestResult {
+        final ObjectWriterProvider provider;
+        final Set<ObjectWriter> writers;
+        final AtomicInteger createCount;
+
+        ObjectWriterTestResult(
+                ObjectWriterProvider provider,
+                Set<ObjectWriter> writers,
+                AtomicInteger createCount
+        ) {
+            this.provider = provider;
+            this.writers = writers;
+            this.createCount = createCount;
+        }
     }
 
     public static class Bean {
@@ -82,5 +216,21 @@ public class ObjectWriterProviderConcurrentTest {
         public void setName(String name) {
             this.name = name;
         }
+    }
+
+    public static class BeanA {
+    }
+
+    public static class BeanB {
+    }
+
+    public static class GenericBean<T> {
+        public T value;
+    }
+
+    public static class ValueA {
+    }
+
+    public static class ValueB {
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.writer;
 
 import com.alibaba.fastjson2.TypeReference;
+import com.alibaba.fastjson2.modules.ObjectWriterModule;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
@@ -26,7 +27,85 @@ public class ObjectWriterProviderConcurrentTest {
         ObjectWriter methodBasedWriter = result.provider.getObjectWriter(Bean.class, Bean.class, false);
 
         assertNotSame(fieldBasedWriter, methodBasedWriter);
-        assertEquals(2, result.createCount.get());
+    }
+
+    @Test
+    public void testCreateModuleObjectWriterOnce() throws InterruptedException {
+        AtomicInteger moduleCount = new AtomicInteger();
+        ObjectWriterProvider provider = new ObjectWriterProvider();
+        provider.register(new ObjectWriterModule() {
+            @Override
+            public ObjectWriter getObjectWriter(Type objectType, Class objectClass) {
+                if (objectType != ModuleBean.class) {
+                    return null;
+                }
+
+                moduleCount.incrementAndGet();
+                sleep(100);
+                return ObjectWriterImplString.INSTANCE;
+            }
+        });
+
+        Set<ObjectWriter> writers = getWriters(provider, ModuleBean.class, false, 32);
+        assertEquals(1, writers.size());
+        assertEquals(1, moduleCount.get());
+    }
+
+    @Test
+    public void testCreatorFailureDoesNotReplaceLiveLock() throws InterruptedException {
+        AtomicInteger createCount = new AtomicInteger();
+        AtomicInteger concurrentCount = new AtomicInteger();
+        AtomicInteger maxConcurrentCount = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch failFirst = new CountDownLatch(1);
+        CountDownLatch secondStarted = new CountDownLatch(1);
+        CountDownLatch finishSecond = new CountDownLatch(1);
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                int concurrent = concurrentCount.incrementAndGet();
+                maxConcurrentCount.accumulateAndGet(concurrent, Math::max);
+                try {
+                    int count = createCount.incrementAndGet();
+                    if (count == 1) {
+                        firstStarted.countDown();
+                        await(failFirst);
+                        throw new IllegalStateException("first creation failed");
+                    }
+                    if (count == 2) {
+                        secondStarted.countDown();
+                        await(finishSecond);
+                    }
+                    return super.createObjectWriter(objectClass, features, provider);
+                } finally {
+                    concurrentCount.decrementAndGet();
+                }
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        CountDownLatch done = new CountDownLatch(3);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, new AtomicReference<>(), done));
+        assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, error, done));
+        sleep(100);
+        failFirst.countDown();
+        assertTrue(secondStarted.await(5, TimeUnit.SECONDS));
+        sleep(100);
+        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, error, done));
+        sleep(200);
+
+        assertEquals(2, createCount.get());
+        assertEquals(1, maxConcurrentCount.get());
+        finishSecond.countDown();
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(2, createCount.get());
     }
 
     @Test
@@ -120,16 +199,24 @@ public class ObjectWriterProviderConcurrentTest {
                     ObjectWriterProvider provider
             ) {
                 createCount.incrementAndGet();
-                try {
-                    TimeUnit.MILLISECONDS.sleep(100);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new RuntimeException(e);
-                }
+                sleep(1200);
                 return super.createObjectWriter(objectClass, features, provider);
             }
         };
         ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        Set<ObjectWriter> writers = getWriters(provider, Bean.class, fieldBased, 32);
+
+        assertEquals(1, writers.size());
+        assertEquals(1, createCount.get());
+        return new ObjectWriterTestResult(provider, writers, createCount);
+    }
+
+    private static Set<ObjectWriter> getWriters(
+            ObjectWriterProvider provider,
+            Type type,
+            boolean fieldBased,
+            int threadCount
+    ) throws InterruptedException {
         CountDownLatch ready = new CountDownLatch(threadCount);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch done = new CountDownLatch(threadCount);
@@ -141,7 +228,7 @@ public class ObjectWriterProviderConcurrentTest {
                 ready.countDown();
                 try {
                     start.await();
-                    writers.add(provider.getObjectWriter(Bean.class, Bean.class, fieldBased));
+                    writers.add(provider.getObjectWriter(type, (Class) type, fieldBased));
                 } catch (Throwable e) {
                     error.compareAndSet(null, e);
                 } finally {
@@ -155,9 +242,25 @@ public class ObjectWriterProviderConcurrentTest {
         assertTrue(allReady);
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
-        assertEquals(1, writers.size());
-        assertEquals(1, createCount.get());
-        return new ObjectWriterTestResult(provider, writers, createCount);
+        return writers;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            TimeUnit.MILLISECONDS.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     private static void getObjectWriter(
@@ -222,6 +325,12 @@ public class ObjectWriterProviderConcurrentTest {
     }
 
     public static class BeanB {
+    }
+
+    public static class ModuleBean {
+    }
+
+    public static class FailureBean {
     }
 
     public static class GenericBean<T> {

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -1,0 +1,86 @@
+package com.alibaba.fastjson2.writer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ObjectWriterProviderConcurrentTest {
+    @Test
+    public void testCreateObjectWriterOnce() throws InterruptedException {
+        int threadCount = 32;
+        AtomicInteger createCount = new AtomicInteger();
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                createCount.incrementAndGet();
+                try {
+                    TimeUnit.MILLISECONDS.sleep(100);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        CountDownLatch ready = new CountDownLatch(threadCount);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threadCount);
+        Set<ObjectWriter> writers = ConcurrentHashMap.newKeySet();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            new Thread(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    writers.add(provider.getObjectWriter(Bean.class));
+                } catch (Throwable e) {
+                    error.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            }).start();
+        }
+
+        boolean allReady = ready.await(5, TimeUnit.SECONDS);
+        start.countDown();
+        assertTrue(allReady);
+        assertTrue(done.await(10, TimeUnit.SECONDS));
+        assertNull(error.get());
+        assertEquals(1, writers.size());
+        assertEquals(1, createCount.get());
+    }
+
+    public static class Bean {
+        private String id;
+        private String name;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -231,6 +231,72 @@ public class ObjectWriterProviderConcurrentTest {
     }
 
     @Test
+    public void testFallbackOwnerSameTypeReentryDoesNotDeadlock() throws InterruptedException {
+        AtomicInteger createCount = new AtomicInteger();
+        CountDownLatch firstStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirst = new CountDownLatch(1);
+        CountDownLatch fallbackStarted = new CountDownLatch(1);
+        ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        AtomicReference<ObjectWriter> nestedWriter = new AtomicReference<>();
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (objectClass == Bean.class) {
+                    int count = createCount.incrementAndGet();
+                    if (count == 1) {
+                        firstStarted.countDown();
+                        await(releaseFirst);
+                    } else if (nested.get() == null) {
+                        nested.set(Boolean.TRUE);
+                        try {
+                            fallbackStarted.countDown();
+                            nestedWriter.set(provider.getObjectWriter(Bean.class));
+                        } finally {
+                            nested.remove();
+                        }
+                    }
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        AtomicReference<ObjectWriter> firstWriter = new AtomicReference<>();
+        AtomicReference<ObjectWriter> fallbackWriter = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch firstDone = new CountDownLatch(1);
+        CountDownLatch fallbackDone = new CountDownLatch(1);
+
+        startDaemonThread(() -> getObjectWriter(provider, Bean.class, firstWriter, error, firstDone));
+        boolean fallbackEntered;
+        boolean completedWhileFirstHeld;
+        try {
+            assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+            startDaemonThread(() -> getObjectWriter(provider, Bean.class, fallbackWriter, error, fallbackDone));
+            fallbackEntered = fallbackStarted.await(10, TimeUnit.SECONDS);
+            completedWhileFirstHeld = fallbackEntered
+                    && fallbackDone.await(5, TimeUnit.SECONDS);
+        } finally {
+            releaseFirst.countDown();
+        }
+
+        assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+        assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
+        assertTrue(fallbackEntered);
+        assertTrue(completedWhileFirstHeld);
+        assertNull(error.get());
+        assertEquals(3, createCount.get());
+        ObjectWriter canonical = provider.getObjectWriter(Bean.class);
+        assertSame(canonical, firstWriter.get());
+        assertSame(canonical, fallbackWriter.get());
+        assertSame(canonical, nestedWriter.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
     public void testParameterizedTypesCreateConcurrently() throws InterruptedException {
         CountDownLatch creating = new CountDownLatch(2);
         AtomicInteger createCount = new AtomicInteger();

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson2.modules.ObjectWriterModule;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -27,6 +28,7 @@ public class ObjectWriterProviderConcurrentTest {
         ObjectWriter methodBasedWriter = result.provider.getObjectWriter(Bean.class, Bean.class, false);
 
         assertNotSame(fieldBasedWriter, methodBasedWriter);
+        assertNoCreateLocks(result.provider);
     }
 
     @Test
@@ -49,17 +51,26 @@ public class ObjectWriterProviderConcurrentTest {
         Set<ObjectWriter> writers = getWriters(provider, ModuleBean.class, false, 32);
         assertEquals(1, writers.size());
         assertEquals(1, moduleCount.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testSpecializedObjectWriterIsPublished() throws InterruptedException {
+        ObjectWriterProvider provider = new ObjectWriterProvider();
+
+        Set<ObjectWriter> writers = getWriters(provider, ExtendedMap.class, false, 32);
+
+        assertEquals(1, writers.size());
+        assertSame(writers.iterator().next(), provider.cache.get(ExtendedMap.class));
+        assertNoCreateLocks(provider);
     }
 
     @Test
     public void testCreatorFailureDoesNotReplaceLiveLock() throws InterruptedException {
         AtomicInteger createCount = new AtomicInteger();
-        AtomicInteger concurrentCount = new AtomicInteger();
-        AtomicInteger maxConcurrentCount = new AtomicInteger();
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch failFirst = new CountDownLatch(1);
-        CountDownLatch secondStarted = new CountDownLatch(1);
-        CountDownLatch finishSecond = new CountDownLatch(1);
+        IllegalStateException expectedError = new IllegalStateException("first creation failed");
         ObjectWriterCreator creator = new ObjectWriterCreator() {
             @Override
             public ObjectWriter createObjectWriter(
@@ -67,45 +78,72 @@ public class ObjectWriterProviderConcurrentTest {
                     long features,
                     ObjectWriterProvider provider
             ) {
-                int concurrent = concurrentCount.incrementAndGet();
-                maxConcurrentCount.accumulateAndGet(concurrent, Math::max);
-                try {
-                    int count = createCount.incrementAndGet();
-                    if (count == 1) {
-                        firstStarted.countDown();
-                        await(failFirst);
-                        throw new IllegalStateException("first creation failed");
-                    }
-                    if (count == 2) {
-                        secondStarted.countDown();
-                        await(finishSecond);
-                    }
-                    return super.createObjectWriter(objectClass, features, provider);
-                } finally {
-                    concurrentCount.decrementAndGet();
+                if (createCount.incrementAndGet() == 1) {
+                    firstStarted.countDown();
+                    await(failFirst);
+                    throw expectedError;
                 }
+                return super.createObjectWriter(objectClass, features, provider);
             }
         };
         ObjectWriterProvider provider = new ObjectWriterProvider(creator);
-        CountDownLatch done = new CountDownLatch(3);
-        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicReference<Throwable> firstError = new AtomicReference<>();
+        AtomicReference<Throwable> secondError = new AtomicReference<>();
 
-        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, new AtomicReference<>(), done));
+        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, firstError, done));
         assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
-        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, error, done));
-        sleep(100);
+        Thread second = startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, secondError, done));
+        awaitWaiting(second);
         failFirst.countDown();
-        assertTrue(secondStarted.await(5, TimeUnit.SECONDS));
-        sleep(100);
-        startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, error, done));
-        sleep(200);
+        assertTrue(done.await(5, TimeUnit.SECONDS));
 
+        assertSame(expectedError, firstError.get());
+        assertSame(expectedError, secondError.get());
+        assertEquals(1, createCount.get());
+        assertNotNull(provider.getObjectWriter(FailureBean.class));
         assertEquals(2, createCount.get());
-        assertEquals(1, maxConcurrentCount.get());
-        finishSecond.countDown();
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testNestedCreationWaitsWhenThereIsNoCycle() throws InterruptedException {
+        AtomicInteger beanBCreateCount = new AtomicInteger();
+        CountDownLatch beanBStarted = new CountDownLatch(1);
+        CountDownLatch finishBeanB = new CountDownLatch(1);
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (objectClass == BeanB.class) {
+                    beanBCreateCount.incrementAndGet();
+                    beanBStarted.countDown();
+                    await(finishBeanB);
+                } else if (objectClass == BeanA.class) {
+                    await(beanBStarted);
+                    provider.getObjectWriter(BeanB.class);
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(2);
+
+        startDaemonThread(() -> getObjectWriter(provider, BeanB.class, error, done));
+        assertTrue(beanBStarted.await(5, TimeUnit.SECONDS));
+        Thread beanAThread = startDaemonThread(() -> getObjectWriter(provider, BeanA.class, error, done));
+        awaitWaiting(beanAThread);
+
+        assertEquals(1, beanBCreateCount.get());
+        finishBeanB.countDown();
         assertTrue(done.await(5, TimeUnit.SECONDS));
         assertNull(error.get());
-        assertEquals(2, createCount.get());
+        assertEquals(1, beanBCreateCount.get());
+        assertNoCreateLocks(provider);
     }
 
     @Test
@@ -146,6 +184,7 @@ public class ObjectWriterProviderConcurrentTest {
 
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
+        assertNoCreateLocks(provider);
     }
 
     @Test
@@ -186,6 +225,7 @@ public class ObjectWriterProviderConcurrentTest {
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
         assertEquals(2, createCount.get());
+        assertNoCreateLocks(provider);
     }
 
     private ObjectWriterTestResult assertCreateObjectWriterOnce(boolean fieldBased) throws InterruptedException {
@@ -208,7 +248,13 @@ public class ObjectWriterProviderConcurrentTest {
 
         assertEquals(1, writers.size());
         assertEquals(1, createCount.get());
+        assertNoCreateLocks(provider);
         return new ObjectWriterTestResult(provider, writers, createCount);
+    }
+
+    private static void assertNoCreateLocks(ObjectWriterProvider provider) {
+        assertTrue(provider.createLocks.isEmpty());
+        assertTrue(provider.createLocksFieldBased.isEmpty());
     }
 
     private static Set<ObjectWriter> getWriters(
@@ -278,10 +324,19 @@ public class ObjectWriterProviderConcurrentTest {
         }
     }
 
-    private static void startDaemonThread(Runnable task) {
+    private static void awaitWaiting(Thread thread) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(1);
+        }
+        assertEquals(Thread.State.WAITING, thread.getState());
+    }
+
+    private static Thread startDaemonThread(Runnable task) {
         Thread thread = new Thread(task);
         thread.setDaemon(true);
         thread.start();
+        return thread;
     }
 
     static final class ObjectWriterTestResult {
@@ -331,6 +386,11 @@ public class ObjectWriterProviderConcurrentTest {
     }
 
     public static class FailureBean {
+    }
+
+    public static class ExtendedMap extends HashMap<String, String> {
+        public ExtendedMap(String ignored) {
+        }
     }
 
     public static class GenericBean<T> {

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -101,7 +101,23 @@ public class ObjectWriterProviderConcurrentTest {
         assertSame(expectedError, firstError.get());
         assertSame(expectedError, secondError.get());
         assertEquals(1, createCount.get());
-        assertNotNull(provider.getObjectWriter(FailureBean.class));
+
+        CountDownLatch retryDone = new CountDownLatch(1);
+        AtomicReference<ObjectWriter> retryWriter = new AtomicReference<>();
+        AtomicReference<Throwable> retryError = new AtomicReference<>();
+        startDaemonThread(() -> {
+            try {
+                retryWriter.set(provider.getObjectWriter(FailureBean.class));
+            } catch (Throwable e) {
+                retryError.set(e);
+            } finally {
+                retryDone.countDown();
+            }
+        });
+
+        assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+        assertNull(retryError.get());
+        assertNotNull(retryWriter.get());
         assertEquals(2, createCount.get());
         assertNoCreateLocks(provider);
     }

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -165,7 +165,12 @@ public class ObjectWriterProviderConcurrentTest {
     @Test
     public void testNestedCreationDoesNotDeadlock() throws InterruptedException {
         CountDownLatch creating = new CountDownLatch(2);
+        CountDownLatch fallbackStarted = new CountDownLatch(1);
+        CountDownLatch continueFallback = new CountDownLatch(1);
         ThreadLocal<Boolean> nested = new ThreadLocal<>();
+        AtomicReference<Class<?>> fallbackType = new AtomicReference<>();
+        AtomicReference<ObjectWriter> nestedWriterA = new AtomicReference<>();
+        AtomicReference<ObjectWriter> nestedWriterB = new AtomicReference<>();
         ObjectWriterCreator creator = new ObjectWriterCreator() {
             @Override
             public ObjectWriter createObjectWriter(
@@ -180,26 +185,48 @@ public class ObjectWriterProviderConcurrentTest {
                         if (!creating.await(5, TimeUnit.SECONDS)) {
                             throw new IllegalStateException("object writers were not created concurrently");
                         }
-                        provider.getObjectWriter(objectClass == BeanA.class ? BeanB.class : BeanA.class);
+                        Class<?> nestedType = objectClass == BeanA.class ? BeanB.class : BeanA.class;
+                        ObjectWriter nestedWriter = provider.getObjectWriter(nestedType);
+                        if (nestedType == BeanA.class) {
+                            nestedWriterA.set(nestedWriter);
+                        } else {
+                            nestedWriterB.set(nestedWriter);
+                        }
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         throw new RuntimeException(e);
                     } finally {
                         nested.remove();
                     }
+                } else if ((objectClass == BeanA.class || objectClass == BeanB.class)
+                        && fallbackType.compareAndSet(null, objectClass)) {
+                    fallbackStarted.countDown();
+                    await(continueFallback);
                 }
                 return super.createObjectWriter(objectClass, features, provider);
             }
         };
         ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        ObjectWriter canonical = ObjectWriterImplString.INSTANCE;
         AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicReference<ObjectWriter> writerA = new AtomicReference<>();
+        AtomicReference<ObjectWriter> writerB = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(2);
 
-        startDaemonThread(() -> getObjectWriter(provider, BeanA.class, error, done));
-        startDaemonThread(() -> getObjectWriter(provider, BeanB.class, error, done));
+        startDaemonThread(() -> getObjectWriter(provider, BeanA.class, writerA, error, done));
+        startDaemonThread(() -> getObjectWriter(provider, BeanB.class, writerB, error, done));
 
+        assertTrue(fallbackStarted.await(5, TimeUnit.SECONDS));
+        assertNotNull(fallbackType.get());
+        provider.register(fallbackType.get(), canonical);
+        continueFallback.countDown();
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
+        assertSame(canonical, provider.getObjectWriter(fallbackType.get()));
+        assertSame(provider.getObjectWriter(BeanA.class), writerA.get());
+        assertSame(provider.getObjectWriter(BeanB.class), writerB.get());
+        assertSame(provider.getObjectWriter(BeanA.class), nestedWriterA.get());
+        assertSame(provider.getObjectWriter(BeanB.class), nestedWriterB.get());
         assertNoCreateLocks(provider);
     }
 
@@ -331,8 +358,21 @@ public class ObjectWriterProviderConcurrentTest {
             AtomicReference<Throwable> error,
             CountDownLatch done
     ) {
+        getObjectWriter(provider, type, null, error, done);
+    }
+
+    private static void getObjectWriter(
+            ObjectWriterProvider provider,
+            Type type,
+            AtomicReference<ObjectWriter> result,
+            AtomicReference<Throwable> error,
+            CountDownLatch done
+    ) {
         try {
-            provider.getObjectWriter(type);
+            ObjectWriter objectWriter = provider.getObjectWriter(type);
+            if (result != null) {
+                result.set(objectWriter);
+            }
         } catch (Throwable e) {
             error.compareAndSet(null, e);
         } finally {
@@ -342,10 +382,15 @@ public class ObjectWriterProviderConcurrentTest {
 
     private static void awaitWaiting(Thread thread) throws InterruptedException {
         long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-        while (thread.getState() != Thread.State.WAITING && System.nanoTime() < deadline) {
+        while (!isWaiting(thread) && System.nanoTime() < deadline) {
             TimeUnit.MILLISECONDS.sleep(1);
         }
-        assertEquals(Thread.State.WAITING, thread.getState());
+        assertTrue(isWaiting(thread));
+    }
+
+    private static boolean isWaiting(Thread thread) {
+        Thread.State state = thread.getState();
+        return state == Thread.State.WAITING || state == Thread.State.TIMED_WAITING;
     }
 
     private static Thread startDaemonThread(Runnable task) {

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -235,20 +235,26 @@ public class ObjectWriterProviderConcurrentTest {
         CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(provider.createLocks, Bean.class);
         ObjectWriter canonical = ObjectWriterImplString.INSTANCE;
         AtomicReference<ObjectWriter> result = new AtomicReference<>();
+        AtomicReference<ObjectWriter> secondResult = new AtomicReference<>();
         AtomicReference<Throwable> error = new AtomicReference<>();
-        CountDownLatch done = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
         Thread waiter = startDaemonThread(() -> getObjectWriter(provider, Bean.class, result, error, done));
+        Thread second = startDaemonThread(() -> getObjectWriter(provider, Bean.class, secondResult, error, done));
 
         try {
             awaitWaiting(waiter);
+            awaitWaiting(second);
             provider.register(Bean.class, canonical);
-            assertTrue(done.await(10, TimeUnit.SECONDS));
+            // Cache hits must not wait for the five-second creation fallback budget.
+            assertTrue(done.await(2, TimeUnit.SECONDS));
         } finally {
             owner.close();
+            assertTrue(done.await(5, TimeUnit.SECONDS));
         }
 
         assertNull(error.get());
         assertSame(canonical, result.get());
+        assertSame(canonical, secondResult.get());
         assertEquals(0, createCount.get());
         assertNoCreateLocks(provider);
     }

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriterProviderConcurrentTest.java
@@ -59,10 +59,12 @@ public class ObjectWriterProviderConcurrentTest {
     @Test
     public void testSpecializedObjectWriterIsPublished() throws InterruptedException {
         ObjectWriterProvider provider = new ObjectWriterProvider();
+        provider.modules.clear();
 
         Set<ObjectWriter> writers = getWriters(provider, ExtendedMap.class, false, 32);
 
         assertEquals(1, writers.size());
+        assertTrue(writers.iterator().next() instanceof ObjectWriterImplMap);
         assertSame(writers.iterator().next(), provider.cache.get(ExtendedMap.class));
         assertNoCreateLocks(provider);
     }
@@ -72,7 +74,7 @@ public class ObjectWriterProviderConcurrentTest {
         AtomicInteger createCount = new AtomicInteger();
         CountDownLatch firstStarted = new CountDownLatch(1);
         CountDownLatch failFirst = new CountDownLatch(1);
-        IllegalStateException expectedError = new IllegalStateException("first creation failed");
+        AssertionError expectedError = new AssertionError("first creation failed");
         ObjectWriterCreator creator = new ObjectWriterCreator() {
             @Override
             public ObjectWriter createObjectWriter(
@@ -151,6 +153,8 @@ public class ObjectWriterProviderConcurrentTest {
         AtomicReference<Throwable> firstError = new AtomicReference<>();
         startDaemonThread(() -> getObjectWriter(provider, FailureBean.class, firstError, firstDone));
         assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+        CodecCreationCoordinator.LockEntry retainedLock = provider.createLocks.get(FailureBean.class);
+        assertNotNull(retainedLock);
 
         CountDownLatch fallbackEntered = new CountDownLatch(1);
         CountDownLatch releaseFallback = new CountDownLatch(1);
@@ -167,6 +171,7 @@ public class ObjectWriterProviderConcurrentTest {
                 assertTrue(fallback.isLockFreeFallback());
                 fallbackEntered.countDown();
                 await(releaseFallback);
+                fallback.throwIfFailed();
             } catch (Throwable error) {
                 fallbackError.set(error);
             } finally {
@@ -179,8 +184,10 @@ public class ObjectWriterProviderConcurrentTest {
         CountDownLatch retryDone = new CountDownLatch(1);
         try {
             assertTrue(fallbackEntered.await(5, TimeUnit.SECONDS));
+            assertSame(retainedLock, provider.createLocks.get(FailureBean.class));
             failFirst.countDown();
             assertTrue(firstDone.await(5, TimeUnit.SECONDS));
+            assertSame(retainedLock, provider.createLocks.get(FailureBean.class));
 
             startDaemonThread(() -> {
                 try {
@@ -192,6 +199,10 @@ public class ObjectWriterProviderConcurrentTest {
                 }
             });
             assertTrue(retryDone.await(5, TimeUnit.SECONDS));
+            assertNull(retryError.get());
+            assertNotNull(retryWriter.get());
+            assertSame(retainedLock, provider.createLocks.get(FailureBean.class));
+            assertSame(retryWriter.get(), provider.unregister(FailureBean.class));
         } finally {
             failFirst.countDown();
             releaseFallback.countDown();
@@ -200,9 +211,45 @@ public class ObjectWriterProviderConcurrentTest {
         assertTrue(fallbackDone.await(5, TimeUnit.SECONDS));
         assertSame(expectedError, firstError.get());
         assertNull(fallbackError.get());
-        assertNull(retryError.get());
-        assertNotNull(retryWriter.get());
         assertEquals(2, createCount.get());
+        assertNoCreateLocks(provider);
+    }
+
+    @Test
+    public void testFallbackRechecksCacheBeforeCreating() throws InterruptedException {
+        AtomicInteger createCount = new AtomicInteger();
+        ObjectWriterCreator creator = new ObjectWriterCreator() {
+            @Override
+            public ObjectWriter createObjectWriter(
+                    Class objectClass,
+                    long features,
+                    ObjectWriterProvider provider
+            ) {
+                if (objectClass == Bean.class) {
+                    createCount.incrementAndGet();
+                }
+                return super.createObjectWriter(objectClass, features, provider);
+            }
+        };
+        ObjectWriterProvider provider = new ObjectWriterProvider(creator);
+        CodecCreationCoordinator.Scope owner = CodecCreationCoordinator.acquire(provider.createLocks, Bean.class);
+        ObjectWriter canonical = ObjectWriterImplString.INSTANCE;
+        AtomicReference<ObjectWriter> result = new AtomicReference<>();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        CountDownLatch done = new CountDownLatch(1);
+        Thread waiter = startDaemonThread(() -> getObjectWriter(provider, Bean.class, result, error, done));
+
+        try {
+            awaitWaiting(waiter);
+            provider.register(Bean.class, canonical);
+            assertTrue(done.await(10, TimeUnit.SECONDS));
+        } finally {
+            owner.close();
+        }
+
+        assertNull(error.get());
+        assertSame(canonical, result.get());
+        assertEquals(0, createCount.get());
         assertNoCreateLocks(provider);
     }
 
@@ -413,15 +460,22 @@ public class ObjectWriterProviderConcurrentTest {
         ObjectWriterProvider provider = new ObjectWriterProvider(creator);
         Type typeA = new TypeReference<GenericBean<ValueA>>() { }.getType();
         Type typeB = new TypeReference<GenericBean<ValueB>>() { }.getType();
+        AtomicReference<ObjectWriter> writerA = new AtomicReference<>();
+        AtomicReference<ObjectWriter> writerB = new AtomicReference<>();
         AtomicReference<Throwable> error = new AtomicReference<>();
         CountDownLatch done = new CountDownLatch(2);
 
-        startDaemonThread(() -> getObjectWriter(provider, typeA, error, done));
-        startDaemonThread(() -> getObjectWriter(provider, typeB, error, done));
+        startDaemonThread(() -> getObjectWriter(provider, typeA, writerA, error, done));
+        startDaemonThread(() -> getObjectWriter(provider, typeB, writerB, error, done));
 
         assertTrue(done.await(10, TimeUnit.SECONDS));
         assertNull(error.get());
         assertEquals(2, createCount.get());
+        assertNotNull(writerA.get());
+        assertNotNull(writerB.get());
+        assertNotSame(writerA.get(), writerB.get());
+        assertSame(writerA.get(), provider.cache.get(typeA));
+        assertSame(writerB.get(), provider.cache.get(typeB));
         assertNoCreateLocks(provider);
     }
 


### PR DESCRIPTION
### Motivation

When multiple threads access the same uncached JavaBean concurrently, every thread may create its own `ObjectReader` or `ObjectWriter` before one instance is published by `putIfAbsent`.

`putIfAbsent` guarantees that only one instance is retained, but the losing instances have already created their property accessors. This can produce many unnecessary hidden Lambda classes during the first concurrent serialization or deserialization burst.

For a bean with two getters and 100 concurrent first-time serializations, fastjson2 2.0.63 loaded 200 `RuleEntity$$Lambda` classes instead of the expected 2. Pre-warming `ObjectReader` does not help serialization because `toJSONString` uses `ObjectWriterProvider`.

### Changes

* Coordinate generic reader and writer creation with provider-local locks keyed by the complete `Type`.
* Use separate lock maps for normal and field-based caches in each provider.
* Recheck the selected cache after obtaining the creation lock.
* Use timed `tryLock`; if nested user extension code creates a cyclic dependency, the caller falls back to the original create-and-`putIfAbsent` behavior instead of waiting indefinitely.
* Remove `ClassValue` to preserve Android API 26 compatibility.
* Remove transient locks after creation, while keeping the cache-hit hot paths unchanged and lock-free.

### Tests

The concurrent regression tests cover both providers and verify:

* 32 concurrent first lookups create one shared reader/writer.
* Normal and field-based caches remain isolated, and each field-based instance is created once.
* Different parameterizations of the same generic class initialize concurrently.
* Cyclic nested creation of two cold types terminates instead of deadlocking.

For the original two-getter reproduction with 100 concurrent first-time serializations:

scenario | `RuleEntity$$Lambda` classes loaded
--- | ---:
no pre-warming | 200
pre-warm `ObjectReader` only | 202
pre-warm `ObjectWriter` | 2
this change, no pre-warming | 2

The following commands pass after the change:

```text
./mvnw -pl core -Dtest=ObjectReaderProviderConcurrentTest,ObjectWriterProviderConcurrentTest test
./mvnw -pl core test
./mvnw -pl core -Dfastjson2.creator=reflect test
./mvnw -pl core validate
./mvnw test
```

The Android Gradle test was not run locally because no Android SDK is installed. The unconditional `ClassValue` dependency has been removed; the replacement uses APIs available before the project's minSdk 26.

<details>
<summary>中文</summary>

### 动机

多个线程并发首次访问同一个尚未缓存的 JavaBean 时，每个线程都可能在某个实例通过 `putIfAbsent` 发布到缓存之前，分别创建自己的 `ObjectReader` 或 `ObjectWriter`。

`putIfAbsent` 只能保证最终缓存中保留一个实例，其他竞争失败的实例已经创建了属性访问器，因此首次并发序列化或反序列化时可能产生大量无用的 Lambda 隐藏类。

对于包含两个 getter 的 Bean，使用 100 个线程并发首次序列化时，fastjson2 2.0.63 会加载 200 个 `RuleEntity$$Lambda` 类，而正常只需要 2 个。预热 `ObjectReader` 无法规避序列化问题，因为 `toJSONString` 使用的是 `ObjectWriterProvider`。

### 改动

* 使用 Provider 内部、按完整 `Type` 划分的锁协调通用 reader 和 writer 创建。
* 每个 Provider 的普通缓存和 FieldBased 缓存分别使用独立锁表。
* 获得创建锁后再次检查选中的缓存。
* 使用有超时的 `tryLock`；如果用户扩展代码的嵌套创建形成循环依赖，则回退到原来的创建并 `putIfAbsent` 行为，而不是无限等待。
* 移除 `ClassValue`，保持 Android API 26 兼容性。
* 创建结束后移除临时锁，缓存命中的热路径保持不变且不加锁。

### 测试

Reader 和 Writer 的并发回归测试均覆盖：

* 32 个线程并发首次获取时只创建一个共享 reader/writer。
* 普通缓存与 FieldBased 缓存保持隔离，FieldBased 实例也只创建一次。
* 同一泛型类的不同参数化 Type 可以并行初始化。
* 两个冷类型的循环嵌套创建能够结束，不会永久死锁。

对于原始的双 getter Bean，使用 100 个线程并发首次序列化：

场景 | 加载的 `RuleEntity$$Lambda` 类数
--- | ---:
不做预热 | 200
只预热 `ObjectReader` | 202
预热 `ObjectWriter` | 2
应用本修复，不做预热 | 2

应用修复后，以下命令均执行通过：

```text
./mvnw -pl core -Dtest=ObjectReaderProviderConcurrentTest,ObjectWriterProviderConcurrentTest test
./mvnw -pl core test
./mvnw -pl core -Dfastjson2.creator=reflect test
./mvnw -pl core validate
./mvnw test
```

本机没有安装 Android SDK，因此未运行 Android Gradle 测试。无条件使用的 `ClassValue` 已移除，替代实现使用的 API 均早于项目的 minSdk 26。

</details>
