### PR TITLE
fix: Fix NPE when serializing Kotlin classes without kotlin-reflect on classpath

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterBaseModule.java
@@ -319,16 +319,18 @@ public class ObjectWriterBaseModule
                 Constructor kotlinConstructor = KotlinUtils.getKotlinConstructor(getConstructor(objectClass));
                 if (kotlinConstructor != null) {
                     String[] paramNames = KotlinUtils.getKoltinConstructorParameters(objectClass);
-                    for (int i = 0; i < paramNames.length; i++) {
-                        if (paramNames[i].equals(field.getName())) {
-                            annotations = kotlinConstructor.getParameterAnnotations()[i];
-                            break;
+                    if (paramNames != null) {
+                        for (int i = 0; i < paramNames.length; i++) {
+                            if (paramNames[i].equals(field.getName())) {
+                                annotations = kotlinConstructor.getParameterAnnotations()[i];
+                                break;
+                            }
                         }
-                    }
-                    if (fieldInfo.ignore) {
-                        for (Annotation annotation : annotations) {
-                            if (annotation.annotationType() == JSONField.class) {
-                                fieldInfo.ignore = !((JSONField) annotation).serialize();
+                        if (fieldInfo.ignore) {
+                            for (Annotation annotation : annotations) {
+                                if (annotation.annotationType() == JSONField.class) {
+                                    fieldInfo.ignore = !((JSONField) annotation).serialize();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### What this PR does / why we need it?

When `kotlin-reflect` is not on the classpath, serializing a Kotlin class with fastjson2 throws:

```
java.lang.NullPointerException: Cannot read the array length because "paramNames" is null
```

at `ObjectWriterBaseModule.java:322`

The call chain:

1. `ObjectWriterBaseModule` detects a Kotlin class via `@Metadata` annotation
2. Calls `KotlinUtils.getKoltinConstructorParameters()`
3. That method returns `null` when `kotlin-reflect` is absent
4. The caller does `for (int i = 0; i < paramNames.length; i++)` → **NPE**

This affects users who have `kotlin-stdlib` transitively (e.g. via RocketMQ, OkHttp) but not `kotlin-reflect`. The serialization side throws; the deserialization side already handles this correctly.


### Summary of your change

Add `if (paramNames != null)` guard around the parameter name iteration — the same pattern already used on the deserialization side (`com.alibaba.fastjson.util.TypeUtils.java:751`). When `kotlin-reflect` is missing, the code now gracefully skips the Kotlin-specific parameter annotation lookup and falls back to standard Java reflection.

#### Please indicate you've done the following:

- [X] Made sure tests are passing and test coverage is added if needed.
- [X] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [X] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.
