### PR TITLE
fix: exclude JVM-singleton empty collections from raw $ref path tracking

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONWriter.java
@@ -299,6 +299,10 @@ public abstract class JSONWriter
      * @return the previous path as a string, or null if no previous path exists
      */
     public final String setPath0(FieldWriter fieldWriter, Object object) {
+        if (ObjectWriterProvider.isNotReferenceDetect(object.getClass())) {
+            return null;
+        }
+
         this.path = this.path == Path.ROOT
                 ? fieldWriter.getRootParentPath()
                 : fieldWriter.getPath(path);
@@ -376,7 +380,7 @@ public abstract class JSONWriter
      * @return the previous path as a string, or null if no previous path exists
      */
     public final String setPath0(int index, Object object) {
-        if (path == null) {
+        if (path == null || ObjectWriterProvider.isNotReferenceDetect(object.getClass())) {
             return null;
         }
         this.path = index == 0
@@ -424,8 +428,7 @@ public abstract class JSONWriter
     public final void popPath0(Object object) {
         if (this.path == null
                 || (context.features & MASK_REFERENCE_DETECTION) == 0
-                || object == Collections.EMPTY_LIST
-                || object == Collections.EMPTY_SET
+                || ObjectWriterProvider.isNotReferenceDetect(object.getClass())
         ) {
             return;
         }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7795.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7795.java
@@ -1,0 +1,116 @@
+package com.alibaba.fastjson2.issues_7000;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * {@link Collections#emptySet()}/{@link Collections#emptyList()}/{@link Collections#emptyMap()} are
+ * JVM-wide singletons, so {@link com.alibaba.fastjson2.writer.ObjectWriterProvider#isNotReferenceDetect(Class)}
+ * excludes them from reference tracking. But the ASM-generated bean field writers
+ * (see {@code ObjectWriterCreatorASM}) call the raw {@code JSONWriter.setPath0}/{@code popPath0}
+ * directly for non-{@code Object}-declared fields, bypassing that exclusion on the push side, while
+ * {@code popPath0} only special-cased the two singletons by identity on the pop side. That push/pop
+ * asymmetry left {@code JSONWriter.path} one level too deep after writing a shared empty collection,
+ * corrupting every path computed afterwards and producing a bogus {@code $ref} for the next occurrence.
+ */
+public class Issue7795 {
+    public static class Model {
+        private Set<Integer> ids;
+        private Map<String, Integer> counts;
+
+        public Model() {
+        }
+
+        public Model(Set<Integer> ids) {
+            this.ids = ids;
+        }
+
+        public Model(Map<String, Integer> counts) {
+            this.counts = counts;
+        }
+
+        public Set<Integer> getIds() {
+            return ids;
+        }
+
+        public void setIds(Set<Integer> ids) {
+            this.ids = ids;
+        }
+
+        public Map<String, Integer> getCounts() {
+            return counts;
+        }
+
+        public void setCounts(Map<String, Integer> counts) {
+            this.counts = counts;
+        }
+    }
+
+    @Test
+    public void testSharedEmptySetAcrossMapEntries() {
+        Set<Integer> sharedEmptySet = Collections.emptySet();
+
+        Map<Integer, Model> sourceModels = new LinkedHashMap<>();
+        sourceModels.put(1001, new Model(sharedEmptySet));
+        sourceModels.put(1002, new Model(sharedEmptySet));
+
+        String json = JSON.toJSONString(sourceModels, JSONWriter.Feature.ReferenceDetection);
+        assertFalse(json.contains("$ref"), "shared empty collections must not be turned into $ref: " + json);
+
+        Map<Integer, Model> parsed = JSON.parseObject(json, new TypeReference<Map<Integer, Model>>() {
+        });
+        assertEquals(Collections.emptySet(), parsed.get(1001).getIds());
+        assertEquals(Collections.emptySet(), parsed.get(1002).getIds());
+    }
+
+    @Test
+    public void testSharedEmptyMapAcrossMapEntries() {
+        Map<String, Integer> sharedEmptyMap = Collections.emptyMap();
+
+        Map<Integer, Model> sourceModels = new LinkedHashMap<>();
+        sourceModels.put(1001, new Model(sharedEmptyMap));
+        sourceModels.put(1002, new Model(sharedEmptyMap));
+
+        String json = JSON.toJSONString(sourceModels, JSONWriter.Feature.ReferenceDetection);
+        assertFalse(json.contains("$ref"), "shared empty collections must not be turned into $ref: " + json);
+
+        Map<Integer, Model> parsed = JSON.parseObject(json, new TypeReference<Map<Integer, Model>>() {
+        });
+        assertEquals(Collections.emptyMap(), parsed.get(1001).getCounts());
+        assertEquals(Collections.emptyMap(), parsed.get(1002).getCounts());
+    }
+
+    /**
+     * {@code ObjectWriterImplList.writeJSONB} is the only other caller of the raw
+     * {@code setPath0(int, Object)} overload, and its own {@code refDetect} pre-check already
+     * excludes singleton classes before ever reaching it - so no current caller can trip this
+     * overload unguarded. It is fixed anyway for defense-in-depth, since it is a {@code public}
+     * method on {@code JSONWriter} with the same "raw path-tracking" contract as the
+     * {@code FieldWriter} overload that caused this issue. Exercise that contract directly.
+     */
+    @Test
+    public void testSetPath0IntOverloadExcludesSingletons() {
+        JSONWriter jsonWriter = JSONWriter.of(JSONWriter.Feature.ReferenceDetection);
+        jsonWriter.setRootObject(new Object());
+
+        Set<Integer> sharedEmptySet = Collections.emptySet();
+
+        assertNull(jsonWriter.setPath0(0, sharedEmptySet));
+        jsonWriter.popPath0(sharedEmptySet);
+
+        assertNull(jsonWriter.setPath0(1, sharedEmptySet),
+                "a JVM-wide singleton must never be resolved to a $ref, even via the raw overload");
+        jsonWriter.popPath0(sharedEmptySet);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #7795.

`Collections.emptySet()` / `emptyList()` / `emptyMap()` are JVM-wide singletons. `ObjectWriterProvider.isNotReferenceDetect()` is meant to exclude these (and other immutable value types) from `$ref` reference-detection, since tracking a JVM singleton by identity is meaningless. The guarded `JSONWriter.setPath()` / `popPath()` overloads already check this via `isRefDetect(Object)`.

However, ASM-generated bean field writers (`ObjectWriterCreatorASM`) call the **raw** `setPath0(FieldWriter, Object)` overload directly for non-`Object`-declared fields, bypassing that exclusion entirely on the push side. Meanwhile `popPath0(Object)` only special-cased `Collections.EMPTY_LIST`/`EMPTY_SET` by identity on the pop side (not `EMPTY_MAP`, and not any of the other excluded types reachable through this path). This push/pop asymmetry left `JSONWriter.path` one level too deep after writing a shared empty collection field, corrupting every path computed afterward.

Repro (works against plain `com.alibaba.fastjson2.JSON`, not just the fastjson1-compatible module):

```java
Set<Integer> sharedEmptySet = Collections.emptySet();
Map<Integer, Model> map = new LinkedHashMap<>();
map.put(1001, new Model(sharedEmptySet));
map.put(1002, new Model(sharedEmptySet));

JSON.toJSONString(map, JSONWriter.Feature.ReferenceDetection);
// before: {1001:{"ids":[]},1002:{"ids":{"$ref":"$.ids"}}}  <- bogus ref, path missing "1001"
// after:  {1001:{"ids":[]},1002:{"ids":[]}}
```

Deserializing the bogus `$ref` silently resolved to `null` instead of throwing or resolving to the real empty collection.

## Fix

Centralize the exclusion check in the raw choke-point methods on `JSONWriter` instead of patching every individual ASM codegen call site (which is scattered across ~5 methods in `ObjectWriterCreatorASM.java` and is how this asymmetry was introduced in the first place):

- `setPath0(FieldWriter, Object)`: early-return when `ObjectWriterProvider.isNotReferenceDetect(object.getClass())`.
- `setPath0(int, Object)`: same guard, for symmetry with the sibling raw overload (its one current caller, `ObjectWriterImplList.writeJSONB`, already pre-filters via a guarded check, so this is defense-in-depth on the public raw API rather than a currently-reachable fix).
- `popPath0(Object)`: replaced the `EMPTY_LIST`/`EMPTY_SET`-only identity check with the same class-based `isNotReferenceDetect` check, so push and pop are symmetric again (this also correctly extends the exclusion to `EMPTY_MAP`).

## Test plan

- [x] Added `core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7795.java`:
  - `testSharedEmptySetAcrossMapEntries` / `testSharedEmptyMapAcrossMapEntries`: reproduce the reported scenario (`Map<Integer, Bean>` with a shared empty `Set`/`Map` field); verified these fail without the `setPath0(FieldWriter, Object)` fix and pass with it.
  - `testSetPath0IntOverloadExcludesSingletons`: direct contract test for the `setPath0(int, Object)` overload.
- [x] `mvn -pl core -am validate` (checkstyle) clean.
- [x] `mvn -pl core -am test`: full core suite green (7977 tests, 0 failures/errors), both incrementally and after a clean rebuild.
- [x] Independently reviewed by two separate agents (one Claude-based, one Codex-based); both confirmed the root-cause diagnosis and fix are correct with no NPE risk or regression, and both independently caught a test-quality gap in an earlier draft (a `List`-based test that didn't actually exercise the fixed code path), which was reworked before this PR.

<details>
<summary>中文说明</summary>

## 概述

修复 #7795。

`Collections.emptySet()` / `emptyList()` / `emptyMap()` 是 JVM 全局单例，`ObjectWriterProvider.isNotReferenceDetect()` 的设计意图就是把它们（以及其他不可变值类型）从 `$ref` 引用检测中排除，因为按对象身份去追踪一个全局单例是没有意义的。有保护的 `JSONWriter.setPath()`/`popPath()` 已经通过 `isRefDetect(Object)` 做了这个检查。

但 ASM 生成的 Bean 字段写入代码（`ObjectWriterCreatorASM`）对于非 `Object` 声明类型的字段，会直接调用**裸的** `setPath0(FieldWriter, Object)`，在压栈侧完全绕过了这层排除；而 `popPath0(Object)` 在出栈侧只是按对象身份特判了 `Collections.EMPTY_LIST`/`EMPTY_SET` 两个单例（不包括 `EMPTY_MAP`，也不包括这条路径上其他本该排除的类型）。这种压栈会记、弹栈不弹的不对称，导致写完一个共享的空集合字段后，`JSONWriter.path` 多陷了一层且不再恢复，污染了后续所有路径计算。

## 修复方案

没有去逐个修补 `ObjectWriterCreatorASM.java` 里分散在约 5 处的 ASM 字节码生成调用点（这种分散正是这次不对称产生的原因），而是把排除判断集中收口到 `JSONWriter` 上的裸方法本身：

- `setPath0(FieldWriter, Object)`：命中 `ObjectWriterProvider.isNotReferenceDetect(object.getClass())` 时提前返回。
- `setPath0(int, Object)`：同样加上这层判断，保持和另一个裸重载的契约一致（它目前唯一的调用方 `ObjectWriterImplList.writeJSONB` 在调用前已经做了有保护的判断，所以这里属于对公开裸 API 的防御性加固，不对应当前可触发的路径）。
- `popPath0(Object)`：把原来只认 `EMPTY_LIST`/`EMPTY_SET` 两个单例的身份判断，换成同样的按 class 排除判断，让压栈和弹栈重新对称（顺带正确覆盖了 `EMPTY_MAP`）。

## 测试

新增 `core/src/test/java/com/alibaba/fastjson2/issues_7000/Issue7795.java`，并做了完整的正反验证：去掉修复代码时对应测试会失败、加回后通过；`mvn validate`（checkstyle）干净；`core` 模块全量测试 7977 个用例全部通过。修复方案本身也经过两个独立 agent（一个基于 Claude、一个基于 Codex）分别审查，结论一致：修复正确、无 NPE 风险、无回归；两边还各自独立发现了草稿阶段一个测试没有真正覆盖到修复点的问题，已在提交前修正。

</details>

## Review round 2 (4609730e6)

Addressing the review feedback on the raw path methods:

- **Null tolerance (Critical).** Centralizing the exclusion introduced an implicit non-null precondition — the previous implementations compared identity (`popPath0`) or only stored the value in an `IdentityHashMap` (`setPath0`), so `null` was harmless, whereas `object.getClass()` is not. This is reachable at runtime, not only via the public raw API: `ObjectWriterCreatorASM` guards the **push** side with an explicit `ifnull` before `setPath0` but emits the trailing `popPath0(fieldValue)` **unguarded**, so an ordinary bean with a `null` Collection field written as JSONB with `ReferenceDetection` + `WriteNulls` threw `NullPointerException` in `popPath0`.

  `null` now takes exactly the same path as an excluded class — **never pushed, never popped** — rather than restoring the old behavior verbatim. Restoring it would keep `popPath0(null)` popping a level `setPath0` never pushed, which is a pre-existing over-pop on this same path:

  ```java
  class Bean { List<String> aItems; Model b; Model c; }  // aItems == null, b == c
  root = {"k": bean}

  // before: JSONB -> {"k":{"aItems":null,"b":{...},"c":{"$ref":"$.b"}}}    <- missing ".k"
  //         text  -> {"k":{"aItems":null,"b":{...},"c":{"$ref":"$.k.b"}}}
  // after:  both  -> {"k":{"aItems":null,"b":{...},"c":{"$ref":"$.k.b"}}}
  ```

  Same push/pop asymmetry this PR is about, so it is fixed here rather than left behind.

- **Javadoc (Suggestion).** All three raw methods now state that they bypass only the `Feature.ReferenceDetection` feature check, still enforce the `ObjectWriterProvider.isNotReferenceDetect` class exclusion, ignore `null`, and apply identical exclusions on both sides.

- **Tests.** `Issue7795.testRawPathMethodsAcceptNull` (initializes `JSONWriter.path` first, otherwise the `path == null` guard masks the problem, then calls both `setPath0` overloads and `popPath0(null)`) and `Issue7795.testNullCollectionFieldDoesNotCorruptPath` (end-to-end JSONB/text, pinning the `$.k.b` ref above). Removing either `object == null` guard makes both fail with the NPE — verified. `mvn -pl core -am validate` clean; `mvn -pl core test` → 7979 tests, 0 failures, 0 errors.

<details>
<summary>中文说明（Review round 2）</summary>

- **null 兼容性（Critical）**：把排除判断收口后，隐含引入了「入参必须非空」的前提——旧实现要么做身份比较（`popPath0`），要么只是把值放进 `IdentityHashMap`（`setPath0`），`null` 都是安全的，而 `object.getClass()` 不是。这不只影响公开裸 API，运行时就能触发：`ObjectWriterCreatorASM` 在**压栈侧**用 `ifnull` 显式跳过 `setPath0`，但结尾的 `popPath0(fieldValue)` **没有保护**，因此一个带 `null` 集合字段的普通 Bean，在 `ReferenceDetection` + `WriteNulls` 下写 JSONB 会在 `popPath0` 抛 NPE。

  现在 `null` 走和被排除 class 完全相同的路径——**不压栈、也不弹栈**——而不是原样恢复旧行为。原样恢复会保留 `popPath0(null)` 弹掉一个 `setPath0` 从未压入的层级，这本身就是这条路径上已存在的多弹一层的问题（示例见上：JSONB 输出 `$.b`，文本 writer 对同一对象图输出 `$.k.b`）。这与本 PR 要修的是同一个压栈/弹栈不对称，故一并修复。

- **Javadoc（Suggestion）**：三个裸方法的 Javadoc 现在明确写明只绕过 `Feature.ReferenceDetection` 这层 feature 检查，仍执行 `ObjectWriterProvider.isNotReferenceDetect` 的 class 排除并忽略 `null`，且两侧排除条件完全一致。

- **测试**：新增 `testRawPathMethodsAcceptNull`（先初始化 `path`，否则 `path == null` 会掩盖问题）与 `testNullCollectionFieldDoesNotCorruptPath`（端到端，钉住上面的 `$.k.b`）。去掉任一 `object == null` 保护，两个测试都会以 NPE 失败（已验证）。`mvn -pl core -am validate` 干净；`mvn -pl core test` 7979 个用例全通过。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFzJPj75rwUU5YetDZLSyd
