### PR TITLE
fix: avoid D/F suffix for non-finite numbers

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplDouble.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplDouble.java
@@ -62,7 +62,8 @@ final class ObjectWriterImplDouble
         if ((features2 & JSONWriter.Feature.WriteClassName.mask) != 0
                 && (features2 & JSONWriter.Feature.WriteNonStringKeyAsString.mask) == 0
                 && (features2 & JSONWriter.Feature.NotWriteNumberClassName.mask) == 0
-                && fieldType != Double.class && fieldType != double.class) {
+                && fieldType != Double.class && fieldType != double.class
+                && Double.isFinite(value)) {
             jsonWriter.writeRaw('D');
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplFloat.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplFloat.java
@@ -55,7 +55,8 @@ final class ObjectWriterImplFloat
         if ((features2 & JSONWriter.Feature.WriteClassName.mask) != 0
                 && (features2 & JSONWriter.Feature.WriteNonStringKeyAsString.mask) == 0
                 && (features2 & JSONWriter.Feature.NotWriteNumberClassName.mask) == 0
-                && fieldType != Float.class && fieldType != float.class) {
+                && fieldType != Float.class && fieldType != float.class
+                && Float.isFinite(value)) {
             jsonWriter.writeRaw('F');
         }
     }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3400/Issue3449.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3400/Issue3449.java
@@ -5,6 +5,7 @@ import com.alibaba.fastjson2.JSONWriter;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("regression")
@@ -44,5 +45,26 @@ public class Issue3449 {
 
         assertEquals("1.0D", JSON.toJSONString(1D, JSONWriter.Feature.WriteClassName));
         assertEquals("1.0F", JSON.toJSONString(1F, JSONWriter.Feature.WriteClassName));
+    }
+
+    @Test
+    public void testWriteClassNameInObjectGraph() {
+        Bean bean = new Bean();
+        bean.d = Double.NaN;
+        bean.f = Float.POSITIVE_INFINITY;
+        bean.finite = 1.5D;
+
+        String json = JSON.toJSONString(bean, JSONWriter.Feature.WriteClassName);
+        assertEquals(
+                "{\"@type\":\"com.alibaba.fastjson2.issues_3400.Issue3449$Bean\",\"d\":null,\"f\":null,\"finite\":1.5D}",
+                json
+        );
+        assertDoesNotThrow(() -> JSON.parse(json));
+    }
+
+    public static class Bean {
+        public Object d;
+        public Object f;
+        public Object finite;
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_3400/Issue3449.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_3400/Issue3449.java
@@ -1,6 +1,7 @@
 package com.alibaba.fastjson2.issues_3400;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -32,5 +33,16 @@ public class Issue3449 {
         float newNan = Float.intBitsToFloat(newBits);
         assertEquals("null", JSON.toJSONString(newNan));
         assertEquals("null", new String(JSON.toJSONBytes(newNan)));
+    }
+
+    @Test
+    public void testWriteClassName() {
+        assertEquals("null", JSON.toJSONString(Double.NaN, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Double.POSITIVE_INFINITY, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Float.NaN, JSONWriter.Feature.WriteClassName));
+        assertEquals("null", JSON.toJSONString(Float.NEGATIVE_INFINITY, JSONWriter.Feature.WriteClassName));
+
+        assertEquals("1.0D", JSON.toJSONString(1D, JSONWriter.Feature.WriteClassName));
+        assertEquals("1.0F", JSON.toJSONString(1F, JSONWriter.Feature.WriteClassName));
     }
 }


### PR DESCRIPTION


## Description

When `JSONWriter.Feature.WriteClassName` is enabled, non-finite
Double/Float values such as `NaN` and `Infinity` are serialized as
`null`, but `ObjectWriterImplDouble` and `ObjectWriterImplFloat`
still append the `D`/`F` suffix.

This can produce invalid JSON such as:

```json
{"value":nullD}
````

or:

```json
{"value":nullF}
```

## Fix

Only append the `D`/`F` type suffix when the value is finite.

Finite Double/Float serialization behavior remains unchanged.

## Tests

Added regression tests covering:

* `Double.NaN`
* `Double.POSITIVE_INFINITY`
* `Float.NaN`
* `Float.NEGATIVE_INFINITY`
* finite Double/Float values with `WriteClassName`

All targeted tests pass.

