### PR TITLE
fix: make int overflow handling consistent across equivalent JSON numbers

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -1955,7 +1955,9 @@ public abstract class JSONReader
                 Number number = getNumber();
                 if (number instanceof Long) {
                     long longValue = number.longValue();
-                    if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+                    if ((longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE)
+                            && (context.features & Feature.NonErrorOnNumberOverflow.mask) == 0
+                    ) {
                         throw new JSONException(info("integer overflow " + longValue));
                     }
                     return (int) longValue;
@@ -1972,8 +1974,17 @@ public abstract class JSONReader
                     }
                 }
                 return number.intValue();
-            case JSON_TYPE_DEC:
-                return getNumber().intValue();
+            case JSON_TYPE_DEC: {
+                BigDecimal decimal = getBigDecimal();
+                if ((context.features & Feature.NonErrorOnNumberOverflow.mask) != 0) {
+                    return decimal.intValue();
+                }
+                try {
+                    return decimal.toBigInteger().intValueExact();
+                } catch (ArithmeticException e) {
+                    throw numberError();
+                }
+            }
             case JSON_TYPE_BOOL:
                 return boolValue ? 1 : 0;
             case JSON_TYPE_NULL:

--- a/core/src/test/java/com/alibaba/fastjson2/JSONReaderInt32Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONReaderInt32Test.java
@@ -1,0 +1,49 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JSONReaderInt32Test {
+    @Test
+    public void decimalOverflow() {
+        for (String value : new String[]{
+                "10000000000",
+                "10000000000.0",
+                "10000000000.00",
+                "1e10",
+                "1E10",
+                "1.0e10",
+                "100e8",
+                "0.1e11"
+        }) {
+            String json = "{\"count\":" + value + "}";
+            assertThrows(JSONException.class, () -> JSON.parseObject(json, Bean.class), value);
+            assertThrows(JSONException.class, () -> JSON.parseObject(json.toCharArray(), Bean.class), value);
+            assertThrows(
+                    JSONException.class,
+                    () -> JSON.parseObject(json.getBytes(StandardCharsets.UTF_8), Bean.class),
+                    value
+            );
+
+            Bean bean = JSON.parseObject(json, Bean.class, JSONReader.Feature.NonErrorOnNumberOverflow);
+            assertEquals(new BigDecimal(value).intValue(), bean.count, value);
+        }
+    }
+
+    @Test
+    public void decimalFractionWithinRange() {
+        assertEquals(1, JSON.parseObject("{\"count\":1.9}", Bean.class).count);
+        assertEquals(-1, JSON.parseObject("{\"count\":-1.9}", Bean.class).count);
+        assertEquals(Integer.MAX_VALUE, JSON.parseObject("{\"count\":2147483647.9}", Bean.class).count);
+        assertEquals(Integer.MIN_VALUE, JSON.parseObject("{\"count\":-2147483648.9}", Bean.class).count);
+    }
+
+    public static class Bean {
+        public int count;
+    }
+}


### PR DESCRIPTION
Fixes #7801 

  ### What this PR does / why we need it?

  Equivalent JSON representations of the same mathematical value could previously produce different `int` results depending on their lexical form:

  - `10000000000` threw `JSONException`.
  - `10000000000.0` wrapped to `1410065408`.
  - `1e10` saturated to `2147483647`.

  This PR makes `int` overflow handling independent of the JSON number's lexical representation.

  ### Summary of your change

  - Made decimal-to-`int` conversion follow fastjson2's documented overflow policy.
  - By default, all equivalent out-of-range representations throw `JSONException`.
  - With `JSONReader.Feature.NonErrorOnNumberOverflow`, all representations use the same non-error narrowing result.
  - Preserved truncation toward zero for fractional values within the `int` range.
  - Added regression tests for String, `char[]`, and UTF-8 `byte[]` inputs.
  - Added coverage for eight equivalent representations of `10^10`.


#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
