### PR TITLE
fix: ArrayIndexOutOfBoundsException in JSONReaderASCII field-name decoding, for issue #7808

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderASCII.java
@@ -825,9 +825,10 @@ final class JSONReaderASCII
         }
 
         if (JDKUtils.STRING_CREATOR_JDK11 != null) {
-            byte[] chars = new byte[nameLength];
+            byte[] chars = new byte[nameEnd - nameBegin];
+            int i = 0;
             forStmt:
-            for (int i = 0, end = this.end; offset < nameEnd; ++i) {
+            for (int end = this.end; offset < nameEnd; ++i) {
                 byte b = bytes[offset];
 
                 if (b == '\\') {
@@ -878,7 +879,12 @@ final class JSONReaderASCII
             }
 
             if (chars != null) {
-                return STRING_CREATOR_JDK11.apply(chars, LATIN1);
+                // nameLength is computed by the inherited (UTF-8-decoding)
+                // readFieldNameHashCode0(), which counts *characters*; this loop
+                // walks the buffer as latin1 *bytes*, so nameLength can undercount
+                // the byte span and overflow a nameLength-sized buffer (gh-7808).
+                // Size from the byte span instead and trim to what was written.
+                return STRING_CREATOR_JDK11.apply(i == chars.length ? chars : Arrays.copyOf(chars, i), LATIN1);
             }
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7808.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7808.java
@@ -1,0 +1,93 @@
+package com.alibaba.fastjson2.issues_7800;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("regression")
+class Issue7808 {
+    // JSON source text for the field name: a backslash+t escape (2 source chars,
+    // unescaped by the parser to one TAB) followed by 3 raw latin1 bytes
+    // (E0 AA AE) that the inherited UTF-8 field-name decoder misreads as a single
+    // 3-byte character, undercounting nameLength against the actual byte span.
+    // See gh-7808.
+    private static final String KEY_SOURCE = "\\t\u00e0\u00aa\u00ae";
+    // The field name after JSON unescaping: TAB + the 3 latin1 characters.
+    private static final String KEY_PARSED = "\t\u00e0\u00aa\u00ae";
+
+    @Test
+    public void fieldNameWithEscapeAndNonAsciiInsideArray_doesNotThrow() {
+        String json = "[{\"" + KEY_SOURCE + "\":1}]";
+
+        JSONArray array = assertDoesNotThrow(() -> JSON.parseArray(json));
+        JSONObject obj = array.getJSONObject(0);
+        assertEquals(1, obj.size());
+        assertEquals(1, obj.getIntValue(KEY_PARSED));
+    }
+
+    @Test
+    public void nonAsciiWithoutEscape_stillParses() {
+        // Control: same non-ASCII bytes, no escape -- takes the byte-count fast path.
+        String json = "[{\"a\u00e0\u00aa\u00ae\":1}]";
+        JSONObject obj = JSON.parseArray(json).getJSONObject(0);
+        assertEquals(1, obj.getIntValue("a\u00e0\u00aa\u00ae"));
+    }
+
+    @Test
+    public void escapeWithoutNonAscii_stillParses() {
+        // Control: escape present, but no byte >= 0x80 -- nameLength was already correct.
+        String json = "[{\"\\tabc\":1}]";
+        JSONObject obj = JSON.parseArray(json).getJSONObject(0);
+        assertEquals(1, obj.getIntValue("\tabc"));
+    }
+
+    @Test
+    public void sameFieldNameAtTopLevel_stillParses() {
+        // Control: not inside an array -- doesn't route through ObjectReaderImplObject.
+        String json = "{\"" + KEY_SOURCE + "\":1}";
+        JSONObject obj = JSON.parseObject(json);
+        assertEquals(1, obj.getIntValue(KEY_PARSED));
+    }
+
+    @Test
+    public void multipleObjectsInArray_stillParse() {
+        JSONArray array = JSON.parseArray("[{\"a\":1},{\"b\":2}]");
+        assertEquals(1, array.getJSONObject(0).getIntValue("a"));
+        assertEquals(2, array.getJSONObject(1).getIntValue("b"));
+    }
+
+    @Test
+    public void unicodeEscapedFieldName_stillParses() {
+        JSONObject obj = JSON.parseArray("[{\"\\u00e9\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("\u00e9"));
+    }
+
+    @Test
+    public void backslashEscapedFieldName_stillParses() {
+        JSONObject obj = JSON.parseArray("[{\"a\\\\b\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("a\\b"));
+    }
+
+    @Test
+    public void quoteEscapedFieldName_stillParses() {
+        JSONObject obj = JSON.parseArray("[{\"a\\\"b\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("a\"b"));
+    }
+
+    @Test
+    public void emptyFieldName_stillParses() {
+        JSONObject obj = JSON.parseArray("[{\"\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue(""));
+    }
+
+    @Test
+    public void controlCharacterEscapes_stillParse() {
+        JSONObject obj = JSON.parseArray("[{\"\\n\\t\\r\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("\n\t\r"));
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes a crash (`ArrayIndexOutOfBoundsException`) that valid JSON can trigger when a field name inside an array-nested object combines a backslash escape with a byte >= 0x80. `JSONReaderASCII.getFieldName()` sizes its output buffer from `nameLength`, but `nameLength` is computed by the inherited (UTF-8-decoding) `readFieldNameHashCode0()`, which counts *characters*, while `getFieldName()` walks the same span as latin1 *bytes* -- so `nameLength` can undercount the actual byte span and overflow the buffer.

### Summary of your change

- `JSONReaderASCII.getFieldName()`: size the byte[] buffer from the byte span (`nameEnd - nameBegin`) instead of `nameLength`, and trim to what was actually written (escapes only ever shrink the output).
- Added an `Issue7808` regression test: reproduces the crash and covers the surrounding escape/non-ASCII/array-nesting combinations that must keep parsing correctly.

Note for maintainers: the same `nameLength`-sized buffer is reused a few lines below as a `char[]` fallback (used when `STRING_CREATOR_JDK11` is unavailable, e.g. on JDK 8) and has the identical bug, but I can't reach that code path on this machine to verify a fix for it, so I left it untouched rather than ship something unverified.

Fixes #7808

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. (N/A -- internal parser bug fix, no user-facing API/behavior change beyond no longer crashing)

<details>
<summary>中文</summary>

### 这个 PR 做了什么 / 为什么需要它？

修复了一个崩溃问题（`ArrayIndexOutOfBoundsException`）：当数组内嵌对象的字段名同时包含反斜杠转义符和一个 >= 0x80 的字节时，合法的 JSON 也会触发该崩溃。`JSONReaderASCII.getFieldName()` 根据 `nameLength` 分配输出缓冲区，但 `nameLength` 是由继承自父类的（按 UTF-8 解码的）`readFieldNameHashCode0()` 计算的，它统计的是"字符数"，而 `getFieldName()` 却把同一段数据当作 latin1 "字节"来遍历——因此 `nameLength` 可能低估实际字节跨度，导致缓冲区越界。

### 变更摘要

- `JSONReaderASCII.getFieldName()`：将 byte[] 缓冲区的大小改为按字节跨度（`nameEnd - nameBegin`）分配，而不是按 `nameLength`，并裁剪为实际写入的长度（转义序列只会使输出变短）。
- 新增 `Issue7808` 回归测试：复现了该崩溃，并覆盖了转义/非 ASCII/数组嵌套等相关组合场景，确保它们仍能正确解析。

给维护者的提示：下方几行代码中还有一个用同样的 `nameLength` 分配大小的 `char[]` 兜底缓冲区（仅在 `STRING_CREATOR_JDK11` 不可用时使用，例如 JDK 8），存在相同的缺陷，但我在本机环境下无法触发并验证该代码路径，因此没有一并修改，以免提交未经验证的改动。

Fixes #7808

#### 请确认您已完成以下事项：

- [x] 确保测试通过，并在需要时添加了测试覆盖。
- [x] 确保提交信息遵循 [Conventional Commits 规范](https://www.conventionalcommits.org/)。
- [ ] 考虑了文档影响，如有需要已提交新的文档 issue 或 PR。（不适用——这是内部解析器的 bug 修复，除了不再崩溃之外，没有面向用户的 API/行为变化）

</details>
