### PR TITLE
fix: numeric fields with @JsonFormat(shape=STRING) produced invalid JSON (#7734)

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/BeanUtils.java
@@ -2911,6 +2911,44 @@ public abstract class BeanUtils {
     }
 
     public static void processJacksonJsonFormat(FieldInfo fieldInfo, Annotation annotation) {
+        processJacksonJsonFormat(fieldInfo, annotation, null);
+    }
+
+    /**
+     * Returns whether the format is one of the sentinel values stored by
+     * {@link #processJacksonJsonFormat}: {@code "string"} for Jackson
+     * shape=STRING and {@code "millis"} for shape=NUMBER. They select a
+     * serialization mode and must never be parsed as a DecimalFormat pattern.
+     */
+    public static boolean isSentinelFormat(String format) {
+        return "string".equals(format) || "millis".equals(format);
+    }
+
+    /**
+     * Returns whether a field of this type is a numeric scalar: the "millis"
+     * sentinel selects the date epoch-millis mode and is meaningless for it.
+     */
+    public static boolean isNumericType(Class<?> fieldClass) {
+        return fieldClass != null && (
+                fieldClass.isPrimitive()
+                        ? fieldClass != boolean.class && fieldClass != char.class && fieldClass != void.class
+                        : Number.class.isAssignableFrom(fieldClass));
+    }
+
+    /**
+     * Returns the bean-level format inherited by a field: the "millis" sentinel
+     * (set for class-level Jackson shape=NUMBER, or explicitly) selects the
+     * date epoch-millis mode and is not inherited by numeric fields, where
+     * pattern consumers emit it verbatim.
+     */
+    public static String inheritBeanFormat(String beanFormat, Class<?> fieldClass) {
+        if ("millis".equals(beanFormat) && isNumericType(fieldClass)) {
+            return null;
+        }
+        return beanFormat;
+    }
+
+    public static void processJacksonJsonFormat(FieldInfo fieldInfo, Annotation annotation, Class<?> fieldClass) {
         Class<? extends Annotation> annotationClass = annotation.getClass();
         final String[] jsonFormatValues = new String[3]; // 0:pattern; 1:shape; 2:locale
         BeanUtils.annotationMethods(annotationClass, m -> {
@@ -2945,7 +2983,12 @@ public abstract class BeanUtils {
         if ("STRING".equals(jsonFormatValues[1]) && fieldInfo.format == null) {
             fieldInfo.format = "string";
         } else if ("NUMBER".equals(jsonFormatValues[1])) {
-            fieldInfo.format = "millis";
+            // "millis" selects the date epoch-millis mode; on a numeric field it
+            // is meaningless and pattern consumers emit it verbatim (e.g.
+            // String.format("millis", value) in JSONWriter.writeInt32)
+            if (!isNumericType(fieldClass)) {
+                fieldInfo.format = "millis";
+            }
         }
 
         if (!jsonFormatValues[2].isEmpty() && !"##default".equals(jsonFormatValues[2])) {

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
@@ -87,6 +87,16 @@ public abstract class FieldWriter<T>
         this(name, ordinal, features, format, locale, label, fieldType, fieldClass, field, method, null);
     }
 
+    /**
+     * Returns whether the format is one of the sentinel values stored by
+     * {@link BeanUtils#processJacksonJsonFormat}: {@code "string"} for Jackson
+     * shape=STRING and {@code "millis"} for shape=NUMBER. They select a
+     * serialization mode and must never be parsed as a DecimalFormat pattern.
+     */
+    static boolean isSentinelFormat(String format) {
+        return BeanUtils.isSentinelFormat(format);
+    }
+
     FieldWriter(
             String name,
             int ordinal,
@@ -122,6 +132,7 @@ public abstract class FieldWriter<T>
 
         DecimalFormat decimalFormat = null;
         if (format != null
+                && !isSentinelFormat(format)
                 && (fieldClass == float.class
                 || fieldClass == float[].class
                 || fieldClass == Float.class
@@ -1048,7 +1059,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal.class == valueClass) {
-                if (format == null || format.isEmpty()) {
+                if (format == null || format.isEmpty() || isSentinelFormat(format)) {
                     return ObjectWriterImplBigDecimal.INSTANCE;
                 } else {
                     return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);
@@ -1056,7 +1067,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal[].class == valueClass) {
-                if (format == null || format.isEmpty()) {
+                if (format == null || format.isEmpty() || isSentinelFormat(format)) {
                     return new ObjectWriterArrayFinal(BigDecimal.class, null);
                 } else {
                     return new ObjectWriterArrayFinal(BigDecimal.class, new DecimalFormat(format));

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterDouble.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterDouble.java
@@ -50,7 +50,12 @@ class FieldWriterDouble<T>
             if (decimalFormat != null) {
                 jsonWriter.writeDouble(doubleValue, decimalFormat);
             } else {
-                jsonWriter.writeDouble(doubleValue);
+                long features = this.features | jsonWriter.getFeatures();
+                if ((features & Feature.WriteNonStringValueAsString.mask) != 0) {
+                    jsonWriter.writeString(doubleValue);
+                } else {
+                    jsonWriter.writeDouble(doubleValue);
+                }
             }
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterFloat.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriterFloat.java
@@ -50,7 +50,12 @@ class FieldWriterFloat<T>
             if (decimalFormat != null) {
                 jsonWriter.writeFloat(floatValue, decimalFormat);
             } else {
-                jsonWriter.writeFloat(floatValue);
+                long features = this.features | jsonWriter.getFeatures();
+                if ((features & Feature.WriteNonStringValueAsString.mask) != 0) {
+                    jsonWriter.writeString(floatValue);
+                } else {
+                    jsonWriter.writeFloat(floatValue);
+                }
             }
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -376,7 +376,7 @@ public class ObjectWriterBaseModule
                         break;
                     case "com.fasterxml.jackson.annotation.JsonFormat":
                         if (useJacksonAnnotation) {
-                            processJacksonJsonFormat(fieldInfo, annotation);
+                            processJacksonJsonFormat(fieldInfo, annotation, field.getType());
                         }
                         break;
                     case "com.fasterxml.jackson.annotation.JsonInclude":
@@ -838,7 +838,7 @@ public class ObjectWriterBaseModule
 
             fieldInfo.isPrivate = false;
             Annotation[] annotations = getAnnotations(method);
-            processAnnotations(fieldInfo, annotations);
+            processAnnotations(fieldInfo, annotations, method.getReturnType());
 
             if (!objectClass.getName().startsWith("java.lang") && !BeanUtils.isRecord(objectClass)) {
                 Field methodField = getField(objectClass, method);
@@ -859,7 +859,7 @@ public class ObjectWriterBaseModule
                                 = beanInfo.creatorConstructor.getParameterAnnotations();
                         if (i < creatorConsParamAnnotations.length) {
                             Annotation[] parameterAnnotations = creatorConsParamAnnotations[i];
-                            processAnnotations(fieldInfo, parameterAnnotations);
+                            processAnnotations(fieldInfo, parameterAnnotations, beanInfo.creatorConstructor.getParameterTypes()[i]);
                             break;
                         }
                     }
@@ -867,7 +867,7 @@ public class ObjectWriterBaseModule
             }
         }
 
-        private void processAnnotations(FieldInfo fieldInfo, Annotation[] annotations) {
+        private void processAnnotations(FieldInfo fieldInfo, Annotation[] annotations, Class<?> fieldClass) {
             for (Annotation annotation : annotations) {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
                 JSONField jsonField = findAnnotation(annotation, JSONField.class);
@@ -913,7 +913,7 @@ public class ObjectWriterBaseModule
                     }
                     case "com.fasterxml.jackson.annotation.JsonFormat":
                         if (useJacksonAnnotation) {
-                            processJacksonJsonFormat(fieldInfo, annotation);
+                            processJacksonJsonFormat(fieldInfo, annotation, fieldClass);
                         }
                         break;
                     case "com.fasterxml.jackson.annotation.JsonValue":

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreator.java
@@ -341,7 +341,7 @@ public class ObjectWriterCreator {
 
         String format = fieldInfo.format;
         if (format == null && beanInfo.format != null) {
-            format = beanInfo.format;
+            format = BeanUtils.inheritBeanFormat(beanInfo.format, field.getType());
         }
 
         return createFieldWriter(
@@ -509,7 +509,7 @@ public class ObjectWriterCreator {
                 BeanUtils.getters(objectClass, mixIn, beanInfo.kotlin, method -> {
                     fieldInfo.init();
                     fieldInfo.features = writerFieldFeatures;
-                    fieldInfo.format = beanInfo.format;
+                    fieldInfo.format = BeanUtils.inheritBeanFormat(beanInfo.format, method.getReturnType());
                     provider.getFieldInfo(beanInfo, fieldInfo, objectClass, method);
                     if (fieldInfo.ignore) {
                         return;

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterCreatorASM.java
@@ -244,7 +244,7 @@ public class ObjectWriterCreatorASM
                 BeanUtils.getters(objectClass, mixIn, beanInfo.kotlin, method -> {
                     fieldInfo.init();
                     fieldInfo.features |= writerFieldFeatures;
-                    fieldInfo.format = beanInfo.format;
+                    fieldInfo.format = BeanUtils.inheritBeanFormat(beanInfo.format, method.getReturnType());
 
                     provider.getFieldInfo(beanInfo, fieldInfo, objectClass, method);
                     if (fieldInfo.ignore) {
@@ -1479,6 +1479,62 @@ public class ObjectWriterCreatorASM
         final int BYTES = mwc.var("bytes");
         final int FEATURES = mwc.var2(CONTEXT_FEATURES);
 
+        /*
+         * WriteNonStringValueAsString set at writer level is not visible when this
+         * method is generated (only bean and field features are); delegate to the
+         * reflective loop, which writes each field with the merged features
+         *
+         * if ((jsonWriter.getFeatures() & WriteNonStringValueAsString.mask) != 0) {
+         *     super.writeArrayMappingJSONB(jsonWriter, object, fieldName, fieldType, features);
+         *     return;
+         * }
+         *
+         * Field-level WriteNonStringValueAsString (set for Jackson shape=STRING in
+         * the FieldWriter constructor) is visible here; the direct-write path below
+         * drops per-field features, so when any field carries it the whole method
+         * is the delegate
+         */
+        boolean fieldWriteAsString = false;
+        for (FieldWriter fieldWriter : fieldWriters) {
+            if ((fieldWriter.features & WriteNonStringValueAsString.mask) != 0) {
+                fieldWriteAsString = true;
+                break;
+            }
+        }
+
+        if (fieldWriteAsString) {
+            mw.aload(THIS);
+            mw.aload(JSON_WRITER);
+            mw.aload(OBJECT);
+            mw.aload(FIELD_NAME);
+            mw.aload(FIELD_TYPE);
+            mw.lload(FIELD_FEATURES);
+            mw.invokespecial(TYPE_OBJECT_WRITER_ADAPTER, "writeArrayMappingJSONB", METHOD_DESC_WRITE);
+            mw.return_();
+            mw.visitMaxs(mwc.maxVariant + 1, mwc.maxVariant + 1);
+            return;
+        }
+
+        Label skipSuper_ = new Label();
+        mw.aload(JSON_WRITER);
+        mw.invokevirtual(TYPE_JSON_WRITER, "getFeatures", "()J");
+        mw.visitLdcInsn(WriteNonStringValueAsString.mask);
+        mw.land();
+        mw.lconst_0();
+        mw.lcmp();
+        mw.ifeq(skipSuper_);
+
+        mw.aload(THIS);
+        mw.aload(JSON_WRITER);
+        mw.aload(OBJECT);
+        mw.aload(FIELD_NAME);
+        mw.aload(FIELD_TYPE);
+        mw.lload(FIELD_FEATURES);
+        mw.invokespecial(TYPE_OBJECT_WRITER_ADAPTER, "writeArrayMappingJSONB", METHOD_DESC_WRITE);
+        mw.return_();
+
+        mw.visitLabel(skipSuper_);
+
         if ((features & FieldInfo.DISABLE_AUTO_TYPE) == 0) {
             Label notWriteType = new Label();
             isWriteTypeInfo(objectFeatures, mw, OBJECT, FIELD_TYPE, FIELD_FEATURES, notWriteType);
@@ -2229,13 +2285,14 @@ public class ObjectWriterCreatorASM
                     mw.invokevirtual(TYPE_JSON_WRITER, "writeDecimal", "(Ljava/math/BigDecimal;JLjava/text/DecimalFormat;)V");
                 }
             } else {
+                boolean writeAsString = (fieldWriter.features & WriteNonStringValueAsString.mask) != 0;
                 mw.aload(FIELD_VALUE);
                 if (fieldClass == Double.class) {
                     mw.invokevirtual("java/lang/Double", "doubleValue", "()D");
-                    mw.invokevirtual(TYPE_JSON_WRITER, "writeDouble", "(D)V");
+                    mw.invokevirtual(TYPE_JSON_WRITER, writeAsString ? "writeString" : "writeDouble", "(D)V");
                 } else if (fieldClass == Float.class) {
                     mw.invokevirtual("java/lang/Float", "floatValue", "()F");
-                    mw.invokevirtual(TYPE_JSON_WRITER, "writeFloat", "(F)V");
+                    mw.invokevirtual(TYPE_JSON_WRITER, writeAsString ? "writeString" : "writeFloat", "(F)V");
                 } else {
                     long features = fieldWriter.features;
                     mw.visitLdcInsn(features);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -459,15 +459,30 @@ public class ObjectWriterProvider
      * @return the ObjectWriter for the specified type
      */
     public ObjectWriter getObjectWriter(Type objectType, String format, Locale locale) {
+        // "string" (Jackson shape=STRING) and "millis" (shape=NUMBER) are sentinel
+        // formats from BeanUtils.processJacksonJsonFormat, not DecimalFormat
+        // patterns; quoting for "string" is driven by WriteNonStringValueAsString
+        // which callers merge into the item features
+        boolean sentinelFormat = FieldWriter.isSentinelFormat(format);
+
         if (objectType == Double.class) {
+            if (sentinelFormat) {
+                return ObjectWriterImplDouble.INSTANCE;
+            }
             return new ObjectWriterImplDouble(new DecimalFormat(format));
         }
 
         if (objectType == Float.class) {
+            if (sentinelFormat) {
+                return ObjectWriterImplFloat.INSTANCE;
+            }
             return new ObjectWriterImplFloat(new DecimalFormat(format));
         }
 
         if (objectType == BigDecimal.class) {
+            if (sentinelFormat) {
+                return ObjectWriterImplBigDecimal.INSTANCE;
+            }
             return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7700/Issue7734.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7700/Issue7734.java
@@ -1,0 +1,596 @@
+package com.alibaba.fastjson2.issues_7700;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TestUtils;
+import com.alibaba.fastjson2.writer.ObjectWriter;
+import com.alibaba.fastjson2.writer.ObjectWriterCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression for #7734: a {@code BigDecimal} field annotated with Jackson's
+ * {@code @JsonFormat(shape = STRING)} produced invalid JSON such as
+ * {@code {"amount":string200}} instead of {@code {"amount":"200"}}.
+ *
+ * <p>Root cause: the {@code "string"} sentinel (set for shape=STRING) was fed
+ * to {@code new DecimalFormat(...)} as a pattern, so {@code writeDecimal} took
+ * the formatted-string branch and emitted the raw pattern text unquoted. The
+ * fix keeps {@code WriteNonStringValueAsString} (set for shape=STRING) in charge
+ * and never builds a {@code DecimalFormat} from a sentinel, in every place a
+ * {@code DecimalFormat} is constructed from a field format: the
+ * {@code FieldWriter} constructor, the static {@code FieldWriter.getObjectWriter}
+ * and {@code ObjectWriterProvider.getObjectWriter} (reached for collection
+ * items via {@code FieldWriterList.getItemWriter}).
+ *
+ * <p>For shape=NUMBER the sibling sentinel {@code "millis"} is assigned only to
+ * non-numeric fields (it selects the date epoch-millis mode), the DecimalFormat
+ * sites exclude it the same way as {@code "string"}, and the bean-level format
+ * is not inherited by numeric fields ({@code BeanUtils.inheritBeanFormat}), so
+ * shape=NUMBER on a numeric field, declared or inherited from a class-level
+ * annotation, serializes as a plain number instead of pattern text such as
+ * {@code millis200} or {@code "millis"}.
+ *
+ * <p>Covers the directly-declared {@code BigDecimal} case plus the sibling
+ * paths that share the same sentinel handling: collection items, polymorphic
+ * {@code Object} and {@code Number} fields whose runtime value is a
+ * {@code BigDecimal} or {@code BigDecimal[]} (runtime {@code getObjectWriter}),
+ * and the {@code float}/{@code double} BeanToArray paths (reflective
+ * {@code writeValue} and ASM array mapping), which previously ignored
+ * {@code WriteNonStringValueAsString}.
+ */
+@Tag("regression")
+public class Issue7734 {
+    public static class Bean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public BigDecimal amount;
+    }
+
+    @Test
+    public void bigDecimalStringShapeSerializesAsQuotedString() {
+        Bean bean = new Bean();
+        bean.amount = new BigDecimal("6.56000000001");
+        String json = JSON.toJSONString(bean);
+        // must be valid JSON with the value quoted as a string
+        assertEquals("{\"amount\":\"6.56000000001\"}", json);
+        Bean parsed = JSON.parseObject(json, Bean.class);
+        assertEquals(new BigDecimal("6.56000000001"), parsed.amount);
+    }
+
+    @Test
+    public void bigDecimalStringShapeNullRoundTripsWithoutCorruption() {
+        Bean bean = new Bean();
+        // amount is null; a null BigDecimal must round-trip cleanly
+        String json = JSON.toJSONString(bean);
+        Bean parsed = JSON.parseObject(json, Bean.class);
+        assertNull(parsed.amount);
+    }
+
+    public static class PatternBean {
+        // a real DecimalFormat pattern (no shape=STRING) must still be applied,
+        // proving the fix only skips the "string" sentinel, not genuine patterns
+        @JsonFormat(pattern = "0.00")
+        public BigDecimal amount;
+    }
+
+    @Test
+    public void realDecimalFormatPatternStillApplied() {
+        PatternBean bean = new PatternBean();
+        bean.amount = new BigDecimal("7");
+        String json = JSON.toJSONString(bean);
+        // exact match: a plain substring check would also pass for the wrong value
+        assertEquals("{\"amount\":7.00}", json);
+    }
+
+    // shape=STRING on a polymorphic Object field whose runtime value is BigDecimal
+    public static class PolyObjectBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Object amount;
+    }
+
+    @Test
+    public void polymorphicObjectBigDecimalShapeString() {
+        PolyObjectBean bean = new PolyObjectBean();
+        bean.amount = new BigDecimal("200");
+        assertEquals("{\"amount\":\"200\"}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void polymorphicObjectBigDecimalArrayShapeString() {
+        PolyObjectBean bean = new PolyObjectBean();
+        bean.amount = new BigDecimal[]{new BigDecimal("1.23"), new BigDecimal("4.56")};
+        assertEquals("{\"amount\":[\"1.23\",\"4.56\"]}", JSON.toJSONString(bean));
+    }
+
+    // shape=NUMBER on a polymorphic Object field whose runtime value is BigDecimal
+    public static class PolyNumberShapeBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Object amount;
+    }
+
+    @Test
+    public void polymorphicObjectBigDecimalShapeNumber() {
+        PolyNumberShapeBean bean = new PolyNumberShapeBean();
+        bean.amount = new BigDecimal("200");
+        assertEquals("{\"amount\":200}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void polymorphicObjectBigDecimalArrayShapeNumber() {
+        // exercises the "millis" clause of the BigDecimal[] branch in the
+        // runtime getObjectWriter, previously only tested for scalars
+        PolyNumberShapeBean bean = new PolyNumberShapeBean();
+        bean.amount = new BigDecimal[]{new BigDecimal("200")};
+        assertEquals("{\"amount\":[200]}", JSON.toJSONString(bean));
+    }
+
+    // shape=STRING on a polymorphic Number field whose runtime value is BigDecimal
+    public static class PolyNumberBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Number amount;
+    }
+
+    @Test
+    public void polymorphicNumberBigDecimalShapeString() {
+        PolyNumberBean bean = new PolyNumberBean();
+        bean.amount = new BigDecimal("200");
+        assertEquals("{\"amount\":\"200\"}", JSON.toJSONString(bean));
+    }
+
+    // shape=STRING on collection fields: the sentinel reaches
+    // ObjectWriterProvider.getObjectWriter via FieldWriterList.getItemWriter
+    public static class ListBigDecimalBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public List<BigDecimal> amounts;
+    }
+
+    public static class ListDoubleBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public List<Double> values;
+    }
+
+    public static class ListFloatBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public List<Float> values;
+    }
+
+    @Test
+    public void listBigDecimalShapeStringQuoted() {
+        ListBigDecimalBean bean = new ListBigDecimalBean();
+        bean.amounts = Arrays.asList(new BigDecimal("200"), new BigDecimal("7"));
+        assertEquals("{\"amounts\":[\"200\",\"7\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void listDoubleShapeStringQuoted() {
+        ListDoubleBean bean = new ListDoubleBean();
+        bean.values = Arrays.asList(2.0D, 2.0D);
+        assertEquals("{\"values\":[\"2.0\",\"2.0\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void listFloatShapeStringQuoted() {
+        ListFloatBean bean = new ListFloatBean();
+        bean.values = Arrays.asList(2.0F, 2.0F);
+        assertEquals("{\"values\":[\"2.0\",\"2.0\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void listBigDecimalShapeStringJsonbRoundTrip() {
+        ListBigDecimalBean bean = new ListBigDecimalBean();
+        bean.amounts = Arrays.asList(new BigDecimal("200"), new BigDecimal("7"));
+        byte[] jsonb = JSONB.toBytes(bean);
+        ListBigDecimalBean parsed = JSONB.parseObject(jsonb, ListBigDecimalBean.class);
+        assertEquals(bean.amounts, parsed.amounts);
+    }
+
+    // shape=NUMBER on numeric fields: the "millis" sentinel must not reach
+    // new DecimalFormat either, the values serialize as plain numbers
+    public static class NumberShapeBigDecimalBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public BigDecimal amount;
+    }
+
+    public static class NumberShapeDoubleBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Double value;
+    }
+
+    public static class NumberShapeFloatBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Float value;
+    }
+
+    public static class NumberShapeListBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public List<BigDecimal> amounts;
+    }
+
+    @Test
+    public void numberShapeBigDecimalPlain() {
+        NumberShapeBigDecimalBean bean = new NumberShapeBigDecimalBean();
+        bean.amount = new BigDecimal("200");
+        assertEquals("{\"amount\":200}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void numberShapeDoublePlain() {
+        NumberShapeDoubleBean bean = new NumberShapeDoubleBean();
+        bean.value = 2.0D;
+        assertEquals("{\"value\":2.0}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void numberShapeFloatPlain() {
+        NumberShapeFloatBean bean = new NumberShapeFloatBean();
+        bean.value = 2.0F;
+        assertEquals("{\"value\":2.0}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void numberShapeListPlain() {
+        NumberShapeListBean bean = new NumberShapeListBean();
+        bean.amounts = Arrays.asList(new BigDecimal("200"), new BigDecimal("7"));
+        assertEquals("{\"amounts\":[200,7]}", JSON.toJSONString(bean));
+    }
+
+    public static class IntShapeNumberBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public int value = 5;
+    }
+
+    @Test
+    public void intShapeNumberPlain() {
+        // FieldWriterInt32 passes the format to writeInt32(int, String), where
+        // String.format("millis", value) silently emits the sentinel text
+        assertEquals("{\"value\":5}", JSON.toJSONString(new IntShapeNumberBean()));
+    }
+
+    public static class DateShapeNumberBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Date date = new Date(1690000000000L);
+    }
+
+    @Test
+    public void dateShapeNumberEpochMillis() {
+        // the "millis" sentinel is semantic for date fields: epoch millis as number
+        assertEquals("{\"date\":1690000000000}", JSON.toJSONString(new DateShapeNumberBean()));
+    }
+
+    public static class GetterShapeNumberBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public int getValue() {
+            return 5;
+        }
+    }
+
+    @Test
+    public void getterShapeNumberPlain() {
+        // annotation on the accessor is processed through the method call site
+        // of the type-aware producer
+        assertEquals("{\"value\":5}", JSON.toJSONString(new GetterShapeNumberBean()));
+    }
+
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    public static class ClassLevelShapeNumberBean {
+        public int f = 5;
+        public long l = 200L;
+        public Date date = new Date(1690000000000L);
+    }
+
+    @Test
+    public void classLevelShapeNumberPlain() {
+        // class-level shape=NUMBER is inherited as the "millis" sentinel, which
+        // must not reach the numeric fields (int previously emitted "millis")
+        // while the Date field keeps the epoch-millis mode; reading is unchanged
+        String json = "{\"date\":1690000000000,\"f\":5,\"l\":200}";
+        assertEquals(json, JSON.toJSONString(new ClassLevelShapeNumberBean()));
+        ClassLevelShapeNumberBean parsed = JSON.parseObject(json, ClassLevelShapeNumberBean.class);
+        assertEquals(5, parsed.f);
+        assertEquals(200L, parsed.l);
+        assertEquals(new Date(1690000000000L), parsed.date);
+    }
+
+    public static class LongShapeNumberBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public long value = 1690000000000L;
+    }
+
+    @Test
+    public void longShapeNumberPlainAndJsonb() {
+        // text is unchanged; in JSONB the field is an int64 (a plain long field
+        // never had date semantics), and the encoding round-trips
+        assertEquals("{\"value\":1690000000000}", JSON.toJSONString(new LongShapeNumberBean()));
+        byte[] jsonb = JSONB.toBytes(new LongShapeNumberBean());
+        assertArrayEquals(new byte[]{-90, 78, 118, 97, 108, 117, 101, -66, 0, 0, 1, -119, 123, -39, -124, 0, -91}, jsonb);
+        assertEquals(1690000000000L, JSONB.parseObject(jsonb, LongShapeNumberBean.class).value);
+    }
+
+    public static class FloatBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Float value;
+    }
+
+    @Test
+    public void floatScalarShapeStringQuoted() {
+        FloatBean bean = new FloatBean();
+        bean.value = 1.5F;
+        assertEquals("{\"value\":\"1.5\"}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void floatBeanToArrayShapeStringQuoted() {
+        // BeanToArray uses writeValue / ASM array mapping, which previously
+        // ignored WriteNonStringValueAsString; exercise both creators.
+        for (ObjectWriterCreator creator : TestUtils.writerCreators()) {
+            FloatBean bean = new FloatBean();
+            bean.value = 1.5F;
+            ObjectWriter<FloatBean> writer = creator.createObjectWriter(FloatBean.class);
+            JSONWriter w = JSONWriter.of(JSONWriter.Feature.BeanToArray);
+            writer.write(w, bean, null, null, 0);
+            assertEquals("[\"1.5\"]", w.toString(),
+                    "Float shape=STRING BeanToArray via " + creator.getClass().getSimpleName());
+        }
+    }
+
+    @Test
+    public void floatShapeStringJsonbRoundTrip() {
+        FloatBean bean = new FloatBean();
+        bean.value = 1.5F;
+        byte[] jsonb = JSONB.toBytes(bean);
+        FloatBean parsed = JSONB.parseObject(jsonb, FloatBean.class);
+        assertEquals(1.5F, parsed.value);
+    }
+
+    public static class DoubleBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Double value;
+    }
+
+    @Test
+    public void doubleScalarShapeStringQuoted() {
+        DoubleBean bean = new DoubleBean();
+        bean.value = 1.5;
+        assertEquals("{\"value\":\"1.5\"}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void doubleBeanToArrayShapeStringQuoted() {
+        for (ObjectWriterCreator creator : TestUtils.writerCreators()) {
+            DoubleBean bean = new DoubleBean();
+            bean.value = 1.5;
+            ObjectWriter<DoubleBean> writer = creator.createObjectWriter(DoubleBean.class);
+            JSONWriter w = JSONWriter.of(JSONWriter.Feature.BeanToArray);
+            writer.write(w, bean, null, null, 0);
+            assertEquals("[\"1.5\"]", w.toString(),
+                    "Double shape=STRING BeanToArray via " + creator.getClass().getSimpleName());
+        }
+    }
+
+    public static class PrimitiveFloatBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public float value;
+    }
+
+    @Test
+    public void primitiveFloatBeanToArrayShapeStringQuoted() {
+        for (ObjectWriterCreator creator : TestUtils.writerCreators()) {
+            PrimitiveFloatBean bean = new PrimitiveFloatBean();
+            bean.value = 1.5F;
+            ObjectWriter<PrimitiveFloatBean> writer = creator.createObjectWriter(PrimitiveFloatBean.class);
+            JSONWriter w = JSONWriter.of(JSONWriter.Feature.BeanToArray);
+            writer.write(w, bean, null, null, 0);
+            assertEquals("[\"1.5\"]", w.toString(),
+                    "float shape=STRING BeanToArray via " + creator.getClass().getSimpleName());
+        }
+    }
+
+    // primitive double and boxed-array fields lock the sentinel guard in the
+    // FieldWriter constructor: without it a sentinel reaches new DecimalFormat
+    // and the raw pattern text is emitted unquoted
+    public static class PrimitiveDoubleBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public double value;
+    }
+
+    public static class NumberShapePrimitiveDoubleBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public double value;
+    }
+
+    @Test
+    public void primitiveDoubleShapeStringQuoted() {
+        PrimitiveDoubleBean bean = new PrimitiveDoubleBean();
+        bean.value = 1.5;
+        assertEquals("{\"value\":\"1.5\"}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void primitiveDoubleShapeNumberPlain() {
+        NumberShapePrimitiveDoubleBean bean = new NumberShapePrimitiveDoubleBean();
+        bean.value = 1.5;
+        assertEquals("{\"value\":1.5}", JSON.toJSONString(bean));
+    }
+
+    public static class DoubleArrayBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Double[] values;
+    }
+
+    public static class NumberShapeDoubleArrayBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Double[] values;
+    }
+
+    @Test
+    public void boxedDoubleArrayShapeStringQuoted() {
+        DoubleArrayBean bean = new DoubleArrayBean();
+        bean.values = new Double[]{1.5, 2.0};
+        assertEquals("{\"values\":[\"1.5\",\"2.0\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void boxedDoubleArrayShapeNumberPlain() {
+        NumberShapeDoubleArrayBean bean = new NumberShapeDoubleArrayBean();
+        bean.values = new Double[]{1.5, 2.0};
+        assertEquals("{\"values\":[1.5,2.0]}", JSON.toJSONString(bean));
+    }
+
+    public static class FloatArrayBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Float[] values;
+    }
+
+    public static class NumberShapeFloatArrayBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public Float[] values;
+    }
+
+    @Test
+    public void boxedFloatArrayShapeStringQuoted() {
+        FloatArrayBean bean = new FloatArrayBean();
+        bean.values = new Float[]{1.5F, 2.0F};
+        assertEquals("{\"values\":[\"1.5\",\"2.0\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void boxedFloatArrayShapeNumberPlain() {
+        NumberShapeFloatArrayBean bean = new NumberShapeFloatArrayBean();
+        bean.values = new Float[]{1.5F, 2.0F};
+        assertEquals("{\"values\":[1.5,2.0]}", JSON.toJSONString(bean));
+    }
+
+    public static class BigDecimalArrayBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public BigDecimal[] values;
+    }
+
+    public static class NumberShapeBigDecimalArrayBean {
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+        public BigDecimal[] values;
+    }
+
+    @Test
+    public void boxedBigDecimalArrayShapeStringQuoted() {
+        BigDecimalArrayBean bean = new BigDecimalArrayBean();
+        bean.values = new BigDecimal[]{new BigDecimal("1.23"), new BigDecimal("4.56")};
+        assertEquals("{\"values\":[\"1.23\",\"4.56\"]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void boxedBigDecimalArrayShapeNumberPlain() {
+        NumberShapeBigDecimalArrayBean bean = new NumberShapeBigDecimalArrayBean();
+        bean.values = new BigDecimal[]{new BigDecimal("1.23"), new BigDecimal("4.56")};
+        assertEquals("{\"values\":[1.23,4.56]}", JSON.toJSONString(bean));
+    }
+
+    @Test
+    public void bigDecimalShapeStringJsonbRoundTrip() {
+        // JSONB is binary; verify the value survives a round-trip
+        Bean bean = new Bean();
+        bean.amount = new BigDecimal("200");
+        byte[] jsonb = JSONB.toBytes(bean);
+        Bean parsed = JSONB.parseObject(jsonb, Bean.class);
+        assertEquals(new BigDecimal("200"), parsed.amount);
+    }
+
+    public static class PlainDoubleBean {
+        public Double value;
+    }
+
+    @Test
+    public void jsonbBeanToArrayWritersAgreeOnWriteAsStringFeature() {
+        // JSONB + BeanToArray with WriteNonStringValueAsString set at writer level
+        // only: the reflective writeValue and the ASM array mapping must produce
+        // the same encoding (string elements, because the feature is honored)
+        byte[] reflectionBytes = null;
+        byte[] asmBytes = null;
+        for (ObjectWriterCreator creator : TestUtils.writerCreators()) {
+            PlainDoubleBean bean = new PlainDoubleBean();
+            bean.value = 1.5D;
+            ObjectWriter<PlainDoubleBean> writer = creator.createObjectWriter(PlainDoubleBean.class);
+            JSONWriter w = JSONWriter.ofJSONB(
+                    JSONWriter.Feature.BeanToArray,
+                    JSONWriter.Feature.WriteNonStringValueAsString);
+            writer.write(w, bean, null, null, 0);
+            byte[] bytes = w.getBytes();
+            if (reflectionBytes == null) {
+                reflectionBytes = bytes;
+            } else {
+                asmBytes = bytes;
+            }
+        }
+        assertArrayEquals(reflectionBytes, asmBytes, "reflective and ASM creators must agree");
+        // string encoding embeds the ASCII text, binary double does not
+        assertTrue(new String(reflectionBytes, StandardCharsets.ISO_8859_1).contains("1.5"),
+                "expected string element, got " + Arrays.toString(reflectionBytes));
+
+        // without the feature both creators must agree on the binary encoding
+        reflectionBytes = null;
+        asmBytes = null;
+        for (ObjectWriterCreator creator : TestUtils.writerCreators()) {
+            PlainDoubleBean bean = new PlainDoubleBean();
+            bean.value = 1.5D;
+            ObjectWriter<PlainDoubleBean> writer = creator.createObjectWriter(PlainDoubleBean.class);
+            JSONWriter w = JSONWriter.ofJSONB(JSONWriter.Feature.BeanToArray);
+            writer.write(w, bean, null, null, 0);
+            byte[] bytes = w.getBytes();
+            if (reflectionBytes == null) {
+                reflectionBytes = bytes;
+            } else {
+                asmBytes = bytes;
+            }
+        }
+        assertArrayEquals(reflectionBytes, asmBytes, "reflective and ASM creators must agree");
+        assertFalse(new String(reflectionBytes, StandardCharsets.ISO_8859_1).contains("1.5"),
+                "expected binary element, got " + Arrays.toString(reflectionBytes));
+    }
+
+    public static class FieldLevelShapeStringBean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Double amount = 1.5D;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public double prim = 2.5D;
+    }
+
+    @Test
+    public void jsonbBeanToArrayFieldLevelShapeStringWritersAgree() {
+        // Jackson shape=STRING sets WriteNonStringValueAsString at field level,
+        // which the runtime writer-level guard cannot see: with the generated
+        // array mapping the boxed Double was written as a binary double while
+        // the reflective creator wrote a string
+        byte[] reflectionBytes = null;
+        byte[] asmBytes = null;
+        for (ObjectWriterCreator creator : TestUtils.writerCreators()) {
+            FieldLevelShapeStringBean bean = new FieldLevelShapeStringBean();
+            ObjectWriter<FieldLevelShapeStringBean> writer = creator.createObjectWriter(FieldLevelShapeStringBean.class);
+            JSONWriter w = JSONWriter.ofJSONB(JSONWriter.Feature.BeanToArray);
+            writer.write(w, bean, null, null, 0);
+            byte[] bytes = w.getBytes();
+            if (reflectionBytes == null) {
+                reflectionBytes = bytes;
+            } else {
+                asmBytes = bytes;
+            }
+        }
+        assertArrayEquals(reflectionBytes, asmBytes, "reflective and ASM creators must agree");
+        String text = new String(reflectionBytes, StandardCharsets.ISO_8859_1);
+        assertTrue(text.contains("1.5") && text.contains("2.5"),
+                "expected string elements, got " + Arrays.toString(reflectionBytes));
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

### What this PR does / why we need it?

A `BigDecimal` field annotated with Jackson `@JsonFormat(shape = JsonFormat.Shape.STRING)` was serialized as **invalid JSON** like `{"amount":string200}` instead of `{"amount":"200"}`. Closes #7734.

The emitted text (`string200`, no quotes) is not parseable JSON, so any consumer (Jackson, fastjson itself, browsers) fails to read it. Reported as a regression since 2.0.61 / 2.0.63.

Supersedes #7772 (closed after its branch was force-pushed into a state GitHub could no longer reconcile). It carries the same fix, extended to every path the reviews on #7772 and on this PR surfaced.

### Summary of your change

For `shape = STRING`, `BeanUtils` stores the sentinel `fieldInfo.format = "string"` (and the `FieldWriter` constructor sets the `WriteNonStringValueAsString` feature, the intended "write as string" mechanism). For `shape = NUMBER` it stores the sibling sentinel `"millis"` for non-numeric fields only. Either sentinel reaching `new DecimalFormat(...)` (or `String.format`) as a pattern made the numeric writers emit the raw pattern text unquoted (`string200`, `millis200`, `"millis"`).

Changes (each mirrors an existing project pattern):

- `FieldWriter` constructor: skip building a `DecimalFormat` when the format is the `"string"` or `"millis"` sentinel -> `writeDecimal` reaches the existing `writeAsString` logic.
- `FieldWriter.getObjectWriter` BigDecimal / BigDecimal[]: treat the sentinels like a null format -> returns the no-format writer, so polymorphic `Object` / `Number` fields no longer emit pattern text.
- `ObjectWriterProvider.getObjectWriter(Type, String, Locale)` (reached for collection items through `FieldWriterList.getItemWriter`): return the format-less writers for the sentinels, so `List` fields holding `Double` / `Float` / `BigDecimal` serialize quoted instead of emitting `[string200,string7]`.
- `FieldWriterFloat.writeValue` / `FieldWriterDouble.writeValue` (reflection BeanToArray): honor `WriteNonStringValueAsString` through the existing `writeString(float)` / `writeString(double)` overloads, mirroring `writeFloatValue` / `writeDoubleValue`.
- `ObjectWriterCreatorASM.gwObject` (ASM BeanToArray for text writers, the default creator): mirror the existing `gwValue` `writeAsString` pattern (`writeAsString ? "writeString" : "writeDouble"` / `"writeFloat"`).
- `ObjectWriterCreatorASM.genMethodWriteArrayMappingJSONB` (ASM BeanToArray for JSONB): delegate to `ObjectWriterAdapter.writeArrayMappingJSONB` when `WriteNonStringValueAsString` is enabled at writer level at runtime (not visible at class-generation time) or carried by any field's features (visible at generation time; the direct-write path drops per-field features), so the reflective and ASM creators produce the same encoding.
- `BeanUtils.processJacksonJsonFormat`: gained a `fieldClass` parameter (the writer call sites pass the field / method-return / Kotlin creator-parameter type) and assigns `"millis"` for `shape = NUMBER` only to non-numeric fields: it selects the date epoch-millis mode, while on a numeric field it is meaningless and pattern consumers emit it verbatim (`{"f":"millis"}` via `String.format` in `JSONWriter.writeInt32`). The reader call sites keep the type-less overload, so read behavior is unchanged.
- `BeanUtils.inheritBeanFormat`: the bean-level format is no longer inherited by numeric fields at the field, getter and ASM creator copy sites (`fieldInfo.format = beanInfo.format`), so a class-level `@JsonFormat(shape = NUMBER)` no longer emits `{"f":"millis"}` from an `int` field either; `Date` fields keep the epoch-millis mode.
- The sentinel checks live in `BeanUtils` (`isSentinelFormat` / `isNumericType`), with the package-private `FieldWriter.isSentinelFormat` delegating to them; all guard sites share the one predicate.

Genuine `DecimalFormat` patterns (e.g. `@JsonFormat(pattern = "0.00")`) are unaffected. Date fields are unaffected: `"millis"` is still assigned for `shape = NUMBER` on date/time fields (epoch millis) and the `DecimalFormat` guards only apply to float / double / BigDecimal classes. `Integer` / `int` fields with `shape = STRING` were already quoted (separate `toString` flag, no `decimalFormat`); with `shape = NUMBER` an `int` field previously emitted the literal `{"f":"millis"}` (declared or inherited from a class-level annotation) and now serializes a plain number. One observable encoding change is intentional: in plain JSONB a `long` field with `shape = NUMBER` is now an int64 instead of a timestamp value (a plain `long` field never had date semantics); the text encoding is unchanged and both encodings parse back to the same value. The default (no `shape = STRING`) serialization path is unchanged.

Addresses the #7772 review findings (polymorphic `Object` / `Number`, `float` / `double` BeanToArray, broader coverage, exact assertion), this PR review's findings (List items reaching `ObjectWriterProvider`, the sibling `"millis"` sentinel, a `BigDecimal[]` test, real JSONB tests, creator agreement in JSONB BeanToArray), its re-review's suggestions (the shared `isSentinelFormat` predicate, the `writeString(double)` / `writeString(float)` overloads instead of re-implementing them, tests for the primitive `double` and `Double[]` / `Float[]` / `BigDecimal[]` guard shapes and the `BigDecimal[]` `millis` clause), its third review's findings (the field-level `WriteNonStringValueAsString` gap in the JSONB BeanToArray guard, closed by delegating whenever any field carries the feature; the `"millis"` sentinel reaching `writeInt32`'s `String.format` on `int` fields, closed at the producer by assigning `"millis"` only to non-numeric fields), and a self-audit follow-up (the same sentinel still reaching numeric fields through the bean-format inheritance for class-level annotations, closed by `BeanUtils.inheritBeanFormat`).

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

Testing: `Issue7734` (`@Tag("regression")`, 38 cases) covers declared `BigDecimal`, primitive `double` and boxed `Double[]` / `Float[]` / `BigDecimal[]` fields under `shape = STRING` and `shape = NUMBER`, polymorphic `Object` / `Number` holding `BigDecimal` and `BigDecimal[]`, `List` / `List<Double>` / `List<Float>` items, `shape = NUMBER` on scalar (`int`, getter-annotated `int`, class-level annotated `int` / `long` / `Date` epoch millis, `long` with text + JSONB int64 encoding), and collection fields, `float` / `double` BeanToArray via both `TestUtils.writerCreators()` (reflection + ASM), primitive `float` BeanToArray, JSONB round-trips (`JSONB.toBytes` / `JSONB.parseObject`), and cross-creator JSONB BeanToArray encoding agreement with writer-level and field-level (annotated) `WriteNonStringValueAsString`. Verified the reported cases fail before the fix (`{"amount":string200}`, `{"amounts":[string200,string7]}`, `{"amount":millis200}`, `{"value":"millis"}`, the class-level `{"f":"millis"}`, and a 9-vs-14-byte creator divergence in JSONB BeanToArray for annotated `Double` / `double` fields) and pass after. Full `core` suite: 8003 tests, 0 failures.
