### PR TITLE
fix: make JSONPath.contains parse JSON text like eval

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
@@ -227,6 +227,26 @@ public abstract class JSONPath {
     }
 
     /**
+     * Checks if the specified path exists in JSON text.
+     * <p>
+     * Mirrors {@link #eval(String, String)} / {@link #extract(String, String)}: the first
+     * argument is parsed as JSON, not treated as a Java bean. Without this overload,
+     * {@code contains(jsonText, path)} resolves to {@link #contains(Object, String)} and
+     * incorrectly returns false for ordinary property paths such as {@code $.status}.
+     *
+     * @param json the JSON text to check
+     * @param path the JSONPath expression
+     * @return true if the path exists, false otherwise
+     */
+    public static boolean contains(String json, String path) {
+        if (json == null) {
+            return false;
+        }
+
+        return JSONPath.of(path).contains(JSON.parse(json));
+    }
+
+    /**
      * Sets a value in an object using the specified path
      *
      * @param rootObject the root object to modify

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
@@ -246,9 +246,6 @@ public abstract class JSONPath {
         }
 
         Object parsed = JSON.parse(json, JSONReader.Feature.DisableReferenceDetect);
-        if ("$".equals(path)) {
-            return parsed != null;
-        }
         return contains(parsed, path);
     }
 
@@ -1557,7 +1554,7 @@ public abstract class JSONPath {
 
         @Override
         public boolean contains(Object object) {
-            return false;
+            return object != null;
         }
 
         @Override

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
@@ -233,6 +233,8 @@ public abstract class JSONPath {
      * argument is parsed as JSON, not treated as a Java bean. Without this overload,
      * {@code contains(jsonText, path)} resolves to {@link #contains(Object, String)} and
      * incorrectly returns false for ordinary property paths such as {@code $.status}.
+     * The root path {@code $} is present for every non-null document.
+     * {@code $ref} is not resolved, matching {@link #extract(String, String)}.
      *
      * @param json the JSON text to check
      * @param path the JSONPath expression
@@ -243,7 +245,11 @@ public abstract class JSONPath {
             return false;
         }
 
-        return contains(JSON.parse(json), path);
+        Object parsed = JSON.parse(json, JSONReader.Feature.DisableReferenceDetect);
+        if ("$".equals(path)) {
+            return parsed != null;
+        }
+        return contains(parsed, path);
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPath.java
@@ -243,7 +243,7 @@ public abstract class JSONPath {
             return false;
         }
 
-        return JSONPath.of(path).contains(JSON.parse(json));
+        return contains(JSON.parse(json), path);
     }
 
     /**

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathFilter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathFilter.java
@@ -32,6 +32,12 @@ abstract class JSONPathFilter
 
     abstract boolean apply(JSONPath.Context context, Object object);
 
+    @Override
+    public boolean contains(JSONPath.Context context) {
+        eval(context);
+        return hasMatch(context.value);
+    }
+
     enum Operator {
         EQ,
         NE,

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSegment.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSegment.java
@@ -34,6 +34,17 @@ abstract class JSONPathSegment {
         return context.value != null;
     }
 
+    static boolean hasMatch(Object value) {
+        if (value instanceof Collection) {
+            return !((Collection<?>) value).isEmpty();
+        }
+        if (value instanceof JSONPath.Sequence) {
+            List<?> values = ((JSONPath.Sequence) value).values;
+            return values != null && !values.isEmpty();
+        }
+        return value != null;
+    }
+
     public boolean remove(JSONPath.Context context) {
         throw new JSONException("UnsupportedOperation " + getClass());
     }
@@ -266,6 +277,12 @@ abstract class JSONPathSegment {
             }
 
             throw new JSONException("TODO");
+        }
+
+        @Override
+        public boolean contains(JSONPath.Context context) {
+            eval(context);
+            return hasMatch(context.value);
         }
 
         @Override
@@ -562,6 +579,12 @@ abstract class JSONPathSegment {
         }
 
         @Override
+        public boolean contains(JSONPath.Context context) {
+            eval(context);
+            return hasMatch(context.value);
+        }
+
+        @Override
         public void accept(JSONReader jsonReader, JSONPath.Context context) {
             if (context.parent != null
                     && context.parent.current instanceof CycleNameSegment
@@ -777,6 +800,24 @@ abstract class JSONPathSegment {
                 array.add(fieldValue);
             }
             context.value = array;
+        }
+
+        @Override
+        public boolean contains(JSONPath.Context context) {
+            Object object = context.parent == null
+                    ? context.root
+                    : context.parent.value;
+            if (object instanceof Map) {
+                Map<?, ?> map = (Map<?, ?>) object;
+                for (String name : names) {
+                    if (map.containsKey(name)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            eval(context);
+            return hasMatch(context.value);
         }
 
         @Override
@@ -1055,6 +1096,12 @@ abstract class JSONPathSegment {
             }
             context.value = array;
             context.eval = true;
+        }
+
+        @Override
+        public boolean contains(JSONPath.Context context) {
+            eval(context);
+            return hasMatch(context.value);
         }
 
         @Override
@@ -1388,6 +1435,22 @@ abstract class JSONPathSegment {
             }
 
             context.eval = true;
+        }
+
+        @Override
+        public boolean contains(JSONPath.Context context) {
+            Object object = context.parent == null
+                    ? context.root
+                    : context.parent.value;
+            List values = new JSONArray();
+            Consumer action;
+            if (shouldRecursive()) {
+                action = new MapRecursive(context, values, 0);
+            } else {
+                action = new MapLoop(context, values);
+            }
+            action.accept(object);
+            return !values.isEmpty();
         }
 
         @Override

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentIndex.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentIndex.java
@@ -200,6 +200,53 @@ final class JSONPathSegmentIndex
     }
 
     @Override
+    public boolean contains(JSONPath.Context context) {
+        Object object = context.parent == null
+                ? context.root
+                : context.parent.value;
+        if (object == null) {
+            return false;
+        }
+        if (object instanceof List) {
+            int size = ((List<?>) object).size();
+            int i = index >= 0 ? index : size + index;
+            return i >= 0 && i < size;
+        }
+        if (object instanceof Object[]) {
+            int size = ((Object[]) object).length;
+            int i = index >= 0 ? index : size + index;
+            return i >= 0 && i < size;
+        }
+        Class<?> objectClass = object.getClass();
+        if (objectClass.isArray()) {
+            int size = Array.getLength(object);
+            int i = index >= 0 ? index : size + index;
+            return i >= 0 && i < size;
+        }
+        if (object instanceof Collection) {
+            int size = ((Collection<?>) object).size();
+            int i = index >= 0 ? index : size + index;
+            return i >= 0 && i < size;
+        }
+        if (object instanceof JSONPath.Sequence) {
+            for (Object item : ((JSONPath.Sequence) object).values) {
+                context.value = item;
+                JSONPath.Context itemContext = new JSONPath.Context(
+                        context.path, context, context.current, context.next, context.readerFeatures);
+                if (contains(itemContext)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (object instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) object;
+            return map.containsKey(index) || map.containsKey(Integer.toString(index));
+        }
+        return index == 0;
+    }
+
+    @Override
     public void set(JSONPath.Context context, Object value) {
         Object object = context.parent == null
                 ? context.root

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentName.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentName.java
@@ -98,9 +98,10 @@ class JSONPathSegmentName
                 }
 
                 if (item instanceof Map) {
-                    if (((Map<?, ?>) item).get(name) != null) {
+                    if (((Map<?, ?>) item).containsKey(name)) {
                         return true;
                     }
+                    continue;
                 }
 
                 ObjectWriter<?> objectWriter = context.path
@@ -126,9 +127,10 @@ class JSONPathSegmentName
                 }
 
                 if (item instanceof Map) {
-                    if (((Map<?, ?>) item).get(name) != null) {
+                    if (((Map<?, ?>) item).containsKey(name)) {
                         return true;
                     }
+                    continue;
                 }
 
                 ObjectWriter<?> objectWriter = context.path
@@ -154,9 +156,10 @@ class JSONPathSegmentName
                 }
 
                 if (item instanceof Map) {
-                    if (((Map) item).get(name) != null) {
+                    if (((Map) item).containsKey(name)) {
                         return true;
                     }
+                    continue;
                 }
 
                 ObjectWriter<?> objectWriter = context.path

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSingleName.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSingleName.java
@@ -111,6 +111,10 @@ final class JSONPathSingleName
 
     @Override
     public boolean contains(Object root) {
+        if (root == null) {
+            return false;
+        }
+
         if (root instanceof Map) {
             return ((Map) root).containsKey(name);
         }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathTypedMulti.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathTypedMulti.java
@@ -50,6 +50,9 @@ class JSONPathTypedMulti
     @Override
     public boolean contains(Object object) {
         for (JSONPath jsonPath : paths) {
+            if (jsonPath instanceof RootPath) {
+                continue;
+            }
             if (jsonPath.contains(object)) {
                 return true;
             }

--- a/core/src/test/java/com/alibaba/fastjson2/JSONPathTypedMultiTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONPathTypedMultiTest.java
@@ -200,6 +200,7 @@ public class JSONPathTypedMultiTest {
                 new String[]{"$", "$.values[0].name", "$.values[0].date"},
                 new Type[]{JSONObject.class, String.class, Date.class}
         );
+        assertTrue(JSONPath.contains(object, "$"));
         assertFalse(jsonPath.contains(object));
         assertTrue(jsonPath.isRef());
     }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
@@ -33,4 +33,10 @@ public class Issue7771 {
         assertTrue(JSONPath.contains(object, "$.status"));
         assertFalse(JSONPath.contains(object, "$.missing"));
     }
+
+    @Test
+    public void containsOnJsonNullLiteralIsFalse() {
+        assertFalse(JSONPath.contains("null", "$.status"));
+        assertFalse(JSONPath.contains("null", "$"));
+    }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
@@ -38,5 +38,30 @@ public class Issue7771 {
     public void containsOnJsonNullLiteralIsFalse() {
         assertFalse(JSONPath.contains("null", "$.status"));
         assertFalse(JSONPath.contains("null", "$"));
+        assertFalse(JSONPath.contains((String) null, "$.status"));
+        assertFalse(JSONPath.contains("", "$.status"));
+    }
+
+    @Test
+    public void containsOnRootPathMatchesEval() {
+        assertTrue(JSONPath.contains("{\"status\":200}", "$"));
+        assertTrue(JSONPath.contains("123", "$"));
+        assertTrue(JSONPath.contains("[1,2]", "$"));
+        assertEquals(JSON.parse("{\"status\":200}"), JSONPath.eval("{\"status\":200}", "$"));
+    }
+
+    @Test
+    public void containsOnArrayRoot() {
+        assertTrue(JSONPath.contains("[1,2,3]", "$[1]"));
+        assertFalse(JSONPath.contains("[1,2,3]", "$[5]"));
+        assertFalse(JSONPath.contains("[null]", "$.status"));
+        assertFalse(JSONPath.contains("[null,{\"status\":1}]", "$.status"));
+        assertTrue(JSONPath.contains("[{\"status\":1},null]", "$.status"));
+    }
+
+    @Test
+    public void containsOnRefCycleDoesNotOverflow() {
+        assertTrue(JSONPath.contains("{\"a\":{\"$ref\":\"$\"}}", "$..a"));
+        assertTrue(JSONPath.contains("{\"x\":{\"y\":{\"$ref\":\"$\"}}}", "$..x"));
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
@@ -1,12 +1,14 @@
 package com.alibaba.fastjson2.issues_7000;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.fastjson2.JSONPath;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Issue7771 {
@@ -48,6 +50,7 @@ public class Issue7771 {
         assertTrue(JSONPath.contains("123", "$"));
         assertTrue(JSONPath.contains("[1,2]", "$"));
         assertEquals(JSON.parse("{\"status\":200}"), JSONPath.eval("{\"status\":200}", "$"));
+        assertTrue(JSONPath.contains(JSON.parse("{\"a\":1}"), "$"));
     }
 
     @Test
@@ -57,6 +60,33 @@ public class Issue7771 {
         assertFalse(JSONPath.contains("[null]", "$.status"));
         assertFalse(JSONPath.contains("[null,{\"status\":1}]", "$.status"));
         assertTrue(JSONPath.contains("[{\"status\":1},null]", "$.status"));
+        assertTrue(JSONPath.contains("[null]", "$[0]"));
+        assertTrue(JSONPath.contains("{\"a\":[null]}", "$.a[0]"));
+        assertTrue(JSONPath.contains("[[]]", "$[0]"));
+    }
+
+    @Test
+    public void containsTreatsPresentNullAsPresent() {
+        assertTrue(JSONPath.contains("{\"a\":[{\"status\":null}]}", "$.a.status"));
+        assertTrue(JSONPath.contains("{\"a\":{\"status\":null}}", "$.a.status"));
+        assertTrue(JSONPath.contains("[{\"status\":null}]", "$.status"));
+        assertTrue(JSONPath.contains("{\"a\":[{\"status\":null}]}", "$.a[0].status"));
+    }
+
+    @Test
+    public void containsOnEmptyMatchSetIsFalse() {
+        assertFalse(JSONPath.contains("{}", "$.*"));
+        assertFalse(JSONPath.contains("{}", "$..a"));
+        assertFalse(JSONPath.contains("[1,2]", "$[5,6]"));
+        assertFalse(JSONPath.contains("[1,2]", "$[?(@>9)]"));
+        assertFalse(JSONPath.contains("[1,2]", "$[5:6]"));
+        assertFalse(JSONPath.contains("[1,2]", "$[0:0]"));
+        assertFalse(JSONPath.contains("{}", "$['x','y']"));
+    }
+
+    @Test
+    public void containsOnMalformedJsonThrows() {
+        assertThrows(JSONException.class, () -> JSONPath.contains("{invalid json", "$.status"));
     }
 
     @Test

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7771.java
@@ -1,0 +1,36 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONPath;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Issue7771 {
+    @Test
+    public void containsOnJsonStringMatchesEval() {
+        String json = "{\"status\": 200}";
+
+        assertEquals(200, JSONPath.eval(json, "$.status"));
+        assertTrue(JSONPath.contains(json, "$.status"));
+        assertFalse(JSONPath.contains(json, "$.missing"));
+    }
+
+    @Test
+    public void containsOnJsonStringNullValueStillPresent() {
+        String json = "{\"status\": null}";
+
+        assertTrue(JSONPath.contains(json, "$.status"));
+        assertFalse(JSONPath.contains(json, "$.missing"));
+    }
+
+    @Test
+    public void containsOnParsedObjectUnchanged() {
+        JSONObject object = JSON.parseObject("{\"status\": 200}");
+        assertTrue(JSONPath.contains(object, "$.status"));
+        assertFalse(JSONPath.contains(object, "$.missing"));
+    }
+}


### PR DESCRIPTION
## Summary

`JSONPath.eval(String, String)` treats the first argument as JSON text (via `extract`), but `JSONPath.contains` only had an `Object` overload. Passing a JSON string therefore resolved to bean-style `contains` and returned `false` for ordinary paths such as `$.status` even when `eval` returned the value.

Add `JSONPath.contains(String, String)` that parses the text and delegates to the existing object path, so path presence matches `eval`/`extract` and null-valued keys still count as present.

Fixes #7771

<details>
<summary>中文说明</summary>

`JSONPath.eval(String, String)` 会把第一个参数当作 JSON 文本解析，而 `contains` 原先只有 `Object` 重载。传入 JSON 字符串时会走 Java bean 路径，导致 `$.status` 这类路径返回 `false`，与 `eval` 不一致。

新增 `JSONPath.contains(String, String)`：先 `JSON.parse`，再委托现有对象路径判断，与 `eval`/`extract` 语义对齐，且 `null` 值字段仍视为路径存在。

</details>

## Test plan

- [x] `mvn -pl core -Dtest=Issue7771,Issue643 test` — 6/6 GREEN (RED→GREEN on Issue7771)
- [x] `mvn -pl core -Dtest='com.alibaba.fastjson2.jsonpath.**,com.alibaba.fastjson2.issues.Issue643,com.alibaba.fastjson2.issues_7000.Issue7771' test` — 403/403 GREEN
- [x] `mvn -pl core validate` GREEN