### PR TITLE
fix: make numeric boolean coercion consistent

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -3868,6 +3868,37 @@ public abstract class JSONReader
         return boolValue;
     }
 
+    protected final boolean getBooleanValue() {
+        return (context.features & Feature.NonZeroNumberCastToBooleanAsTrue.mask) != 0
+                ? isNonZeroNumber()
+                : isOneNumber();
+    }
+
+    private boolean isNonZeroNumber() {
+        return mag0 != 0 || mag1 != 0 || mag2 != 0 || mag3 != 0;
+    }
+
+    private boolean isOneNumber() {
+        if (valueType == JSON_TYPE_INT) {
+            return isOneInt();
+        }
+
+        return isOneDecimal();
+    }
+
+    private boolean isOneInt() {
+        return mag0 == 0
+                && mag1 == 0
+                && mag2 == 0
+                && mag3 == 1;
+    }
+
+    private boolean isOneDecimal() {
+        return getBigDecimal()
+                .abs()
+                .compareTo(BigDecimal.ONE) == 0;
+    }
+
     /**
      * Reads a boolean value from JSON data as a primitive boolean.
      *

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF16.java
@@ -5471,17 +5471,7 @@ final class JSONReaderUTF16
             val = false;
         } else if (ch == '-' || (ch >= '0' && ch <= '9')) {
             readNumber();
-            if (valueType == JSON_TYPE_INT) {
-                if ((context.features & Feature.NonZeroNumberCastToBooleanAsTrue.mask) != 0) {
-                    return mag0 != 0 || mag1 != 0 || mag2 != 0 || mag3 != 0;
-                } else {
-                    return mag0 == 0
-                            && mag1 == 0
-                            && mag2 == 0
-                            && mag3 == 1;
-                }
-            }
-            return false;
+            return getBooleanValue();
         } else if (ch == 'n' && offset + 2 < chars.length
                 && chars[offset] == 'u'
                 && chars[offset + 1] == 'l'

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderUTF8.java
@@ -7569,17 +7569,7 @@ class JSONReaderUTF8
             val = false;
         } else if (ch == '-' || (ch >= '0' && ch <= '9')) {
             readNumber();
-            if (valueType == JSON_TYPE_INT) {
-                if ((context.features & Feature.NonZeroNumberCastToBooleanAsTrue.mask) != 0) {
-                    return mag0 != 0 || mag1 != 0 || mag2 != 0 || mag3 != 0;
-                } else {
-                    return mag0 == 0
-                            && mag1 == 0
-                            && mag2 == 0
-                            && mag3 == 1;
-                }
-            }
-            return false;
+            return getBooleanValue();
         } else if (ch == 'n' && offset + 2 < bytes.length
                 && bytes[offset] == 'u'
                 && bytes[offset + 1] == 'l'

--- a/core/src/test/java/com/alibaba/fastjson2/JSONReaderBooleanTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/JSONReaderBooleanTest.java
@@ -1,0 +1,97 @@
+package com.alibaba.fastjson2;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JSONReaderBooleanTest {
+    @Test
+    public void numberNotation() {
+        assertValue(true, "1");
+        assertValue(true, "1.0");
+        assertValue(true, "1.00");
+        assertValue(true, "1e0");
+        assertValue(true, "10e-1");
+        assertValue(true, "-1");
+        assertValue(true, "-1.0");
+        assertValue(false, "2");
+        assertValue(false, "2.0");
+        assertValue(false, "-2");
+        assertValue(false, "-2.0");
+        assertValue(false, "0");
+        assertValue(false, "0.0");
+        assertValue(false, "0.5");
+    }
+
+    @Test
+    public void nonZeroNumberFeature() {
+        for (String value : new String[]{"1", "1.0", "-1", "-1.0", "2", "2.0", "0.5", "-0.5"}) {
+            assertFeatureValue(true, value);
+        }
+
+        for (String value : new String[]{"0", "0.0", "0e10"}) {
+            assertFeatureValue(false, value);
+        }
+    }
+
+    @Test
+    public void stringAndNullBehavior() {
+        assertValue(true, "\"1\"");
+        assertValue(true, "\"true\"");
+        assertValue(false, "null");
+        assertThrows(JSONException.class, () -> parse("\"yes\""));
+    }
+
+    private static void assertValue(boolean expected, String value) {
+        String json = "{\"enabled\":" + value + "}";
+        assertEquals(expected, JSON.parseObject(json, Bean.class).enabled, value);
+        assertEquals(expected, JSON.parseObject(json.toCharArray(), Bean.class).enabled, value);
+        assertEquals(
+                expected,
+                JSON.parseObject(json.getBytes(StandardCharsets.UTF_8), Bean.class).enabled,
+                value
+        );
+    }
+
+    private static boolean parse(String value) {
+        return JSON.parseObject("{\"enabled\":" + value + "}", Bean.class).enabled;
+    }
+
+    private static void assertFeatureValue(boolean expected, String value) {
+        String json = "{\"enabled\":" + value + "}";
+        assertEquals(
+                expected,
+                JSON.parseObject(
+                        json,
+                        Bean.class,
+                        JSONReader.Feature.NonZeroNumberCastToBooleanAsTrue
+                ).enabled,
+                value
+        );
+        assertEquals(
+                expected,
+                JSON.parseObject(
+                        json.toCharArray(),
+                        Bean.class,
+                        JSONReader.Feature.NonZeroNumberCastToBooleanAsTrue
+                ).enabled,
+                value
+        );
+        assertEquals(
+                expected,
+                JSON.parseObject(
+                        json.getBytes(StandardCharsets.UTF_8),
+                        Bean.class,
+                        JSONReader.Feature.NonZeroNumberCastToBooleanAsTrue
+                ).enabled,
+                value
+        );
+    }
+
+    public static class Bean {
+        public boolean enabled;
+    }
+}


### PR DESCRIPTION
  ### What this PR does / why we need it?

  Fixes #7803 

  Equivalent JSON number representations currently produce different boolean
  values. For example, `1` is converted to `true`, while the mathematically
  equivalent `1.0` is silently converted to `false`.

  Decimal values also bypass
  `JSONReader.Feature.NonZeroNumberCastToBooleanAsTrue`, causing non-zero values
  such as `0.5` and `2.0` to be converted to `false`.

  ### Summary of your change

  - Centralize numeric-to-boolean conversion for UTF-16 and UTF-8 readers.
  - Preserve the existing default rule where values with an absolute value of
    one are converted to `true`.
  - Make integer, decimal, and exponent representations behave consistently.
  - Apply `NonZeroNumberCastToBooleanAsTrue` to decimal values.
  - Preserve the allocation-free integer path.
  - Add regression tests for String, char[], and UTF-8 byte[] inputs.

  #### Please indicate you've done the following:

  - [x] Made sure tests are passing and test coverage is added if needed.
  - [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
  - [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
