### PR TITLE
fix: resolve $ref for shared objects nested under numeric-keyed maps

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentName.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONPathSegmentName.java
@@ -202,6 +202,7 @@ class JSONPathSegmentName
             if (value == null) {
                 boolean isNum = IOUtils.isNumber(this.name);
                 Long longValue = null;
+                Integer intValue = null;
 
                 for (Object o : map.entrySet()) {
                     Map.Entry entry = (Map.Entry) o;
@@ -214,6 +215,14 @@ class JSONPathSegmentName
                             longValue = Long.parseLong(this.name);
                         }
                         if (entryKey.equals(longValue)) {
+                            value = entry.getValue();
+                            break;
+                        }
+                    } else if (entryKey instanceof Integer) {
+                        if (intValue == null && isNum) {
+                            intValue = Integer.parseInt(this.name);
+                        }
+                        if (entryKey.equals(intValue)) {
                             value = entry.getValue();
                             break;
                         }

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterImplMap.java
@@ -436,8 +436,10 @@ public final class ObjectWriterImplMap
             } else {
                 if (key instanceof Integer) {
                     jsonWriter.writeName((Integer) key);
+                    strKey = key.toString();
                 } else if (key instanceof Long) {
                     jsonWriter.writeName((Long) key);
+                    strKey = key.toString();
                 } else {
                     jsonWriter.writeNameAny(key);
                 }

--- a/core/src/test/java/com/alibaba/fastjson2/codec/RefTest8.java
+++ b/core/src/test/java/com/alibaba/fastjson2/codec/RefTest8.java
@@ -6,6 +6,8 @@ import com.alibaba.fastjson2.TypeReference;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +42,7 @@ public class RefTest8 {
         riskInfo2.itemMap = new HashMap<>();
         riskInfo2.itemMap.put(item2.itemId, item2);
 
-        List<RiskInfo> list = List.of(riskInfo1, riskInfo2);
+        List<RiskInfo> list = Arrays.asList(riskInfo1, riskInfo2);
 
         String json = JSON.toJSONString(list, JSONWriter.Feature.ReferenceDetection);
         assertEquals(
@@ -53,7 +55,7 @@ public class RefTest8 {
         });
         Item item1Parsed = list2.get(0).itemMap.get(1L);
         Item item2Parsed = list2.get(1).itemMap.get(2L);
-        assertEquals(Map.of("1", 1L), item1Parsed.reversePriceMap);
+        assertEquals(Collections.singletonMap("1", 1L), item1Parsed.reversePriceMap);
         assertSame(item1Parsed.reversePriceMap, item2Parsed.reversePriceMap);
     }
 

--- a/core/src/test/java/com/alibaba/fastjson2/codec/RefTest8.java
+++ b/core/src/test/java/com/alibaba/fastjson2/codec/RefTest8.java
@@ -1,0 +1,136 @@
+package com.alibaba.fastjson2.codec;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONWriter;
+import com.alibaba.fastjson2.TypeReference;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * https://github.com/alibaba/fastjson2/issues/3516
+ * A shared object nested one level below a Map keyed by Long/Integer produced a $ref path
+ * that skipped the map key segment, so the reference could not be resolved on read and the
+ * field was silently set to null instead of pointing back at the shared object.
+ */
+@Tag("codec")
+public class RefTest8 {
+    @Test
+    public void test_issue3516_longKeyedMap() {
+        Map<String, Long> reversePriceMap = new HashMap<>();
+        reversePriceMap.put("1", 1L);
+
+        Item item1 = new Item();
+        item1.itemId = 1L;
+        item1.reversePriceMap = reversePriceMap;
+        RiskInfo riskInfo1 = new RiskInfo();
+        riskInfo1.itemMap = new HashMap<>();
+        riskInfo1.itemMap.put(item1.itemId, item1);
+
+        Item item2 = new Item();
+        item2.itemId = 2L;
+        item2.reversePriceMap = reversePriceMap;
+        RiskInfo riskInfo2 = new RiskInfo();
+        riskInfo2.itemMap = new HashMap<>();
+        riskInfo2.itemMap.put(item2.itemId, item2);
+
+        List<RiskInfo> list = List.of(riskInfo1, riskInfo2);
+
+        String json = JSON.toJSONString(list, JSONWriter.Feature.ReferenceDetection);
+        assertEquals(
+                "[{\"itemMap\":{1:{\"itemId\":1,\"reversePriceMap\":{\"1\":1}}}},"
+                        + "{\"itemMap\":{2:{\"itemId\":2,\"reversePriceMap\":{\"$ref\":\"$[0].itemMap.1.reversePriceMap\"}}}}]",
+                json
+        );
+
+        List<RiskInfo> list2 = JSON.parseObject(json, new TypeReference<List<RiskInfo>>() {
+        });
+        Item item1Parsed = list2.get(0).itemMap.get(1L);
+        Item item2Parsed = list2.get(1).itemMap.get(2L);
+        assertEquals(Map.of("1", 1L), item1Parsed.reversePriceMap);
+        assertSame(item1Parsed.reversePriceMap, item2Parsed.reversePriceMap);
+    }
+
+    @Test
+    public void test_longKeyedMap_directShare() {
+        Item shared = new Item();
+        shared.itemId = 100L;
+
+        Bean bean = new Bean();
+        bean.map1 = new HashMap<>();
+        bean.map1.put(1L, shared);
+        bean.map2 = new HashMap<>();
+        bean.map2.put(2L, shared);
+
+        String json = JSON.toJSONString(bean, JSONWriter.Feature.ReferenceDetection);
+        assertEquals(
+                "{\"map1\":{1:{\"itemId\":100}},\"map2\":{2:{\"$ref\":\"$.map1.1\"}}}",
+                json
+        );
+
+        Bean bean2 = JSON.parseObject(json, Bean.class);
+        assertSame(bean2.map1.get(1L), bean2.map2.get(2L));
+        assertEquals(100L, bean2.map1.get(1L).itemId);
+    }
+
+    @Test
+    public void test_integerKeyedMap_directShare() {
+        Item shared = new Item();
+        shared.itemId = 200L;
+
+        BeanInt bean = new BeanInt();
+        bean.map1 = new HashMap<>();
+        bean.map1.put(1, shared);
+        bean.map2 = new HashMap<>();
+        bean.map2.put(2, shared);
+
+        String json = JSON.toJSONString(bean, JSONWriter.Feature.ReferenceDetection);
+        assertEquals(
+                "{\"map1\":{1:{\"itemId\":200}},\"map2\":{2:{\"$ref\":\"$.map1.1\"}}}",
+                json
+        );
+
+        BeanInt bean2 = JSON.parseObject(json, BeanInt.class);
+        assertSame(bean2.map1.get(1), bean2.map2.get(2));
+        assertEquals(200L, bean2.map1.get(1).itemId);
+    }
+
+    @Test
+    public void test_longKeyedMap_noSharing_outputUnchanged() {
+        Bean bean = new Bean();
+        bean.map1 = new HashMap<>();
+        bean.map1.put(1L, new Item());
+        bean.map2 = new HashMap<>();
+        bean.map2.put(2L, new Item());
+
+        assertEquals(
+                "{\"map1\":{1:{}},\"map2\":{2:{}}}",
+                JSON.toJSONString(bean, JSONWriter.Feature.ReferenceDetection)
+        );
+    }
+
+    public static class RiskInfo {
+        public Map<Long, Item> itemMap;
+    }
+
+    public static class Item {
+        public Long itemId;
+        public Map<String, Long> reversePriceMap;
+    }
+
+    public static class Bean {
+        public Map<Long, Item> map1;
+        public Map<Long, Item> map2;
+    }
+
+    public static class BeanInt {
+        public Map<Integer, Item> map1;
+        public Map<Integer, Item> map2;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3516.

When a `Map<Long, V>` / `Map<Integer, V>` field was serialized with `JSONWriter.Feature.ReferenceDetection` enabled, an object shared between two map entries got a `$ref` path that silently dropped the map's key segment (e.g. `$[0].itemMap.reversePriceMap` instead of `$[0].itemMap.1.reversePriceMap`). On read, that broken path resolved to `null` instead of the shared object.

Root cause, on both ends:

- **Write side** (`ObjectWriterImplMap.writeMapKey`): for `Integer`/`Long` keys written in raw (unquoted) form, the method returned `strKey == null`. The caller uses `strKey != null` as the gate for whether to call `jsonWriter.setPath(...)` for that entry, so the key segment was never pushed onto the path stack — nested `$ref` paths ended up pointing one level too high.
- **Read side** (`JSONPathSegmentName.eval`): the numeric-key fallback matching (used when `map.get(name)` fails because `name` is a `String` but the actual key is boxed numeric) only handled `Long` keys, not `Integer`. So even once the write side produces a correct path with an `Integer` key segment, resolution would still fail.

Both are fixed:
- `writeMapKey` now sets `strKey = key.toString()` for `Integer`/`Long` keys (the actual bytes written to the JSON key are unchanged — still unquoted).
- `JSONPathSegmentName.eval` gets an `Integer` fallback branch mirroring the existing `Long` one.

## Test plan

- [x] Added `RefTest8` covering: the exact issue #3516 repro (`Map<Long,Item>` with a shared inner `Map<String,Long>`, asserting the exact `$ref` path string and reference identity after round-trip), a direct-share case for `Long` keys, a direct-share case for `Integer` keys, and a regression guard proving output is byte-for-byte unchanged when there's no shared object to reference.
- [x] Verified all four new tests fail without the fix (reverted the fix locally, reran) and pass with it.
- [x] `mvn test -pl core` (full suite) passes.
- [x] `mvn validate -pl core` (checkstyle) passes.

<details>
<summary>中文说明</summary>

修复 #3516。

当 `Map<Long, V>` / `Map<Integer, V>` 字段在开启 `JSONWriter.Feature.ReferenceDetection` 的情况下序列化时，被两个 map entry 共享的对象生成的 `$ref` 路径会漏掉 map key 这一段（例如 `$[0].itemMap.reversePriceMap`，而不是正确的 `$[0].itemMap.1.reversePriceMap`）。反序列化时这个残缺路径解析不出对象，结果被静默置为 `null`。

根因分两处：

- **写端**（`ObjectWriterImplMap.writeMapKey`）：对于以裸数字形式写出的 `Integer`/`Long` key，该方法返回的 `strKey` 始终是 `null`。调用方用 `strKey != null` 作为"是否要为这个 entry 调用 `jsonWriter.setPath(...)`"的开关，导致 key 这一层路径从未被压入路径栈，后续嵌套对象的 `$ref` 路径因此少了一层。
- **读端**（`JSONPathSegmentName.eval`）：当 `map.get(name)` 因为 `name` 是 `String` 而实际 key 是装箱数字类型而失败时，有一个数字兜底匹配逻辑，但只处理了 `Long`，没处理 `Integer`。所以即便写端修好、生成了带 `Integer` key 的正确路径，读端依然解析不出来。

两处都已修复：
- `writeMapKey` 对 `Integer`/`Long` key 补上 `strKey = key.toString()`（实际写入 JSON 的字节不变，依然是不带引号的数字）。
- `JSONPathSegmentName.eval` 参照现有的 `Long` 分支，新增了 `Integer` 分支。

**测试**：新增 `RefTest8`，覆盖 issue #3516 的原始复现场景、`Long`/`Integer` key 直接共享场景，以及一个回归测试（证明没有共享对象时输出的 JSON 文本完全不变）。已验证：去掉修复后这些测试会失败，恢复修复后全部通过；`mvn test -pl core` 全量测试通过；`mvn validate -pl core` checkstyle 检查通过。

</details>

---

## Review follow-up — round 1

The first review round found that the write-side fix opened up a `$ref` path shape the read side had never been exercised with: a segment that is a bare number pointing at a map whose keys are not Strings. Four read-side gaps and one hot-path allocation were reported; all five are addressed in `5425ac9`, `f3fe7d2` and `ca816ee`. Reproductions and details are in the individual review threads — summary below.

### Read side: one shared lookup instead of two copies

The root cause of R1-1 was structural. `JSONPathSegmentName` and `JSONPathSingleName` each carried a near-identical copy of the "String segment to typed map key" fallback, so a fix in one was invisible to the other — and single-segment paths (`$.1`), which is exactly what a root-level map produces, are evaluated by the copy that was never updated.

Both now delegate to one `JSONPathSegmentName#getMapValue`, and the three remaining defects were fixed inside it:

| Finding | Problem | Fix |
| --- | --- | --- |
| R1-1 | root `Map<Integer, V>` reference `$.1` resolved to null | `JSONPathSingleName#eval` delegates to the shared helper; the duplicate is deleted |
| R1-4 | `map.get(name)` throws `ClassCastException` on a comparator-based map (declared `SortedMap`/`TreeMap`) before the fallback can run | the exact lookup is guarded, catching only `ClassCastException`, then resolution continues with the typed-key scan |
| R1-3 | an exact String key mapped to `null` was treated as absent and shadowed by a numeric key | fall back only when `map.containsKey(name)` is false |
| R1-2 | `Integer.parseInt` aborted the whole evaluation for a segment outside the 32-bit range | parse once as `long` outside the loop and derive the `Integer` candidate only when it is in range; a segment beyond `long` matches nothing instead of throwing |

R1-3, and part of R1-2, were **pre-existing on `main`** for `Long`/`Enum` keys rather than introduced by this PR — for example `JSONPath.eval(map, "$.99999999999999999999")` throws on `main` today when the map has a `Long` key. Since the change touches this exact code, they are fixed here rather than left behind.

Side effect: `JSONPathSegmentName#eval` shrank from 949 to 726 bytes of bytecode, since the entrySet scan no longer sits inside the hot method.

### Write side: derive the ref path lazily (R1-5)

`strKey` was computed at the top of the loop body, ahead of the primitive-value fast paths that all `continue` without reading it — so a `Map<Long, Long>` allocated one immediately-garbage String per entry even with reference detection disabled.

`writeMapKey` is now **byte-for-byte identical to `main`**, and the path String is derived inside the reference-detection branch, matching what the JSONB branch in this same file already does. With reference detection off the cost is two `instanceof` checks and zero allocation; with it on, `toString()` runs only for the entries that actually get a path pushed onto the stack.

### Verification

- `mvn clean test -pl core` — **7984 tests, 0 failures, 0 errors**
- `mvn validate -pl core` — checkstyle passes
- `RefTest8` grew from 4 to **10** tests: `SortedMap` round trips for Long and Integer keys, root `Map<Integer,V>` / `Map<Long,V>` round trips asserting the exact `$ref` path and `assertSame`, exact-null String key semantics on both evaluators, and ordered mixed Integer/Long keys including a segment beyond `long`
- Each guard was removed one at a time and the matching test confirmed to turn red (4/4)

<details><summary>中文说明</summary>

第一轮评审指出：写端的修复放开了一类读端从未被压测过的 `$ref` 路径形态——路径段是裸数字、且指向一个 key 不是 String 的 Map。共报告 4 处读端缺口和 1 处热路径分配，全部已在 `5425ac9`、`f3fe7d2`、`ca816ee` 中处理。复现细节见各条评审线程，摘要如下。

### 读端：用一份共享查找替换两份拷贝

R1-1 的根因是结构性的。`JSONPathSegmentName` 和 `JSONPathSingleName` 各自持有一份几乎相同的「String 段名 → 类型化 map key」兜底逻辑，改一份对另一份不可见——而单段路径（`$.1`）恰恰由那份从未更新的拷贝求值，根级 map 产生的正是单段路径。

现在两者都委托给同一个 `JSONPathSegmentName#getMapValue`，其余三个缺陷在其中一并修复：

| 问题 | 现象 | 修法 |
| --- | --- | --- |
| R1-1 | 根级 `Map<Integer, V>` 的引用 `$.1` 解析为 null | `JSONPathSingleName#eval` 委托给共享 helper，删除重复实现 |
| R1-4 | 比较型 Map（声明为 `SortedMap`/`TreeMap`）上 `map.get(name)` 抛 `ClassCastException`，兜底逻辑根本跑不到 | 保护精确查询，只捕获 `ClassCastException`，之后继续执行类型化 key 扫描 |
| R1-3 | 精确 String key 映射到 `null` 时被当作不存在，被数值 key 遮蔽 | 仅当 `map.containsKey(name)` 为 false 时才降级 |
| R1-2 | 超出 32 位范围的路径段上 `Integer.parseInt` 中断整个求值 | 循环外用 `long` 解析一次，只在 int 范围内构造 `Integer` 候选；超出 `long` 范围的段不匹配任何 key 而非抛异常 |

其中 R1-3 与 R1-2 的一部分在 `main` 上对 `Long`/`Enum` key **本就存在**，并非本 PR 引入——例如 map 含 `Long` key 时，`JSONPath.eval(map, "$.99999999999999999999")` 在 `main` 上今天就会抛异常。既然改动正好落在这段代码上，就在这里一并修掉而不是留在原地。

附带效果：`JSONPathSegmentName#eval` 的字节码从 949 字节降到 726 字节，entrySet 扫描不再位于这个热方法内部。

### 写端：路径字符串改为惰性求值（R1-5）

`strKey` 原先在循环体开头求值，位于那些全部 `continue` 掉、从不读取它的 primitive value 快速路径之前——因此 `Map<Long, Long>` 即使关闭引用检测，每个 entry 也会分配一个立即变成垃圾的 String。

现在 `writeMapKey` 与 `main` **逐字节一致**，路径字符串改在引用检测分支内部求值，与本文件 JSONB 分支已有的写法保持一致。关闭引用检测时的代价是两次 `instanceof`、零分配；开启时 `toString()` 只对真正会被压入路径栈的 entry 执行。

### 验证

- `mvn clean test -pl core` —— **7984 个测试，0 失败 0 错误**
- `mvn validate -pl core` —— checkstyle 通过
- `RefTest8` 从 4 个测试扩充到 **10** 个：Long/Integer key 的 `SortedMap` 往返、根级 `Map<Integer,V>` / `Map<Long,V>` 往返（断言精确 `$ref` 路径与 `assertSame`）、两个 evaluator 上精确 null String key 的语义、以及含超出 `long` 范围段的有序 Integer/Long 混合 key
- 每个保护逻辑均单独移除并确认对应测试变红（4/4）

</details>
