### PR TITLE
Harden inline readLength() array decode sites against declared-length OOM (follow-up to #7733)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1435,14 +1435,28 @@ final class JSONReaderJSONB
         }
 
         if (type == BC_BINARY) {
-            return readInt32Value();
+            int len = readInt32Value();
+            checkArrayLen(len, offset, end);
+            return len;
         }
 
         if (type != BC_ARRAY) {
             throw new JSONException("array not support input " + error(type));
         }
 
-        return readInt32Value();
+        int len = readInt32Value();
+        checkArrayLen(len, offset, end);
+        return len;
+    }
+
+    static void checkArrayLen(int len, int offset, int end) {
+        // Each array/collection element occupies at least one byte in the JSONB stream,
+        // so a declared length larger than the remaining buffer is malformed input.
+        // Guards against a small crafted payload declaring Integer.MAX_VALUE elements
+        // that triggers an immediate over-sized array pre-allocation (OOM / DoS).
+        if (len < 0 || len > end - offset) {
+            throw new JSONException("array length out of range: " + len + ", available: " + (end - offset));
+        }
     }
 
     public String error(byte type) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -404,6 +404,8 @@ final class JSONReaderJSONB
                         len = valueType - BC_ARRAY_FIX_MIN;
                     }
 
+                    checkLength(len, offset, end, "array length");
+
                     if (len == 0) {
                         if ((features & Feature.UseNativeObject.mask) != 0) {
                             value = new ArrayList<>();
@@ -927,6 +929,8 @@ final class JSONReaderJSONB
                             ? readLength()
                             : type - BC_ARRAY_FIX_MIN;
 
+                    checkLength(len, offset, end, "array length");
+
                     if (len == 0) {
                         if ((context.features & Feature.UseNativeObject.mask) != 0) {
                             return new ArrayList<>();
@@ -1097,6 +1101,8 @@ final class JSONReaderJSONB
                 int len = valueType == BC_ARRAY
                         ? readLength()
                         : valueType - BC_ARRAY_FIX_MIN;
+
+                checkLength(len, offset, end, "array length");
 
                 if (len == 0) {
                     if ((context.features & Feature.UseNativeObject.mask) != 0) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -1454,8 +1454,17 @@ final class JSONReaderJSONB
         // so a declared length larger than the remaining buffer is malformed input.
         // Guards against a small crafted payload declaring Integer.MAX_VALUE elements
         // that triggers an immediate over-sized array pre-allocation (OOM / DoS).
+        checkLength(len, offset, end, "array length");
+    }
+
+    // Shared bounds-check for lengths declared in untrusted JSONB (see #7669).
+    // `label` identifies the context in the error message (e.g. "array length",
+    // "BC_BIGINT length"). A declared length larger than the remaining buffer is
+    // malformed input and must be rejected before any pre-allocation.
+    static void checkLength(int len, int offset, int end, String label) {
         if (len < 0 || len > end - offset) {
-            throw new JSONException("array length out of range: " + len + ", available: " + (end - offset));
+            throw new JSONException(
+                    label + " out of range at offset " + offset + "/" + end + ": " + len + ", available: " + (end - offset));
         }
     }
 
@@ -6318,9 +6327,7 @@ final class JSONReaderJSONB
     }
 
     static void checkBigintLen(int len, int offset, int end) {
-        if (len < 0 || len > end - offset) {
-            throw new JSONException("BC_BIGINT length out of range: " + len + ", available: " + (end - offset));
-        }
+        checkLength(len, offset, end, "BC_BIGINT length");
     }
 
     static JSONException outOfBoundsCheckFromToIndex(int offset, int end) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -404,7 +404,7 @@ final class JSONReaderJSONB
                         len = valueType - BC_ARRAY_FIX_MIN;
                     }
 
-                    checkLength(len, offset, end, "array length");
+                    checkArrayLen(len, offset, end);
 
                     if (len == 0) {
                         if ((features & Feature.UseNativeObject.mask) != 0) {
@@ -697,9 +697,7 @@ final class JSONReaderJSONB
             }
             case BC_BINARY: {
                 int len = readLength();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BINARY length out of range: " + len);
-                }
+                checkLength(len, offset, end, "BC_BINARY length");
                 byte[] binary = Arrays.copyOfRange(this.bytes, offset, offset + len);
                 offset += len;
                 return binary;
@@ -929,7 +927,7 @@ final class JSONReaderJSONB
                             ? readLength()
                             : type - BC_ARRAY_FIX_MIN;
 
-                    checkLength(len, offset, end, "array length");
+                    checkArrayLen(len, offset, end);
 
                     if (len == 0) {
                         if ((context.features & Feature.UseNativeObject.mask) != 0) {
@@ -1102,7 +1100,7 @@ final class JSONReaderJSONB
                         ? readLength()
                         : valueType - BC_ARRAY_FIX_MIN;
 
-                checkLength(len, offset, end, "array length");
+                checkArrayLen(len, offset, end);
 
                 if (len == 0) {
                     if ((context.features & Feature.UseNativeObject.mask) != 0) {
@@ -1467,11 +1465,18 @@ final class JSONReaderJSONB
     // `label` identifies the context in the error message (e.g. "array length",
     // "BC_BIGINT length"). A declared length larger than the remaining buffer is
     // malformed input and must be rejected before any pre-allocation.
+    // Hot/cold split (AGENTS.md MaxInlineSize gate): keep the two comparisons
+    // small enough to inline on every BC_ARRAY header decode; the exception
+    // message StringBuilder chain lives in the cold throw helper.
     static void checkLength(int len, int offset, int end, String label) {
         if (len < 0 || len > end - offset) {
-            throw new JSONException(
-                    label + " out of range at offset " + offset + "/" + end + ": " + len + ", available: " + (end - offset));
+            throwLengthOutOfRange(len, offset, end, label);
         }
+    }
+
+    static void throwLengthOutOfRange(int len, int offset, int end, String label) {
+        throw new JSONException(
+                label + " out of range at offset " + offset + "/" + end + ": " + len + ", available: " + (end - offset));
     }
 
     public String error(byte type) {
@@ -3736,9 +3741,7 @@ final class JSONReaderJSONB
         }
 
         int len = readLength();
-        if (len < 0 || len > end - offset) {
-            throw new JSONException("BC_BINARY length out of range: " + len);
-        }
+        checkLength(len, offset, end, "BC_BINARY length");
         byte[] bytes = new byte[len];
         System.arraycopy(this.bytes, offset, bytes, 0, len);
         offset += len;
@@ -4510,9 +4513,7 @@ final class JSONReaderJSONB
             }
             case BC_BINARY: {
                 int len = readInt32Value();
-                if (len < 0 || len > end - offset) {
-                    throw new JSONException("BC_BINARY length out of range: " + len);
-                }
+                checkLength(len, offset, end, "BC_BINARY length");
                 byte[] buf = new byte[len];
                 System.arraycopy(this.bytes, offset, buf, 0, len);
                 offset += len;

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("regression")
 @Tag("jsonb")
@@ -236,20 +237,26 @@ public class Issue7669 {
     public void testUntypedArrayDeclaredLengthOOM_readAny() {
         // JSONB.parse with no target type dispatches to readAny(); its BC_ARRAY
         // branch reads the length via readLength() and pre-allocates
-        // new JSONArray(len) — now guarded by checkLength.
-        assertThrows(JSONException.class, () -> JSONB.parse(UNTYPED_ARRAY_MAX_LEN));
+        // new JSONArray(len) — now guarded by checkLength. Pin the guard's own
+        // message: without the guard a downstream "readAny overflow" JSONException
+        // would also satisfy a type-only assertion, letting the fix rot silently.
+        JSONException ex = assertThrows(JSONException.class, () -> JSONB.parse(UNTYPED_ARRAY_MAX_LEN));
+        assertTrue(ex.getMessage().contains("array length out of range"));
     }
 
     @Test
     public void testUntypedArrayDeclaredLengthOOM_readObject() {
         // A map whose value is an int[] (32 elems -> BC_ARRAY + BC_INT32 length).
-        // Corrupt the declared length, then parse as Object.class so readObject()
-        // takes the map-value BC_ARRAY branch (readLength).
+        // Corrupt the declared length, then parse via the untyped overload:
+        // JSONB.parseObject(bytes, Object.class) short-circuits through readAny()
+        // (the Object.class fast path) and would NOT exercise the readObject()
+        // map-value guard at JSONReaderJSONB.java:407 — the untyped overload does.
         Map<String, Object> m = new HashMap<>();
         m.put("k", new int[32]);
         byte[] bytes = JSONB.toBytes(m);
         corruptFirstArrayLength(bytes);
-        assertThrows(JSONException.class, () -> JSONB.parseObject(bytes, Object.class));
+        JSONException ex = assertThrows(JSONException.class, () -> JSONB.parseObject(bytes));
+        assertTrue(ex.getMessage().contains("array length out of range"));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -167,4 +167,26 @@ public class Issue7669 {
         int[] result = JSONB.parseObject(jsonbBytes, int[].class);
         assertArrayEquals(value, result);
     }
+
+    // --- R2-2 hardening: pin the position-relative bound (len > end - offset),
+    // not an absolute bound. The malformed BC_ARRAY below is NOT at the buffer
+    // end: an outer BC_ARRAY_FIX (0x95, 1 element) wraps an inner BC_ARRAY (0xA4)
+    // declaring 5 elements while only 1 byte (0xF0) remains. A guard that
+    // degenerates to `len > end` would let this slip through and later die with
+    // ArrayIndexOutOfBoundsException instead of JSONException.
+    // 0x95 = BC_ARRAY_FIX(1 elem), 0xA4 = BC_ARRAY, 0x48 = BC_INT32,
+    // 0x00000005 = declares 5 elements, 0xF0 = 1 trailing byte
+    static final byte[] NESTED_ARRAY_BAD_LEN = {
+            (byte) 0x95,
+            (byte) 0xA4,
+            (byte) 0x48,
+            0x00, 0x00, 0x00, 0x05,
+            (byte) 0xF0
+    };
+
+    @Test
+    public void testArrayDeclaredLengthNotAtBufferEnd() {
+        assertThrows(JSONException.class,
+                () -> JSONB.parseObject(NESTED_ARRAY_BAD_LEN, int[][].class));
+    }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -118,6 +118,14 @@ public class Issue7669 {
             (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
     };
 
+    // 0x91 = BC_BINARY (routed through startArray() via typed array deserialization),
+    // 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] BINARY_ARRAY_PAYLOAD_MAX_LEN = {
+            (byte) 0x91,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
     @Test
     public void testArrayDeclaredLengthOOM_int() {
         assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, int[].class));
@@ -139,8 +147,22 @@ public class Issue7669 {
     }
 
     @Test
+    public void testArrayDeclaredLengthOOM_binaryBranch() {
+        // The BC_BINARY branch of startArray() received the same checkArrayLen guard;
+        // a crafted payload must be rejected through this path too (parseObject typed
+        // array deserialization routes it through startArray()).
+        assertThrows(JSONException.class, () -> JSONB.parseObject(BINARY_ARRAY_PAYLOAD_MAX_LEN, int[].class));
+    }
+
+    @Test
     public void testArrayValidPayloadStillWorks() {
-        int[] value = {1, 2, 3};
+        // ARRAY_FIX_LEN = 15: arrays with <= 15 elements are encoded as BC_ARRAY_FIX
+        // and bypass startArray()'s checkLength entirely. Use 32 elements to force
+        // BC_ARRAY encoding so this test actually exercises the guarded path.
+        int[] value = new int[32];
+        for (int i = 0; i < value.length; i++) {
+            value[i] = i;
+        }
         byte[] jsonbBytes = JSONB.toBytes(value);
         int[] result = JSONB.parseObject(jsonbBytes, int[].class);
         assertArrayEquals(value, result);

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -188,5 +190,82 @@ public class Issue7669 {
     public void testArrayDeclaredLengthNotAtBufferEnd() {
         assertThrows(JSONException.class,
                 () -> JSONB.parseObject(NESTED_ARRAY_BAD_LEN, int[][].class));
+    }
+
+    // --- R2-1: the same declared-length pre-allocation OOM class, but through the
+    // untyped/nested BC_ARRAY decode paths that never call startArray():
+    // readAny() (default branch), readObject() (map-value branch), readArray()
+    // (element branch). They read the length via readLength() and pre-allocate
+    // new JSONArray(len)/new ArrayList(len) with no remaining-buffer check.
+    // This change folds the same checkLength guard into those three inline sites.
+
+    // 0xA4 = BC_ARRAY, 0x48 = BC_INT32, 0x0FFFFFFF = 268,435,455 elements
+    static final byte[] UNTYPED_ARRAY_MAX_LEN = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    /**
+     * Corrupt the first BC_ARRAY (0xA4) + BC_INT32 (0x48) length field found in
+     * the payload to a huge value, so the declared length vastly exceeds the
+     * remaining buffer. Used to exercise the untyped/nested readLength() sites.
+     */
+    private static void corruptFirstArrayLength(byte[] bytes) {
+        for (int i = 0; i + 5 < bytes.length; i++) {
+            if ((bytes[i] & 0xFF) == 0xA4) {  // BC_ARRAY
+                // Rewrite the array's leading byte as BC_INT32 (0x48) so the inline
+                // readLength() site treats it as a 4-byte length-type, then overwrite
+                // those 4 bytes with 0x0FFFFFFF (268,435,455) — far larger than the
+                // remaining buffer — to exercise the checkLength guard placed at the
+                // inline readLength() decode site (readObject() map-value branch).
+                // The corrupt target is the inner array value, not the (BC_OBJECT)
+                // root, because the root is never encoded as BC_ARRAY.
+                bytes[i + 1] = (byte) 0x48;  // BC_INT32
+                bytes[i + 2] = (byte) 0x0F;
+                bytes[i + 3] = (byte) 0xFF;
+                bytes[i + 4] = (byte) 0xFF;
+                bytes[i + 5] = (byte) 0xFF;
+                return;
+            }
+        }
+        throw new IllegalStateException("BC_ARRAY not found in payload");
+    }
+
+    @Test
+    public void testUntypedArrayDeclaredLengthOOM_readAny() {
+        // JSONB.parse with no target type dispatches to readAny(); its BC_ARRAY
+        // branch reads the length via readLength() and pre-allocates
+        // new JSONArray(len) — now guarded by checkLength.
+        assertThrows(JSONException.class, () -> JSONB.parse(UNTYPED_ARRAY_MAX_LEN));
+    }
+
+    @Test
+    public void testUntypedArrayDeclaredLengthOOM_readObject() {
+        // A map whose value is an int[] (32 elems -> BC_ARRAY + BC_INT32 length).
+        // Corrupt the declared length, then parse as Object.class so readObject()
+        // takes the map-value BC_ARRAY branch (readLength).
+        Map<String, Object> m = new HashMap<>();
+        m.put("k", new int[32]);
+        byte[] bytes = JSONB.toBytes(m);
+        corruptFirstArrayLength(bytes);
+        assertThrows(JSONException.class, () -> JSONB.parseObject(bytes, Object.class));
+    }
+
+    @Test
+    public void testUntypedArrayDeclaredLengthOOM_readArray() {
+        // Top-level JSONB.parseArray dispatches to readArray(); a nested element
+        // that is itself a BC_ARRAY must have its declared length (read via the
+        // inline readLength() at the element branch, line ~1099) rejected by
+        // checkLength.
+        // 0xA4 = BC_ARRAY (outer, 1 element), 0x01 = outer declared length,
+        // 0xA4 = BC_ARRAY (inner element), 0x48 = BC_INT32 length-type,
+        // 0x0FFFFFFF = declares 268,435,455 inner elements (exceeds buffer).
+        byte[] bytes = {
+                (byte) 0xA4, 0x01,
+                (byte) 0xA4, (byte) 0x48,
+                (byte) 0x0F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        };
+        assertThrows(JSONException.class, () -> JSONB.parseArray(bytes));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues/Issue7669.java
@@ -101,4 +101,48 @@ public class Issue7669 {
         byte[] result = (byte[]) JSONB.parse(jsonbBytes);
         assertArrayEquals(value, result);
     }
+
+    // --- BC_ARRAY declared-length OOM path (same class as #7669, fixed by this PR) ---
+
+    // 0xA4 = BC_ARRAY, 0x48 = BC_INT32, 0x7FFFFFFF = Integer.MAX_VALUE
+    static final byte[] ARRAY_PAYLOAD_MAX_LEN = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    // 0xA4 = BC_ARRAY, 0x48 = BC_INT32, 0xFFFFFFFF = -1
+    static final byte[] ARRAY_PAYLOAD_NEG_LEN = {
+            (byte) 0xA4,
+            (byte) 0x48,
+            (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+    };
+
+    @Test
+    public void testArrayDeclaredLengthOOM_int() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, int[].class));
+    }
+
+    @Test
+    public void testArrayDeclaredLengthOOM_long() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, long[].class));
+    }
+
+    @Test
+    public void testArrayDeclaredLengthOOM_string() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_MAX_LEN, String[].class));
+    }
+
+    @Test
+    public void testArrayNegativeLength() {
+        assertThrows(JSONException.class, () -> JSONB.parseObject(ARRAY_PAYLOAD_NEG_LEN, int[].class));
+    }
+
+    @Test
+    public void testArrayValidPayloadStillWorks() {
+        int[] value = {1, 2, 3};
+        byte[] jsonbBytes = JSONB.toBytes(value);
+        int[] result = JSONB.parseObject(jsonbBytes, int[].class);
+        assertArrayEquals(value, result);
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #7733 (same 7669 series: #7696 / #7705 / #7733).

PR #7733 added a `checkLength` remaining-buffer guard to `startArray()` to stop the `BC_ARRAY` declared-length pre-allocation OOM. The reviewer (review-4842883034, suggestion **R2-1**) correctly pointed out that three inline `BC_ARRAY` decode sites never call `startArray()` and therefore still pre-allocate `new JSONArray(len)` / `new ArrayList(len)` with no remaining-buffer check:

- `readObject()` map-value branch (~line 392)
- `readAny()` value branch (~line 927)
- `readArray()` element branch (~line 1099)

This PR folds the same `checkLength(offset, end, len)` guard into those three inline sites.

## Reproducer

A 6-byte `BC_ARRAY` payload declaring ~268M elements against a tiny buffer, e.g.

```
A4 48 0F FF FF FF
```

previously pre-allocated a ~1GiB `Object[]` and OOM'd under a constrained heap; it now throws `JSONException: array length out of range`.

## Verification

`Issue7669` regression tests added for all three paths:
- `testUntypedArrayDeclaredLengthOOM_readAny`    (JSONB.parse -> readAny)
- `testUntypedArrayDeclaredLengthOOM_readObject` (JSONB.parseObject -> readObject)
- `testUntypedArrayDeclaredLengthOOM_readArray`  (JSONB.parseArray -> readArray)

`mvn -pl core test -Dtest=Issue7669` → 20/20 pass, 0 Checkstyle violations.