### PR TITLE
fix: WriteClassName produces illegal JSON for NaN and Infinity, for issue #7783

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplDouble.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplDouble.java
@@ -62,7 +62,8 @@ final class ObjectWriterImplDouble
         if ((features2 & JSONWriter.Feature.WriteClassName.mask) != 0
                 && (features2 & JSONWriter.Feature.WriteNonStringKeyAsString.mask) == 0
                 && (features2 & JSONWriter.Feature.NotWriteNumberClassName.mask) == 0
-                && fieldType != Double.class && fieldType != double.class) {
+                && fieldType != Double.class && fieldType != double.class
+                && Double.isFinite(value)) {
             jsonWriter.writeRaw('D');
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplFloat.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplFloat.java
@@ -55,7 +55,8 @@ final class ObjectWriterImplFloat
         if ((features2 & JSONWriter.Feature.WriteClassName.mask) != 0
                 && (features2 & JSONWriter.Feature.WriteNonStringKeyAsString.mask) == 0
                 && (features2 & JSONWriter.Feature.NotWriteNumberClassName.mask) == 0
-                && fieldType != Float.class && fieldType != float.class) {
+                && fieldType != Float.class && fieldType != float.class
+                && Float.isFinite(value)) {
             jsonWriter.writeRaw('F');
         }
     }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7783.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7783.java
@@ -1,0 +1,85 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Issue7783 {
+    public static class Bean {
+        public Number value;
+
+        public Bean(Number value) {
+            this.value = value;
+        }
+    }
+
+    @Test
+    public void test_double() {
+        assertEquals("null", JSON.toJSONString(Double.NaN, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Double.POSITIVE_INFINITY, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Double.NEGATIVE_INFINITY, JSONWriter.Feature.WriteClassName));
+
+        assertEquals("null", new String(JSON.toJSONBytes(Double.NaN, JSONWriter.Feature.WriteClassName)));
+        assertEquals("null", new String(JSON.toJSONBytes(Double.POSITIVE_INFINITY, JSONWriter.Feature.WriteClassName)));
+        assertEquals("null", new String(JSON.toJSONBytes(Double.NEGATIVE_INFINITY, JSONWriter.Feature.WriteClassName)));
+    }
+
+    @Test
+    public void test_float() {
+        assertEquals("null", JSON.toJSONString(Float.NaN, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Float.POSITIVE_INFINITY, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Float.NEGATIVE_INFINITY, JSONWriter.Feature.WriteClassName));
+
+        assertEquals("null", new String(JSON.toJSONBytes(Float.NaN, JSONWriter.Feature.WriteClassName)));
+        assertEquals("null", new String(JSON.toJSONBytes(Float.POSITIVE_INFINITY, JSONWriter.Feature.WriteClassName)));
+        assertEquals("null", new String(JSON.toJSONBytes(Float.NEGATIVE_INFINITY, JSONWriter.Feature.WriteClassName)));
+    }
+
+    @Test
+    public void test_field() {
+        String json = JSON.toJSONString(
+                new Bean(Double.NaN),
+                JSONWriter.Feature.NotWriteRootClassName,
+                JSONWriter.Feature.WriteClassName
+        );
+        assertEquals("{\"value\":null}", json);
+        assertEquals(null, JSON.parseObject(json).get("value"));
+
+        assertEquals(
+                "{\"value\":null}",
+                JSON.toJSONString(
+                        new Bean(Float.NEGATIVE_INFINITY),
+                        JSONWriter.Feature.NotWriteRootClassName,
+                        JSONWriter.Feature.WriteClassName
+                )
+        );
+    }
+
+    @Test
+    public void test_specialAsString() {
+        assertEquals(
+                "\"NaN\"",
+                JSON.toJSONString(
+                        Double.NaN,
+                        JSONWriter.Feature.WriteClassName,
+                        JSONWriter.Feature.WriteFloatSpecialAsString
+                )
+        );
+        assertEquals(
+                "\"-Infinity\"",
+                JSON.toJSONString(
+                        Float.NEGATIVE_INFINITY,
+                        JSONWriter.Feature.WriteClassName,
+                        JSONWriter.Feature.WriteFloatSpecialAsString
+                )
+        );
+    }
+
+    @Test
+    public void test_finiteStillWritesSuffix() {
+        assertEquals("1.0D", JSON.toJSONString(1D, JSONWriter.Feature.WriteClassName));
+        assertEquals("1.0F", JSON.toJSONString(1F, JSONWriter.Feature.WriteClassName));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

With `JSONWriter.Feature.WriteClassName` enabled, serializing a non-finite `Double` or `Float` produces output that no JSON parser will accept. `writeDouble` writes `null` for NaN and the infinities, but the type suffix was appended unconditionally afterwards, so the result is `nullD`, or `nullF` for `Float`. Feeding that back into `JSON.parseObject` throws.

The same thing happens with `WriteFloatSpecialAsString` turned on. There the value is written as a quoted `"NaN"` and the suffix lands outside the closing quote, giving `"NaN"D`.

Fixes #7783.

### Summary of your change

`ObjectWriterImplDouble` and `ObjectWriterImplFloat` now check `isFinite` before writing the `D`/`F` suffix. The check sits last in the condition chain, so on the common path where `WriteClassName` is off the feature mask short circuits before it is ever evaluated, and behaviour for finite values is unchanged.

Added `Issue7783`, covering NaN and both infinities across the string and byte writers, a `Number` typed field, the `WriteFloatSpecialAsString` case, and an assertion that finite values still get their suffix.

<details>
<summary>中文</summary>

### 这个 PR 解决了什么问题？

开启 `JSONWriter.Feature.WriteClassName` 之后，序列化非有限的 `Double` 或 `Float` 会得到任何 JSON 解析器都无法接受的输出。`writeDouble` 对 NaN 和正负无穷写出的是 `null`，但后面的类型后缀是无条件追加的，结果就成了 `nullD`（`Float` 则是 `nullF`）。把它再交给 `JSON.parseObject` 会直接抛异常。

打开 `WriteFloatSpecialAsString` 时是同样的问题：值被写成带引号的 `"NaN"`，后缀落在引号外面，变成 `"NaN"D`。

### 改动说明

`ObjectWriterImplDouble` 和 `ObjectWriterImplFloat` 在写 `D`/`F` 后缀前先判断 `isFinite`。这个判断放在条件链的最后，这样在 `WriteClassName` 关闭的常规路径上会先被 feature mask 短路掉，有限值的行为也完全不变。

新增 `Issue7783`，覆盖 NaN、正负无穷、字符串和字节两种 writer、`Number` 类型的字段、`WriteFloatSpecialAsString`，并断言有限值仍然会带上后缀。

</details>

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
