### PR TITLE
fix: handle truncated escape in JSONReaderUTF16

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3284,7 +3284,10 @@ final class JSONReaderUTF16
 
                 char c = chars[offset];
                 if (c == '\\') {
-                    c = chars[++offset];
+                    if (++offset == end) {
+                        throw error("invalid escape character EOI");
+                    }
+                    c = chars[offset];
                     if (c == 'u') {
                         c = (char) hexDigit4(chars, offset + 1, end);
                         offset += 4;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -3350,7 +3350,7 @@ final class JSONReaderUTF16
     }
 
     private void checkEscapeEnd(int offset) {
-        if (offset > end) {
+        if (offset >= end) {
             throw error("invalid escape character EOI");
         }
     }

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -969,7 +969,7 @@ final class JSONReaderUTF16
 
             if (ch == '\\') {
                 nameEscape = true;
-                ch = chars[offset++];
+                ch = charAfterEscape(offset++);
                 switch (ch) {
                     case 'u': {
                         ch = (char) hexDigit4(chars, offset, end);
@@ -977,7 +977,7 @@ final class JSONReaderUTF16
                         break;
                     }
                     case 'x': {
-                        ch = char2(chars[offset], chars[offset + 1]);
+                        ch = char2(chars, offset, end);
                         offset += 2;
                         break;
                     }
@@ -1022,7 +1022,7 @@ final class JSONReaderUTF16
             for (int i = 0; ; ++i) {
                 if (ch == '\\') {
                     nameEscape = true;
-                    ch = chars[offset++];
+                    ch = charAfterEscape(offset++);
                     switch (ch) {
                         case 'u': {
                             ch = (char) hexDigit4(chars, offset, end);
@@ -1030,7 +1030,7 @@ final class JSONReaderUTF16
                             break;
                         }
                         case 'x': {
-                            ch = char2(chars[offset], chars[offset + 1]);
+                            ch = char2(chars, offset, end);
                             offset += 2;
                             break;
                         }
@@ -1484,7 +1484,7 @@ final class JSONReaderUTF16
 
                 if (c == '\\') {
                     nameEscape = true;
-                    c = chars[++offset];
+                    c = charAfterEscape(++offset);
                     switch (c) {
                         case 'u': {
                             c = (char) hexDigit4(chars, offset + 1, end);
@@ -1492,7 +1492,7 @@ final class JSONReaderUTF16
                             break;
                         }
                         case 'x': {
-                            c = char2(chars[offset + 1], chars[offset + 2]);
+                            c = char2(chars, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -1550,7 +1550,7 @@ final class JSONReaderUTF16
                 char c = chars[offset];
                 if (c == '\\') {
                     nameEscape = true;
-                    c = chars[++offset];
+                    c = charAfterEscape(++offset);
                     switch (c) {
                         case 'u': {
                             c = (char) hexDigit4(chars, offset + 1, end);
@@ -1558,7 +1558,7 @@ final class JSONReaderUTF16
                             break;
                         }
                         case 'x': {
-                            c = char2(chars[offset + 1], chars[offset + 2]);
+                            c = char2(chars, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -1697,7 +1697,7 @@ final class JSONReaderUTF16
 
             if (ch == '\\') {
                 nameEscape = true;
-                ch = chars[++offset];
+                ch = charAfterEscape(++offset);
                 switch (ch) {
                     case 'u': {
                         ch = (char) hexDigit4(chars, offset + 1, end);
@@ -1705,7 +1705,7 @@ final class JSONReaderUTF16
                         break;
                     }
                     case 'x': {
-                        ch = char2(chars[offset + 1], chars[offset + 2]);
+                        ch = char2(chars, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -1734,7 +1734,7 @@ final class JSONReaderUTF16
                 char c = chars[offset];
                 if (c == '\\') {
                     nameEscape = true;
-                    c = chars[++offset];
+                    c = charAfterEscape(++offset);
                     switch (c) {
                         case 'u': {
                             c = (char) hexDigit4(chars, offset + 1, end);
@@ -1742,7 +1742,7 @@ final class JSONReaderUTF16
                             break;
                         }
                         case 'x': {
-                            c = char2(chars[offset + 1], chars[offset + 2]);
+                            c = char2(chars, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -1817,7 +1817,7 @@ final class JSONReaderUTF16
             char c = chars[offset];
 
             if (c == '\\') {
-                c = chars[++offset];
+                c = charAfterEscape(++offset);
                 switch (c) {
                     case 'u': {
                         c = (char) hexDigit4(chars, offset + 1, end);
@@ -1825,7 +1825,7 @@ final class JSONReaderUTF16
                         break;
                     }
                     case 'x': {
-                        c = char2(chars[offset + 1], chars[offset + 2]);
+                        c = char2(chars, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -1869,7 +1869,7 @@ final class JSONReaderUTF16
             char c = chars[offset];
 
             if (c == '\\') {
-                c = chars[++offset];
+                c = charAfterEscape(++offset);
                 switch (c) {
                     case 'u': {
                         c = (char) hexDigit4(chars, offset + 1, end);
@@ -1877,7 +1877,7 @@ final class JSONReaderUTF16
                         break;
                     }
                     case 'x': {
-                        c = char2(chars[offset + 1], chars[offset + 2]);
+                        c = char2(chars, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -1926,7 +1926,7 @@ final class JSONReaderUTF16
             char c = chars[offset];
 
             if (c == '\\') {
-                c = chars[++offset];
+                c = charAfterEscape(++offset);
                 switch (c) {
                     case 'u': {
                         c = (char) hexDigit4(chars, offset + 1, end);
@@ -1934,7 +1934,7 @@ final class JSONReaderUTF16
                         break;
                     }
                     case 'x': {
-                        c = char2(chars[offset + 1], chars[offset + 2]);
+                        c = char2(chars, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -1988,8 +1988,9 @@ final class JSONReaderUTF16
             int c = chars[offset];
             if (c == '\\') {
                 nameEscape = true;
-                c = chars[offset + 1];
+                c = charAfterEscape(offset + 1);
                 offset += (c == 'u' ? 6 : (c == 'x' ? 4 : 2));
+                checkEscapeEnd(offset);
                 continue;
             }
 
@@ -3063,7 +3064,7 @@ final class JSONReaderUTF16
             char c = chars[offset];
 
             if (c == '\\') {
-                c = chars[++offset];
+                c = charAfterEscape(++offset);
                 switch (c) {
                     case 'u': {
                         c = (char) hexDigit4(chars, offset + 1, end);
@@ -3071,7 +3072,7 @@ final class JSONReaderUTF16
                         break;
                     }
                     case 'x': {
-                        c = char2(chars[offset + 1], chars[offset + 2]);
+                        c = char2(chars, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -3104,8 +3105,9 @@ final class JSONReaderUTF16
             char c = chars[offset];
             if (c == '\\') {
                 valueEscape = true;
-                c = chars[offset + 1];
+                c = charAfterEscape(offset + 1);
                 offset += (c == 'u' ? 6 : (c == 'x' ? 4 : 2));
+                checkEscapeEnd(offset);
                 continue;
             }
 
@@ -3123,12 +3125,12 @@ final class JSONReaderUTF16
             for (int i = 0; ; ++i) {
                 char c = this.chars[offset];
                 if (c == '\\') {
-                    c = this.chars[++offset];
+                    c = charAfterEscape(++offset);
                     if (c == 'u') {
                         c = (char) hexDigit4(chars, offset + 1, end);
                         offset += 4;
                     } else if (c == 'x') {
-                        c = char2(chars[offset + 1], chars[offset + 2]);
+                        c = char2(chars, offset + 1, end);
                         offset += 2;
                     } else if (c != '\\' && c != '"') {
                         c = char1(c);
@@ -3284,10 +3286,7 @@ final class JSONReaderUTF16
 
                 char c = chars[offset];
                 if (c == '\\') {
-                    if (++offset == end) {
-                        throw error("invalid escape character EOI");
-                    }
-                    c = chars[offset];
+                    c = charAfterEscape(++offset);
                     if (c == 'u') {
                         c = (char) hexDigit4(chars, offset + 1, end);
                         offset += 4;
@@ -3343,6 +3342,19 @@ final class JSONReaderUTF16
         }
     }
 
+    private char charAfterEscape(int offset) {
+        if (offset >= end) {
+            throw error("invalid escape character EOI");
+        }
+        return chars[offset];
+    }
+
+    private void checkEscapeEnd(int offset) {
+        if (offset > end) {
+            throw error("invalid escape character EOI");
+        }
+    }
+
     @Override
     public final boolean skipName() {
         this.offset = skipName(this, chars, offset, end);
@@ -3358,8 +3370,9 @@ final class JSONReaderUTF16
         for (; ; ) {
             char ch = chars[offset++];
             if (ch == '\\') {
-                ch = chars[offset];
+                ch = jsonReader.charAfterEscape(offset);
                 offset += (ch == 'u' ? 5 : (ch == 'x' ? 3 : 1));
+                jsonReader.checkEscapeEnd(offset);
                 continue;
             }
 
@@ -3487,7 +3500,7 @@ final class JSONReaderUTF16
         char ch = offset == end ? EOI : chars[offset++];
         for (; ; ) {
             if (ch == '\\') {
-                ch = chars[offset++];
+                ch = jsonReader.charAfterEscape(offset++);
                 if (ch == 'u') {
                     offset += 4;
                 } else if (ch == 'x') {
@@ -3495,7 +3508,7 @@ final class JSONReaderUTF16
                 } else if (ch != '\\' && ch != '"') {
                     jsonReader.char1(ch);
                 }
-                ch = chars[offset++];
+                ch = jsonReader.charAfterEscape(offset++);
                 continue;
             }
 
@@ -3535,6 +3548,9 @@ final class JSONReaderUTF16
         int ch = bytes[offset++];
         for (; ; ) {
             if (ch == '\\') {
+                if (offset == bytes.length) {
+                    throw jsonReader.error("invalid escape character EOI");
+                }
                 ch = bytes[offset++];
                 if (ch == 'u') {
                     offset += 4;
@@ -3542,6 +3558,9 @@ final class JSONReaderUTF16
                     offset += 2;
                 } else if (ch != '\\' && ch != '"') {
                     jsonReader.char1(ch);
+                }
+                if (offset >= bytes.length) {
+                    throw jsonReader.error("invalid escape character EOI");
                 }
                 ch = bytes[offset++];
                 continue;

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -580,7 +580,7 @@ class JSONReaderUTF8
 
             if (ch == '\\') {
                 nameEscape = true;
-                ch = (char) bytes[offset++];
+                ch = (char) byteAfterEscape(offset++);
                 switch (ch) {
                     case 'u': {
                         ch = hexDigit4(bytes, offset, end);
@@ -588,7 +588,7 @@ class JSONReaderUTF8
                         break;
                     }
                     case 'x': {
-                        ch = char2(bytes[offset], bytes[offset + 1]);
+                        ch = char2(bytes, offset, end);
                         offset += 2;
                         break;
                     }
@@ -665,7 +665,7 @@ class JSONReaderUTF8
             for (int i = 0; ; ++i) {
                 if (ch == '\\') {
                     nameEscape = true;
-                    ch = bytes[offset++];
+                    ch = byteAfterEscape(offset++);
                     switch (ch) {
                         case 'u': {
                             ch = hexDigit4(bytes, offset, end);
@@ -673,7 +673,7 @@ class JSONReaderUTF8
                             break;
                         }
                         case 'x': {
-                            ch = char2(bytes[offset], bytes[offset + 1]);
+                            ch = char2(bytes, offset, end);
                             offset += 2;
                             break;
                         }
@@ -2619,7 +2619,7 @@ class JSONReaderUTF8
 
                 if (ch == '\\') {
                     nameEscape = true;
-                    ch = bytes[++offset];
+                    ch = byteAfterEscape(++offset);
                     switch (ch) {
                         case 'u': {
                             ch = hexDigit4(bytes, offset + 1, end);
@@ -2627,7 +2627,7 @@ class JSONReaderUTF8
                             break;
                         }
                         case 'x': {
-                            ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                            ch = char2(bytes, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -2666,7 +2666,7 @@ class JSONReaderUTF8
                 ch = bytes[offset];
                 if (ch == '\\') {
                     nameEscape = true;
-                    ch = bytes[++offset];
+                    ch = byteAfterEscape(++offset);
                     switch (ch) {
                         case 'u': {
                             ch = hexDigit4(bytes, offset + 1, end);
@@ -2674,7 +2674,7 @@ class JSONReaderUTF8
                             break;
                         }
                         case 'x': {
-                            ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                            ch = char2(bytes, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -2841,7 +2841,7 @@ class JSONReaderUTF8
 
             if (ch == '\\') {
                 nameEscape = true;
-                ch = bytes[++offset];
+                ch = byteAfterEscape(++offset);
                 switch (ch) {
                     case 'u': {
                         ch = hexDigit4(bytes, offset + 1, end);
@@ -2849,7 +2849,7 @@ class JSONReaderUTF8
                         break;
                     }
                     case 'x': {
-                        ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                        ch = char2(bytes, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -2881,7 +2881,7 @@ class JSONReaderUTF8
                 ch = bytes[offset];
                 if (ch == '\\') {
                     nameEscape = true;
-                    ch = bytes[++offset];
+                    ch = byteAfterEscape(++offset);
                     switch (ch) {
                         case 'u': {
                             ch = hexDigit4(bytes, offset + 1, end);
@@ -2889,7 +2889,7 @@ class JSONReaderUTF8
                             break;
                         }
                         case 'x': {
-                            ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                            ch = char2(bytes, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -3005,7 +3005,7 @@ class JSONReaderUTF8
             int ch = bytes[offset];
 
             if (ch == '\\') {
-                ch = bytes[++offset];
+                ch = byteAfterEscape(++offset);
                 switch (ch) {
                     case 'u': {
                         ch = hexDigit4(bytes, offset + 1, end);
@@ -3013,7 +3013,7 @@ class JSONReaderUTF8
                         break;
                     }
                     case 'x': {
-                        ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                        ch = char2(bytes, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -3077,7 +3077,7 @@ class JSONReaderUTF8
         for (; ; ) {
             int ch = bytes[offset];
             if (ch == '\\') {
-                ch = bytes[++offset];
+                ch = byteAfterEscape(++offset);
                 switch (ch) {
                     case 'u': {
                         ch = hexDigit4(bytes, offset + 1, end);
@@ -3085,7 +3085,7 @@ class JSONReaderUTF8
                         break;
                     }
                     case 'x': {
-                        ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                        ch = char2(bytes, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -3236,7 +3236,7 @@ class JSONReaderUTF8
             }
 
             if (ch == '\\') {
-                ch = (char) bytes[++offset];
+                ch = byteAfterEscape(++offset);
                 switch (ch) {
                     case 'u': {
                         ch = hexDigit4(bytes, offset + 1, end);
@@ -3244,7 +3244,7 @@ class JSONReaderUTF8
                         break;
                     }
                     case 'x': {
-                        ch = char2(bytes[offset + 1], bytes[offset + 2]);
+                        ch = char2(bytes, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -3298,8 +3298,9 @@ class JSONReaderUTF8
             int ch = bytes[offset];
             if (ch == '\\') {
                 nameEscape = true;
-                ch = bytes[offset + 1];
+                ch = byteAfterEscape(offset + 1);
                 offset += (ch == 'u' ? 6 : (ch == 'x' ? 4 : 2));
+                checkEscapeEnd(offset);
                 continue;
             }
 
@@ -4136,7 +4137,7 @@ class JSONReaderUTF8
             int c = bytes[offset];
             if (c == '\\') {
                 valueEscape = true;
-                c = bytes[++offset];
+                c = byteAfterEscape(++offset);
                 switch (c) {
                     case 'u': {
                         offset += 4;
@@ -4150,6 +4151,7 @@ class JSONReaderUTF8
                         break;
                 }
                 offset++;
+                checkEscapeEnd(offset);
                 continue;
             }
 
@@ -4191,7 +4193,7 @@ class JSONReaderUTF8
             for (int i = 0, end = this.end; ; ++i) {
                 int c = bytes[offset];
                 if (c == '\\') {
-                    c = bytes[++offset];
+                    c = byteAfterEscape(++offset);
                     switch (c) {
                         case 'u': {
                             c = hexDigit4(bytes, offset + 1, end);
@@ -4199,7 +4201,7 @@ class JSONReaderUTF8
                             break;
                         }
                         case 'x': {
-                            c = char2(bytes[offset + 1], bytes[offset + 2]);
+                            c = char2(bytes, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -4320,8 +4322,9 @@ class JSONReaderUTF8
             int c = bytes[offset];
             if (c == '\\') {
                 valueEscape = true;
-                c = bytes[offset + 1];
+                c = byteAfterEscape(offset + 1);
                 offset += (c == 'u' ? 6 : (c == 'x' ? 4 : 2));
+                checkEscapeEnd(offset);
                 continue;
             }
 
@@ -4367,7 +4370,7 @@ class JSONReaderUTF8
             for (int i = 0; ; ++i) {
                 int c = bytes[offset];
                 if (c == '\\') {
-                    c = bytes[++offset];
+                    c = byteAfterEscape(++offset);
                     switch (c) {
                         case 'u': {
                             c = hexDigit4(bytes, offset + 1, end);
@@ -4375,7 +4378,7 @@ class JSONReaderUTF8
                             break;
                         }
                         case 'x': {
-                            c = char2(bytes[offset + 1], bytes[offset + 2]);
+                            c = char2(bytes, offset + 1, end);
                             offset += 2;
                             break;
                         }
@@ -4476,6 +4479,26 @@ class JSONReaderUTF8
         }
 
         stringValue = str;
+    }
+
+    private int byteAfterEscape(int offset) {
+        if (offset >= end) {
+            throw error("invalid escape character EOI");
+        }
+        return bytes[offset];
+    }
+
+    private char char2(byte[] bytes, int offset, int end) {
+        if (offset + 1 >= end) {
+            throw error("invalid escape character EOI");
+        }
+        return char2(bytes[offset], bytes[offset + 1]);
+    }
+
+    private void checkEscapeEnd(int offset) {
+        if (offset >= end) {
+            throw error("invalid escape character EOI");
+        }
     }
 
     @Override
@@ -4628,7 +4651,7 @@ class JSONReaderUTF8
                     ch = offset == end ? EOI : bytes[offset++];
                     break;
                 } else {
-                    ch = bytes[slashIndex + 1];
+                    ch = jsonReader.byteAfterEscape(slashIndex + 1);
                     if (ch == 'u') {
                         offset = slashIndex + 6;
                     } else if (ch == 'x') {
@@ -4682,7 +4705,7 @@ class JSONReaderUTF8
         offset++;
         for (; ; ) {
             if (ch == '\\') {
-                ch = bytes[offset++];
+                ch = jsonReader.byteAfterEscape(offset++);
                 if (ch == 'u') {
                     offset += 4;
                 } else if (ch == 'x') {
@@ -4690,7 +4713,7 @@ class JSONReaderUTF8
                 } else if (ch != '\\' && ch != '"') {
                     jsonReader.char1(ch);
                 }
-                ch = bytes[offset++];
+                ch = jsonReader.byteAfterEscape(offset++);
                 continue;
             }
             if (ch == quote) {
@@ -5070,7 +5093,7 @@ class JSONReaderUTF8
             }
 
             if (c == '\\') {
-                c = (char) bytes[++offset];
+                c = (char) byteAfterEscape(++offset);
                 switch (c) {
                     case 'u': {
                         c = hexDigit4(bytes, offset + 1, end);
@@ -5078,7 +5101,7 @@ class JSONReaderUTF8
                         break;
                     }
                     case 'x': {
-                        c = char2(bytes[offset + 1], bytes[offset + 2]);
+                        c = char2(bytes, offset + 1, end);
                         offset += 2;
                         break;
                     }
@@ -5292,12 +5315,12 @@ class JSONReaderUTF8
                         if (c == quote) {
                             break LOOP;
                         } else {
-                            c = bytes[offset++];
+                            c = byteAfterEscape(offset++);
                             if (c == 'u') {
                                 c = (char) hexDigit4(bytes, offset, end);
                                 offset += 4;
                             } else if (c == 'x') {
-                                c = char2(bytes[offset], bytes[offset + 1]);
+                                c = char2(bytes, offset, end);
                                 offset += 2;
                             } else {
                                 c = char1(c);

--- a/core/src/test/java/com/alibaba/fastjson2/JSONReaderUTF16Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONReaderUTF16Test.java
@@ -2,8 +2,6 @@ package com.alibaba.fastjson2;
 
 import org.junit.jupiter.api.Test;
 
-import java.nio.charset.StandardCharsets;
-
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JSONReaderUTF16Test {
@@ -13,13 +11,65 @@ public class JSONReaderUTF16Test {
                 "\"\\",
                 "{\"a\":\"\\",
                 "[\"\\",
-                "\"ab\\"
+                "\"ab\\",
+                "\"中\\"
         };
 
         for (String input : inputs) {
             assertThrows(JSONException.class, () -> JSON.parse(input));
             assertThrows(JSONException.class, () -> JSON.parse(input.toCharArray()));
-            assertThrows(JSONException.class, () -> JSON.parse(input.getBytes(StandardCharsets.UTF_8)));
         }
+    }
+
+    @Test
+    public void truncatedEscapePublicPaths() {
+        assertThrows(JSONException.class, () -> JSON.parse("{\"a\\".toCharArray()));
+        String[] numberInputs = {
+                "{\"a\":\"\\",
+                "{\"a\":\"\\u",
+                "{\"a\":\"\\x"
+        };
+        for (String input : numberInputs) {
+            assertThrows(JSONException.class, () -> JSON.parseObject(input.toCharArray(), Bean.class));
+        }
+
+        assertThrows(JSONException.class, () -> JSON.parseObject("{\"x\":\"\\".toCharArray(), Bean.class));
+        assertThrows(
+                JSONException.class,
+                () -> JSON.parseObject("{a\\".toCharArray(), Object.class, JSONReader.Feature.AllowUnQuotedFieldNames)
+        );
+        assertThrows(
+                JSONException.class,
+                () -> JSON.parseObject("{a\\x".toCharArray(), Object.class, JSONReader.Feature.AllowUnQuotedFieldNames)
+        );
+        assertThrows(JSONException.class, () -> JSON.parseObject("\"ab\\".toCharArray(), Value.class));
+
+        for (String input : new String[]{"\"a\\u", "\"a\\x"}) {
+            try (JSONReader jsonReader = JSONReader.of(input.toCharArray())) {
+                assertThrows(JSONException.class, jsonReader::skipName);
+            }
+        }
+    }
+
+    @Test
+    public void truncatedEscapeInSubRange() {
+        char[] chars = "\"ab\\\"".toCharArray();
+        try (JSONReader jsonReader = JSONReader.of(chars, 0, 4)) {
+            assertThrows(JSONException.class, jsonReader::readString);
+        }
+
+        char[] unquotedName = "{a\\x12:1}".toCharArray();
+        try (JSONReader jsonReader = JSONReader.of(unquotedName, 0, 4)) {
+            jsonReader.getContext().config(JSONReader.Feature.AllowUnQuotedFieldNames);
+            assertThrows(JSONException.class, jsonReader::readObject);
+        }
+    }
+
+    public static class Bean {
+        public Number a;
+    }
+
+    public enum Value {
+        A
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/JSONReaderUTF16Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONReaderUTF16Test.java
@@ -2,6 +2,8 @@ package com.alibaba.fastjson2;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JSONReaderUTF16Test {
@@ -62,6 +64,29 @@ public class JSONReaderUTF16Test {
         try (JSONReader jsonReader = JSONReader.of(unquotedName, 0, 4)) {
             jsonReader.getContext().config(JSONReader.Feature.AllowUnQuotedFieldNames);
             assertThrows(JSONException.class, jsonReader::readObject);
+        }
+    }
+
+    @Test
+    public void truncatedEscapeUTF8() {
+        assertThrows(JSONException.class, () -> JSON.parse("\"中\\".getBytes(StandardCharsets.UTF_8)));
+        assertThrows(JSONException.class, () -> JSON.parse("{\"中\\".getBytes(StandardCharsets.UTF_8)));
+        assertThrows(
+                JSONException.class,
+                () -> JSON.parseObject("{\"a\":\"中\\".getBytes(StandardCharsets.UTF_8), Bean.class)
+        );
+        assertThrows(
+                JSONException.class,
+                () -> JSON.parseObject("{\"x\":\"中\\".getBytes(StandardCharsets.UTF_8), Bean.class)
+        );
+        assertThrows(
+                JSONException.class,
+                () -> JSON.parseObject("\"中\\".getBytes(StandardCharsets.UTF_8), Value.class)
+        );
+
+        byte[] bytes = "\"中\\\"".getBytes(StandardCharsets.UTF_8);
+        try (JSONReader jsonReader = JSONReader.of(bytes, 0, 5)) {
+            assertThrows(JSONException.class, jsonReader::readString);
         }
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/JSONReaderUTF16Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONReaderUTF16Test.java
@@ -1,0 +1,25 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JSONReaderUTF16Test {
+    @Test
+    public void truncatedEscape() {
+        String[] inputs = {
+                "\"\\",
+                "{\"a\":\"\\",
+                "[\"\\",
+                "\"ab\\"
+        };
+
+        for (String input : inputs) {
+            assertThrows(JSONException.class, () -> JSON.parse(input));
+            assertThrows(JSONException.class, () -> JSON.parse(input.toCharArray()));
+            assertThrows(JSONException.class, () -> JSON.parse(input.getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+}


### PR DESCRIPTION
### 这个 PR 做了什么 / 为什么需要这个修改？

当 JSON 字符串以被截断的反斜杠转义结尾时，`JSONReaderUTF16.readString()` 会读取字符缓冲区末尾之外。

例如，在 JDK 8 上执行 `JSON.parse("\"\\")` 会抛出 `ArrayIndexOutOfBoundsException`，而不是 `JSONException`。由于 `ArrayIndexOutOfBoundsException` 不是 `JSONException` 的子类，调用方无法通过 `catch (JSONException)` 处理该非法输入。

本次修改在读取反斜杠后的字符之前检查是否已经到达输入末尾，并抛出 `JSONException`，使 UTF16 reader 的行为与 UTF8 reader 及其他非法 JSON 输入保持一致。

### 修改摘要

- 在 `JSONReaderUTF16.readString()` 的反斜杠处理分支增加输入结束检查。
- 增加根字符串、对象属性值和数组元素中截断转义的回归测试。
- 覆盖 `String`、`char[]` 和 UTF8 字节数组解析入口。
- 普通无转义字符串的处理路径保持不变。

已执行以下验证：

```text
mvn -pl core -DskipTests compile
mvn -pl core -Dtest=JSONReaderUTF16Test surefire:test
```

上述命令均执行成功。

#7790
