### PR TITLE
fix: use BigDecimal.valueOf for Double and Float values in getBigDecimal

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -748,7 +748,7 @@ public class JSONArray
 
             if (value instanceof Float) {
                 float floatValue = (Float) value;
-                return BigDecimal.valueOf(floatValue);
+                return new BigDecimal(Float.toString(floatValue));
             }
 
             if (value instanceof Double) {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONArray.java
@@ -748,12 +748,12 @@ public class JSONArray
 
             if (value instanceof Float) {
                 float floatValue = (Float) value;
-                return toBigDecimal(floatValue);
+                return BigDecimal.valueOf(floatValue);
             }
 
             if (value instanceof Double) {
                 double doubleValue = (Double) value;
-                return toBigDecimal(doubleValue);
+                return BigDecimal.valueOf(doubleValue);
             }
 
             long longValue = ((Number) value).longValue();

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -914,12 +914,12 @@ public class JSONObject
 
             if (value instanceof Float) {
                 float floatValue = (Float) value;
-                return toBigDecimal(floatValue);
+                return BigDecimal.valueOf(floatValue);
             }
 
             if (value instanceof Double) {
                 double doubleValue = (Double) value;
-                return toBigDecimal(doubleValue);
+                return BigDecimal.valueOf(doubleValue);
             }
 
             long longValue = ((Number) value).longValue();

--- a/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONObject.java
@@ -914,7 +914,7 @@ public class JSONObject
 
             if (value instanceof Float) {
                 float floatValue = (Float) value;
-                return BigDecimal.valueOf(floatValue);
+                return new BigDecimal(Float.toString(floatValue));
             }
 
             if (value instanceof Double) {

--- a/core/src/test/java/com/alibaba/fastjson2/types/JSONObjectTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/types/JSONObjectTest.java
@@ -1508,4 +1508,18 @@ public class JSONObjectTest {
         LocalDateTime resultWithDefault = jsonObject.getLocalDateTime("nullValue", defaultDateTime);
         assertEquals(defaultDateTime, resultWithDefault);
     }
+
+    @Test
+    public void testGetBigDecimalPrecision() {
+        JSONObject value = new JSONObject().fluentPut("value", 0.00054797);
+        java.math.BigDecimal result = value.getBigDecimal("value");
+        assertEquals(new java.math.BigDecimal("0.00054797"), result);
+    }
+    
+    @Test
+    public void testGetBigDecimalPrecisionFloat() {
+        JSONObject value = new JSONObject().fluentPut("value", 0.00054797f);
+        java.math.BigDecimal result = value.getBigDecimal("value");
+        assertEquals(new java.math.BigDecimal("0.00054797"), result);
+    }
 }


### PR DESCRIPTION
Closes #7794.

## Problem
`JSONObject().fluentPut("value", 0.00054797).getBigDecimal("value")` returns `0.0005479699999999999` instead of `0.00054797`.

## Root cause
`JSONObject.getBigDecimal(String)` and `JSONArray.getBigDecimal(int)` call `TypeUtils.toBigDecimal(double)` for Double values, which uses the custom `NumberUtils.writeDouble` → `parseBigDecimal` path. The custom `writeDouble` implementation does not guarantee the same rounding as the JDK's shortest-representation algorithm, so `0.00054797` becomes `0.0005479699999999999`.

## Fix
- **Double values**: `return BigDecimal.valueOf(doubleValue)` — `BigDecimal.valueOf(double)` internally uses `Double.toString(double)`, which the JDK guarantees to produce the shortest representation that can reconstruct the original value.
- **Float values**: `return new BigDecimal(Float.toString(floatValue))` — same rationale; `BigDecimal.valueOf(float)` would widen to `double` and lose the float's own short representation (verified: `BigDecimal.valueOf(0.00054797f)` yields `0.0005479700048454106`).

## Verification
```java
JSONObject value = new JSONObject().fluentPut("value", 0.00054797);
System.out.println(value.getBigDecimal("value"));
// Before: 0.0005479699999999999
// After:  0.00054797
```

Added regression tests `testGetBigDecimalPrecision` and `testGetBigDecimalPrecisionFloat` in `JSONObjectTest`. Both pass with the fix and fail without it.