### PR TITLE
2.0.65.android5: port security fix and guards from main (#7753)

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64.android5</version>
+        <version>2.0.65.android5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/codegen-test/pom.xml
+++ b/codegen-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64.android5</version>
+        <version>2.0.65.android5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.alibaba.fastjson2</groupId>
         <artifactId>fastjson2-parent</artifactId>
-        <version>2.0.64.android5</version>
+        <version>2.0.65.android5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReader.java
@@ -3535,6 +3535,14 @@ public abstract class JSONReader
             return provider;
         }
 
+        /**
+         * Returns an ObjectReader for the specified type hash code, or null if not found.
+         *
+         * @param hashCode The hash code of the type
+         * @return An ObjectReader for the specified type hash code, or null if not found
+         * @deprecated a hash hit is not an AutoType authorization; resolve by type name instead
+         */
+        @Deprecated
         public ObjectReader getObjectReaderAutoType(long hashCode) {
             return provider.getObjectReader(hashCode);
         }
@@ -4103,21 +4111,7 @@ public abstract class JSONReader
     }
 
     public ObjectReader getObjectReaderAutoType(long typeHash, Class expectClass, long features) {
-        ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
-        if (autoTypeObjectReader != null) {
-            return autoTypeObjectReader;
-        }
-
-        String typeName = getString();
-        if (context.autoTypeBeforeHandler != null) {
-            Class<?> autoTypeClass = context.autoTypeBeforeHandler.apply(typeName, expectClass, features);
-            if (autoTypeClass != null) {
-                boolean fieldBased = (features & Feature.FieldBased.mask) != 0;
-                return context.provider.getObjectReader(autoTypeClass, fieldBased);
-            }
-        }
-
-        return context.provider.getObjectReader(typeName, expectClass, context.features | features);
+        return context.getObjectReaderAutoType(getString(), expectClass, context.features | features);
     }
 
     public Byte readInt8() {

--- a/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
+++ b/core/src/main/java/com/alibaba/fastjson2/JSONReaderJSONB.java
@@ -747,15 +747,11 @@ final class JSONReaderJSONB
                 );
             }
             case BC_TYPED_ANY: {
-                long typeHash = readTypeHashCode();
+                readTypeHashCode();
 
                 if (context.autoTypeBeforeHandler != null) {
-                    Class<?> filterClass = context.autoTypeBeforeHandler.apply(typeHash, null, context.features);
-
-                    if (filterClass == null) {
-                        String typeName = getString();
-                        filterClass = context.autoTypeBeforeHandler.apply(typeName, null, context.features);
-                    }
+                    String typeName = getString();
+                    Class<?> filterClass = context.autoTypeBeforeHandler.apply(typeName, null, context.features);
 
                     if (filterClass != null) {
                         ObjectReader autoTypeObjectReader = context.getObjectReader(filterClass);
@@ -776,14 +772,10 @@ final class JSONReaderJSONB
                     throw new JSONException("autoType not support , offset " + offset + "/" + bytes.length);
                 }
 
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException("autoType not support : " + typeName + ", offset " + offset + "/" + bytes.length);
-                    }
+                    throw new JSONException("autoType not support : " + typeName + ", offset " + offset + "/" + bytes.length);
                 }
                 return autoTypeObjectReader.readJSONBObject(this, null, null, 0);
             }
@@ -809,15 +801,11 @@ final class JSONReaderJSONB
                         long hash = readFieldNameHashCode();
 
                         if (hash == ObjectReader.HASH_TYPE) {
-                            long typeHash = readValueHashCode();
-                            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                            readValueHashCode();
+                            String typeName = getString();
+                            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                             if (autoTypeObjectReader == null) {
-                                String typeName = getString();
-                                autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                                if (autoTypeObjectReader == null) {
-                                    throw new JSONException("auotype not support : " + typeName + ", offset " + offset + "/" + bytes.length);
-                                }
+                                throw new JSONException("auotype not support : " + typeName + ", offset " + offset + "/" + bytes.length);
                             }
 
                             typeRedirect = true;
@@ -1197,10 +1185,7 @@ final class JSONReaderJSONB
 
             AutoTypeBeforeHandler autoTypeBeforeHandler = context.autoTypeBeforeHandler;
             if (autoTypeBeforeHandler != null) {
-                Class<?> objectClass = autoTypeBeforeHandler.apply(typeHash, expectClass, features);
-                if (objectClass == null) {
-                    objectClass = autoTypeBeforeHandler.apply(getString(), expectClass, features);
-                }
+                Class<?> objectClass = autoTypeBeforeHandler.apply(getString(), expectClass, features);
                 if (objectClass != null) {
                     ObjectReader objectReader = context.getObjectReader(objectClass);
                     if (objectReader != null) {
@@ -1217,26 +1202,9 @@ final class JSONReaderJSONB
                 autoTypeError();
             }
 
-            autoTypeObjectReader = provider.getObjectReader(typeHash);
-
-            if (autoTypeObjectReader != null) {
-                Class objectClass = autoTypeObjectReader.getObjectClass();
-                if (objectClass != null) {
-                    ClassLoader classLoader = objectClass.getClassLoader();
-                    if (classLoader != null) {
-                        ClassLoader tcl = Thread.currentThread().getContextClassLoader();
-                        if (classLoader != tcl) {
-                            autoTypeObjectReader = getObjectReaderContext(autoTypeObjectReader, objectClass, tcl);
-                        }
-                    }
-                }
-            }
-
+            autoTypeObjectReader = provider.getObjectReader(getString(), expectClass, features2);
             if (autoTypeObjectReader == null) {
-                autoTypeObjectReader = provider.getObjectReader(getString(), expectClass, features2);
-                if (autoTypeObjectReader == null) {
-                    autoTypeError();
-                }
+                autoTypeError();
             }
 
             this.type = bytes[offset];

--- a/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/FieldReaderList.java
@@ -214,16 +214,13 @@ public class FieldReaderList<T, V>
     @Override
     public ObjectReader checkObjectAutoType(JSONReader jsonReader) {
         if (jsonReader.nextIfMatch(JSONB.Constants.BC_TYPED_ANY)) {
-            long typeHash = jsonReader.readTypeHashCode();
+            jsonReader.readTypeHashCode();
             final long features = jsonReader.features(this.features);
             JSONReader.Context context = jsonReader.context;
             JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
+            String typeName = jsonReader.getString();
             if (autoTypeFilter != null) {
-                Class<?> filterClass = autoTypeFilter.apply(typeHash, fieldClass, features);
-                if (filterClass == null) {
-                    String typeName = jsonReader.getString();
-                    filterClass = autoTypeFilter.apply(typeName, fieldClass, features);
-                }
+                Class<?> filterClass = autoTypeFilter.apply(typeName, fieldClass, features);
                 if (filterClass != null) {
                     return context.getObjectReader(fieldClass);
                 }
@@ -238,7 +235,7 @@ public class FieldReaderList<T, V>
                 throw new JSONException(jsonReader.info("autoType not support input " + jsonReader.getString()));
             }
 
-            ObjectReader autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, fieldClass, features);
+            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, fieldClass, features);
 
             if (autoTypeObjectReader instanceof ObjectReaderImplList) {
                 ObjectReaderImplList listReader = (ObjectReaderImplList) autoTypeObjectReader;

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectArrayTypedReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectArrayTypedReader.java
@@ -88,9 +88,11 @@ final class ObjectArrayTypedReader
                 // skip
             } else {
                 if (jsonReader.isSupportAutoType(features)) {
-                    ObjectReader autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, objectClass, features);
+                    String typeName = jsonReader.getString();
+                    ObjectReader autoTypeObjectReader = jsonReader.getContext()
+                            .getObjectReaderAutoType(typeName, objectClass, features);
                     if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("auotype not support : " + jsonReader.getString()));
+                        throw new JSONException(jsonReader.info("auotype not support : " + typeName));
                     }
 
                     return autoTypeObjectReader.readObject(jsonReader, fieldType, fieldName, features);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader.java
@@ -73,11 +73,7 @@ public interface ObjectReader<T> {
 
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
-            ObjectReader<T> reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0 || this instanceof ObjectReaderSeeAlso) {
-                reader = autoType(provider, typeHash);
-            }
+            ObjectReader<T> reader = autoType(provider, Fnv.hashCode64(typeName));
 
             if (reader == null) {
                 reader = provider.getObjectReader(
@@ -181,11 +177,11 @@ public interface ObjectReader<T> {
     }
 
     default ObjectReader autoType(JSONReader.Context context, long typeHash) {
-        return context.getObjectReaderAutoType(typeHash);
+        return null;
     }
 
     default ObjectReader autoType(ObjectReaderProvider provider, long typeHash) {
-        return provider.getObjectReader(typeHash);
+        return null;
     }
 
     /**
@@ -208,17 +204,13 @@ public interface ObjectReader<T> {
             long hash = jsonReader.readFieldNameHashCode();
 
             if (hash == getTypeKeyHash() && i == 0) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader reader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader reader = context.getObjectReaderAutoType(typeName, null);
 
                 if (reader == null) {
-                    String typeName = jsonReader.getString();
-                    reader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (reader == null) {
-                        throw new JSONException(jsonReader.info("No suitable ObjectReader found for" + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("No suitable ObjectReader found for" + typeName));
                 }
 
                 if (reader == this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader1.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader1.java
@@ -131,16 +131,12 @@ public class ObjectReader1<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (hashCode == getTypeKeyHash() && i == 0) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("auotype not support : " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("auotype not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -233,16 +229,12 @@ public class ObjectReader1<T>
 
             long hashCode = jsonReader.readFieldNameHashCode();
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader2.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader2.java
@@ -239,16 +239,12 @@ public class ObjectReader2<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader3.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader3.java
@@ -261,16 +261,12 @@ public class ObjectReader3<T>
             }
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader4.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader4.java
@@ -281,16 +281,12 @@ public class ObjectReader4<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader5.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader5.java
@@ -320,16 +320,12 @@ public class ObjectReader5<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader6.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReader6.java
@@ -315,16 +315,12 @@ public class ObjectReader6<T>
             long hashCode = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hashCode == HASH_TYPE) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                    if (autoTypeObjectReader == null) {
-                        continue;
-                    }
+                    continue;
                 }
 
                 if (autoTypeObjectReader != this) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderAdapter.java
@@ -211,16 +211,14 @@ public class ObjectReaderAdapter<T>
     }
 
     public Object autoType(JSONReader jsonReader, Class expectClass, long features) {
-        long typeHash = jsonReader.readTypeHashCode();
+        jsonReader.readTypeHashCode();
         JSONReader.Context context = jsonReader.context;
+        long featuresAll = this.features | features | context.features;
 
         ObjectReader autoTypeObjectReader = null;
-        if (jsonReader.isSupportAutoTypeOrHandler(features)) {
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
-        }
-        if (autoTypeObjectReader == null) {
+        if (jsonReader.isSupportAutoTypeOrHandler(featuresAll)) {
             String typeName = jsonReader.getString();
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, this.features | features | context.features);
+            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, featuresAll);
 
             if (autoTypeObjectReader == null) {
                 if (expectClass == objectClass) {
@@ -229,6 +227,10 @@ public class ObjectReaderAdapter<T>
                     throw new JSONException(jsonReader.info("auotype not support : " + typeName));
                 }
             }
+        }
+
+        if (autoTypeObjectReader == null) {
+            throw new JSONException(jsonReader.info("autoType not support"));
         }
 
         return autoTypeObjectReader.readObject(jsonReader, null, null, features);
@@ -412,16 +414,12 @@ public class ObjectReaderAdapter<T>
     }
 
     protected T autoType(JSONReader jsonReader) {
-        long typeHash = jsonReader.readTypeHashCode();
+        jsonReader.readTypeHashCode();
         JSONReader.Context context = jsonReader.context;
-        ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+        String typeName = jsonReader.getString();
+        ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
         if (autoTypeObjectReader == null) {
-            String typeName = jsonReader.getString();
-            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-            if (autoTypeObjectReader == null) {
-                throw new JSONException(jsonReader.info("auotype not support : " + typeName));
-            }
+            throw new JSONException(jsonReader.info("auotype not support : " + typeName));
         }
 
         return (T) autoTypeObjectReader.readJSONBObject(jsonReader, null, null, features);
@@ -460,16 +458,12 @@ public class ObjectReaderAdapter<T>
 
             long hash = jsonReader.readFieldNameHashCode();
             if (hash == typeKeyHashCode && i == 0) {
-                long typeHash = jsonReader.readValueHashCode();
+                jsonReader.readValueHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("auotype not support : " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("auotype not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -518,7 +512,7 @@ public class ObjectReaderAdapter<T>
             return provider.getObjectReader(seeAlsoClass);
         }
 
-        return provider.getObjectReader(typeHash);
+        return null;
     }
 
     @Override
@@ -532,7 +526,7 @@ public class ObjectReaderAdapter<T>
             return context.getObjectReader(seeAlsoClass);
         }
 
-        return context.getObjectReaderAutoType(typeHash);
+        return null;
     }
 
     protected void initStringFieldAsEmpty(Object object) {
@@ -551,10 +545,12 @@ public class ObjectReaderAdapter<T>
         long features2 = features | this.features | JSONFactory.getDefaultReaderFeatures();
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
             ObjectReader<T> reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0 || this instanceof ObjectReaderSeeAlso) {
-                reader = autoType(provider, typeHash);
+            if (seeAlsoMapping != null && seeAlsoMapping.size() > 0) {
+                Class seeAlsoClass = seeAlsoMapping.get(Fnv.hashCode64(typeName));
+                if (seeAlsoClass != null) {
+                    reader = provider.getObjectReader(seeAlsoClass);
+                }
             }
 
             if (reader == null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderBean.java
@@ -171,29 +171,26 @@ public abstract class ObjectReaderBean<T>
 
     public final ObjectReader checkAutoType(JSONReader jsonReader, Class expectClass, long features) {
         if (jsonReader.nextIfMatchTypedAny()) {
-            long typeHash = jsonReader.readTypeHashCode();
+            jsonReader.readTypeHashCode();
             JSONReader.Context context = jsonReader.context;
             long features3 = jsonReader.features(features | this.features);
             JSONReader.AutoTypeBeforeHandler autoTypeFilter = context.getContextAutoTypeBeforeHandler();
+            String typeName = jsonReader.getString();
             if (autoTypeFilter != null) {
-                Class<?> filterClass = autoTypeFilter.apply(typeHash, expectClass, features);
-                if (filterClass == null) {
-                    String typeName = jsonReader.getString();
-                    filterClass = autoTypeFilter.apply(typeName, expectClass, features);
+                Class<?> filterClass = autoTypeFilter.apply(typeName, expectClass, features);
 
-                    if (filterClass != null && !expectClass.isAssignableFrom(filterClass)) {
-                        if ((jsonReader.features(features) & IgnoreAutoTypeNotMatch.mask) == 0) {
-                            throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());
-                        }
-
-                        filterClass = expectClass;
+                if (filterClass != null && !expectClass.isAssignableFrom(filterClass)) {
+                    if ((jsonReader.features(features) & IgnoreAutoTypeNotMatch.mask) == 0) {
+                        throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());
                     }
+
+                    filterClass = expectClass;
                 }
 
                 return context.getObjectReader(filterClass);
             }
 
-            ObjectReader autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, expectClass, features);
+            ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, expectClass, features3);
 
             if (autoTypeObjectReader == null) {
                 throw new JSONException(jsonReader.info("auotype not support"));
@@ -207,10 +204,10 @@ public abstract class ObjectReaderBean<T>
                     return context.getObjectReader(expectClass);
                 }
 
-                throw new JSONException("type not match. " + typeName + " -> " + expectClass.getName());
+                throw new JSONException("type not match. " + this.typeName + " -> " + expectClass.getName());
             }
 
-            if (typeHash == this.getTypeNameHash()) {
+            if (Fnv.hashCode64(typeName) == this.getTypeNameHash()) {
                 return this;
             }
 
@@ -319,24 +316,16 @@ public abstract class ObjectReaderBean<T>
             ) {
                 ObjectReader reader = null;
 
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
+                String typeName = jsonReader.getString();
                 if (autoTypeFilter != null) {
-                    Class<?> filterClass = autoTypeFilter.apply(typeHash, objectClass, features3);
-                    if (filterClass == null) {
-                        filterClass = autoTypeFilter.apply(jsonReader.getString(), objectClass, features3);
-                        if (filterClass != null) {
-                            reader = context.getObjectReader(filterClass);
-                        }
+                    Class<?> filterClass = autoTypeFilter.apply(typeName, objectClass, features3);
+                    if (filterClass != null) {
+                        reader = context.getObjectReader(filterClass);
                     }
                 }
 
                 if (reader == null) {
-                    reader = autoType(context, typeHash);
-                }
-
-                String typeName = null;
-                if (reader == null) {
-                    typeName = jsonReader.getString();
                     reader = context.getObjectReaderAutoType(
                             typeName, objectClass, features3
                     );

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderException.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderException.java
@@ -154,17 +154,12 @@ final class ObjectReaderException<T>
             long hash = jsonReader.readFieldNameHashCode();
 
             if (i == 0 && hash == HASH_TYPE && jsonReader.isSupportAutoType(features)) {
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader reader = autoType(context, typeHash);
-                String typeName = null;
+                String typeName = jsonReader.getString();
+                ObjectReader reader = context.getObjectReaderAutoType(typeName, objectClass, features);
                 if (reader == null) {
-                    typeName = jsonReader.getString();
-                    reader = context.getObjectReaderAutoType(typeName, objectClass, features);
-
-                    if (reader == null) {
-                        throw new JSONException(jsonReader.info("No suitable ObjectReader found for" + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("No suitable ObjectReader found for" + typeName));
                 }
 
                 if (reader == this) {
@@ -341,16 +336,12 @@ final class ObjectReaderException<T>
 
             if (jsonReader.isSupportAutoType(features) || context.getContextAutoTypeBeforeHandler() != null) {
                 jsonReader.next();
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
 
-                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException("autoType not support : " + typeName + ", offset " + jsonReader.getOffset());
-                    }
+                    throw new JSONException("autoType not support : " + typeName + ", offset " + jsonReader.getOffset());
                 }
                 return (T) autoTypeObjectReader.readJSONBObject(jsonReader, fieldType, fieldName, 0);
             }

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapTyped.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplMapTyped.java
@@ -322,8 +322,9 @@ class ObjectReaderImplMapTyped
                         && (contextFeatures & JSONReader.Feature.SupportAutoType.mask) != 0
                         && name.equals(getTypeKey())
                 ) {
-                    long typeHashCode = jsonReader.readTypeHashCode();
-                    ObjectReader objectReaderAutoType = jsonReader.getObjectReaderAutoType(typeHashCode, mapType, features);
+                    jsonReader.readTypeHashCode();
+                    ObjectReader objectReaderAutoType = jsonReader.getContext()
+                            .getObjectReaderAutoType(jsonReader.getString(), mapType, features);
                     if (objectReaderAutoType != null) {
                         if (objectReaderAutoType instanceof ObjectReaderImplMap) {
                             if (!object.getClass().equals(((ObjectReaderImplMap) objectReaderAutoType).instanceType)) {
@@ -348,8 +349,9 @@ class ObjectReaderImplMapTyped
                 ) {
                     name = jsonReader.readFieldName();
                     if (name.equals(getTypeKey())) {
-                        long typeHashCode = jsonReader.readTypeHashCode();
-                        ObjectReader objectReaderAutoType = jsonReader.getObjectReaderAutoType(typeHashCode, mapType, features);
+                        jsonReader.readTypeHashCode();
+                        ObjectReader objectReaderAutoType = jsonReader.getContext()
+                                .getObjectReaderAutoType(jsonReader.getString(), mapType, features);
                         if (objectReaderAutoType != null) {
                             if (objectReaderAutoType instanceof ObjectReaderImplMap) {
                                 if (!object.getClass().equals(((ObjectReaderImplMap) objectReaderAutoType).instanceType)) {
@@ -374,8 +376,9 @@ class ObjectReaderImplMapTyped
                     if (index == 0
                             && (contextFeatures & JSONReader.Feature.SupportAutoType.mask) != 0
                             && name.equals(getTypeKey())) {
-                        long typeHashCode = jsonReader.readTypeHashCode();
-                        ObjectReader objectReaderAutoType = jsonReader.getObjectReaderAutoType(typeHashCode, mapType, features);
+                        jsonReader.readTypeHashCode();
+                        ObjectReader objectReaderAutoType = jsonReader.getContext()
+                                .getObjectReaderAutoType(jsonReader.getString(), mapType, features);
                         if (objectReaderAutoType != null) {
                             if (objectReaderAutoType instanceof ObjectReaderImplMap) {
                                 if (!object.getClass().equals(((ObjectReaderImplMap) objectReaderAutoType).instanceType)) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplObject.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderImplObject.java
@@ -2,7 +2,6 @@ package com.alibaba.fastjson2.reader;
 
 import com.alibaba.fastjson2.*;
 import com.alibaba.fastjson2.function.Supplier;
-import com.alibaba.fastjson2.util.Fnv;
 
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -36,20 +35,12 @@ public final class ObjectReaderImplObject
 
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
-            ObjectReader reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0) {
-                reader = autoType(provider, typeHash);
-            }
+            ObjectReader reader = provider.getObjectReader(
+                    typeName, getObjectClass(), features | getFeatures()
+            );
 
             if (reader == null) {
-                reader = provider.getObjectReader(
-                        typeName, getObjectClass(), features | getFeatures()
-                );
-
-                if (reader == null) {
-                    throw new JSONException("No suitable ObjectReader found for" + typeName);
-                }
+                throw new JSONException("No suitable ObjectReader found for" + typeName);
             }
 
             if (reader != this) {
@@ -79,46 +70,13 @@ public final class ObjectReaderImplObject
 
                 if (hash == HASH_TYPE) {
                     boolean supportAutoType = context.isEnabled(JSONReader.Feature.SupportAutoType);
+                    typeName = jsonReader.readString();
+                    ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
 
-                    ObjectReader autoTypeObjectReader;
-
-                    if (supportAutoType) {
-                        long typeHash = jsonReader.readTypeHashCode();
-                        autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
-
-                        if (autoTypeObjectReader != null) {
-                            Class objectClass = autoTypeObjectReader.getObjectClass();
-                            if (objectClass != null) {
-                                ClassLoader objectClassLoader = objectClass.getClassLoader();
-                                ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-                                if (objectClassLoader != contextClassLoader) {
-                                    Class contextClass = null;
-
-                                    typeName = jsonReader.getString();
-                                    try {
-                                        contextClass = contextClassLoader.loadClass(typeName);
-                                    } catch (ClassNotFoundException ignored) {
-                                    }
-
-                                    //明确contextClass类型与objectClass不一致时才更改reader
-                                    if (contextClass != null && !objectClass.equals(contextClass)) {
-                                        autoTypeObjectReader = context.getObjectReader(contextClass);
-                                    }
-                                }
-                            }
-                        }
-
-                        if (autoTypeObjectReader == null) {
-                            typeName = jsonReader.getString();
-                            autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-                        }
-                    } else {
-                        typeName = jsonReader.readString();
-                        autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                        if (autoTypeObjectReader == null && jsonReader.context.isEnabled(JSONReader.Feature.ErrorOnNotSupportAutoType)) {
-                            throw new JSONException(jsonReader.info("autoType not support : " + typeName));
-                        }
+                    if (!supportAutoType
+                            && autoTypeObjectReader == null
+                            && context.isEnabled(JSONReader.Feature.ErrorOnNotSupportAutoType)) {
+                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                     }
 
                     if (autoTypeObjectReader != null) {

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderInterface.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderInterface.java
@@ -52,16 +52,12 @@ public final class ObjectReaderInterface<T>
 
             long hash = jsonReader.readFieldNameHashCode();
             if (hash == typeKeyHashCode && i == 0) {
-                long typeHash = jsonReader.readValueHashCode();
+                jsonReader.readValueHashCode();
                 JSONReader.Context context = jsonReader.context;
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
                 if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("auotype not support : " + typeName));
-                    }
+                    throw new JSONException(jsonReader.info("auotype not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -137,24 +133,16 @@ public final class ObjectReaderInterface<T>
             ) {
                 ObjectReader reader = null;
 
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
+                String typeName = jsonReader.getString();
                 if (autoTypeFilter != null) {
-                    Class<?> filterClass = autoTypeFilter.apply(typeHash, objectClass, features3);
-                    if (filterClass == null) {
-                        filterClass = autoTypeFilter.apply(jsonReader.getString(), objectClass, features3);
-                        if (filterClass != null) {
-                            reader = context.getObjectReader(filterClass);
-                        }
+                    Class<?> filterClass = autoTypeFilter.apply(typeName, objectClass, features3);
+                    if (filterClass != null) {
+                        reader = context.getObjectReader(filterClass);
                     }
                 }
 
                 if (reader == null) {
-                    reader = autoType(context, typeHash);
-                }
-
-                String typeName = null;
-                if (reader == null) {
-                    typeName = jsonReader.getString();
                     reader = context.getObjectReaderAutoType(
                             typeName, objectClass, features3
                     );

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderNoneDefaultConstructor.java
@@ -112,16 +112,12 @@ public class ObjectReaderNoneDefaultConstructor<T>
                 }
 
                 if (hashCode == HASH_TYPE && i == 0) {
-                    long typeHash = jsonReader.readTypeHashCode();
+                    jsonReader.readTypeHashCode();
                     JSONReader.Context context = jsonReader.context;
-                    ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeHash);
+                    String typeName = jsonReader.getString();
+                    ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
                     if (autoTypeObjectReader == null) {
-                        String typeName = jsonReader.getString();
-                        autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-
-                        if (autoTypeObjectReader == null) {
-                            throw new JSONException(jsonReader.info("auotype not support : " + typeName));
-                        }
+                        throw new JSONException(jsonReader.info("auotype not support : " + typeName));
                     }
 
                     T object = (T) autoTypeObjectReader.readJSONBObject(jsonReader, fieldType, fieldName, features);
@@ -245,21 +241,10 @@ public class ObjectReaderNoneDefaultConstructor<T>
                     continue;
                 }
 
-                boolean supportAutoType = (featuresAll & JSONReader.Feature.SupportAutoType.mask) != 0;
-
-                ObjectReader autoTypeObjectReader;
-
-                if (supportAutoType) {
-                    autoTypeObjectReader = jsonReader.getObjectReaderAutoType(typeHash, objectClass, this.features);
-                } else {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
-                }
-
-                if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass, this.features);
-                }
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = context.getObjectReaderAutoType(
+                        typeName, objectClass, this.features | featuresAll
+                );
 
                 if (autoTypeObjectReader != null) {
                     Object object = autoTypeObjectReader.readObject(jsonReader, fieldType, fieldName, 0);
@@ -392,17 +377,9 @@ public class ObjectReaderNoneDefaultConstructor<T>
 
         if (typeKey instanceof String) {
             String typeName = (String) typeKey;
-            long typeHash = Fnv.hashCode64(typeName);
-            ObjectReader<T> reader = null;
-            if ((features & JSONReader.Feature.SupportAutoType.mask) != 0) {
-                reader = autoType(provider, typeHash);
-            }
-
-            if (reader == null) {
-                reader = provider.getObjectReader(
-                        typeName, getObjectClass(), features | getFeatures()
-                );
-            }
+            ObjectReader<T> reader = provider.getObjectReader(
+                    typeName, getObjectClass(), features | getFeatures()
+            );
 
             if (reader != this && reader != null) {
                 return reader.createInstance(map, features);

--- a/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
+++ b/core/src/main/java/com/alibaba/fastjson2/reader/ObjectReaderSeeAlso.java
@@ -111,16 +111,21 @@ final class ObjectReaderSeeAlso<T>
 
             long hash = jsonReader.readFieldNameHashCode();
             if (hash == typeKeyHashCode) {
-                long typeHash = jsonReader.readValueHashCode();
+                jsonReader.readValueHashCode();
                 JSONReader.Context context = jsonReader.getContext();
-                ObjectReader autoTypeObjectReader = autoType(context, typeHash);
-                if (autoTypeObjectReader == null) {
-                    String typeName = jsonReader.getString();
-                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, null);
-
-                    if (autoTypeObjectReader == null) {
-                        throw new JSONException(jsonReader.info("autoType not support : " + typeName));
+                String typeName = jsonReader.getString();
+                ObjectReader autoTypeObjectReader = null;
+                if (seeAlsoMapping != null && seeAlsoMapping.size() > 0) {
+                    Class seeAlsoClass = seeAlsoMapping.get(Fnv.hashCode64(typeName));
+                    if (seeAlsoClass != null) {
+                        autoTypeObjectReader = context.getObjectReader(seeAlsoClass);
                     }
+                }
+                if (autoTypeObjectReader == null) {
+                    autoTypeObjectReader = context.getObjectReaderAutoType(typeName, objectClass);
+                }
+                if (autoTypeObjectReader == null) {
+                    throw new JSONException(jsonReader.info("autoType not support : " + typeName));
                 }
 
                 if (autoTypeObjectReader == this) {
@@ -241,32 +246,31 @@ final class ObjectReaderSeeAlso<T>
                     && ((((features3 = (features | getFeatures() | context.features)) & JSONReader.Feature.SupportAutoType.mask) != 0) || autoTypeFilter != null)
             ) {
                 ObjectReader reader = null;
-                long typeHash = jsonReader.readTypeHashCode();
+                jsonReader.readTypeHashCode();
 
                 Number typeNumber = null;
                 String typeNumberStr = null;
-                if (typeHash == -1 && jsonReader.isNumber()) {
+                if (jsonReader.isNumber()) {
                     typeNumber = jsonReader.readNumber();
                     typeNumberStr = typeNumber.toString();
-                    typeHash = Fnv.hashCode64(typeNumberStr);
                 }
-                if (autoTypeFilter != null) {
-                    Class<?> filterClass = autoTypeFilter.apply(typeHash, objectClass, features3);
-                    if (filterClass == null) {
-                        filterClass = autoTypeFilter.apply(jsonReader.getString(), objectClass, features3);
-                        if (filterClass != null) {
-                            reader = context.getObjectReader(filterClass);
-                        }
+
+                String typeName = typeNumberStr != null ? typeNumberStr : jsonReader.getString();
+                if (seeAlsoMapping != null && seeAlsoMapping.size() > 0) {
+                    Class seeAlsoClass = seeAlsoMapping.get(Fnv.hashCode64(typeName));
+                    if (seeAlsoClass != null) {
+                        reader = context.getObjectReader(seeAlsoClass);
+                    }
+                }
+
+                if (reader == null && autoTypeFilter != null) {
+                    Class<?> filterClass = autoTypeFilter.apply(typeName, objectClass, features3);
+                    if (filterClass != null) {
+                        reader = context.getObjectReader(filterClass);
                     }
                 }
 
                 if (reader == null) {
-                    reader = autoType(context, typeHash);
-                }
-
-                String typeName = null;
-                if (reader == null) {
-                    typeName = jsonReader.getString();
                     reader = context.getObjectReaderAutoType(
                             typeName, objectClass, features3
                     );

--- a/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
+++ b/core/src/test/java/com/alibaba/fastjson2/autoType/AutoTypeValidationTest.java
@@ -1,8 +1,11 @@
 package com.alibaba.fastjson2.autoType;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
 import com.alibaba.fastjson2.JSONException;
+import com.alibaba.fastjson2.JSONFactory;
 import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
 import com.alibaba.fastjson2.filter.ContextAutoTypeBeforeHandler;
 import com.alibaba.fastjson2.reader.ObjectReaderProvider;
 import com.alibaba.fastjson2.util.Fnv;
@@ -26,6 +29,7 @@ public class AutoTypeValidationTest {
     static final String PACKAGE_PREFIX = "com.alibaba.fastjson2.autoType.";
     static final String TEST_BEAN = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestBean";
     static final String TEST_CLASS_LOADER = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestClassLoader";
+    static final String UNAUTHORIZED_TYPE = "com.example.Unauthorized";
     static final String TEST_DATA_SOURCE = "com.alibaba.fastjson2.autoType.AutoTypeValidationTest$TestDataSource";
 
     // =========================================================================
@@ -364,6 +368,144 @@ public class AutoTypeValidationTest {
     }
 
     @Test
+    public void testParseHashCacheDoesNotBypassTypeNameValidation() {
+        String typeName = "jar:http://127.0.0.1/evil.jar!/Evil";
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(typeName),
+                provider.getObjectReader(TestBean.class)
+        );
+
+        AtomicReference<String> requested = new AtomicReference<>();
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader recording = new ClassLoader(contextClassLoader) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                requested.set(name);
+                return super.loadClass(name);
+            }
+        };
+
+        try {
+            Thread.currentThread().setContextClassLoader(recording);
+            Object object = JSON.parseObject(
+                    "{\"@type\":\"" + typeName + "\",\"id\":123}",
+                    Object.class,
+                    JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+            );
+            assertInstanceOf(Map.class, object);
+            assertNull(requested.get(), "invalid type name must not reach the class loader");
+        } finally {
+            Thread.currentThread().setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    @Test
+    public void testParseHashCacheDoesNotBypassDenyClassCheck() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(TEST_CLASS_LOADER),
+                provider.getObjectReader(TestClassLoader.class)
+        );
+
+        JSONReader.Context context = JSONFactory.createReadContext(
+                provider,
+                JSONReader.Feature.SupportAutoType
+        );
+        assertThrows(JSONException.class, () -> JSON.parseObject(
+                "{\"@type\":\"" + TEST_CLASS_LOADER + "\"}",
+                Object.class,
+                context
+        ));
+    }
+
+    @Test
+    public void testParseHashCacheRequiresMatchingTypeName() {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(TEST_BEAN),
+                provider.getObjectReader(String.class)
+        );
+
+        TestBean bean = (TestBean) JSON.parseObject(
+                "{\"@type\":\"" + TEST_BEAN + "\",\"id\":123}",
+                Object.class,
+                JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+        );
+        assertEquals(123, bean.id);
+    }
+
+    @Test
+    public void testParseJSONBHashCacheRequiresMatchingTypeName() {
+        TestBean bean = new TestBean();
+        bean.id = 123;
+        byte[] jsonb = JSONB.toBytes(bean, JSONWriter.Feature.WriteClassName);
+
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(TEST_BEAN),
+                provider.getObjectReader(String.class)
+        );
+
+        try (JSONReader jsonReader = JSONReader.ofJSONB(
+                jsonb,
+                JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+        )) {
+            TestBean parsed = (TestBean) jsonReader.readAny();
+            assertEquals(123, parsed.id);
+        }
+    }
+
+    @Test
+    public void testConcreteBeanHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, OneFieldBean.class, provider);
+        assertFalse(SideEffect.created, "concrete bean hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testInterfaceHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, TestInterface.class, provider);
+        assertFalse(SideEffect.created, "interface hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testNoDefaultConstructorHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, NoDefaultBean.class, provider);
+        assertFalse(SideEffect.created, "no-default-constructor hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testExceptionHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+
+        parseTextIgnoreError(UNAUTHORIZED_TYPE, TestException.class, provider);
+        assertFalse(SideEffect.created, "exception hash cache hit must not authorize reader");
+    }
+
+    @Test
+    public void testJSONBEmbeddedHashCacheDoesNotAuthorizeReader() {
+        SideEffect.created = false;
+        ObjectReaderProvider provider = registerSideEffect(UNAUTHORIZED_TYPE);
+        byte[] jsonb = embeddedTypedJsonb(UNAUTHORIZED_TYPE);
+
+        try {
+            JSONB.parseObject(jsonb, TestInterface.class, JSONFactory.createReadContext(provider));
+        } catch (JSONException ignored) {
+        }
+        assertFalse(SideEffect.created, "JSONB embedded @type hash cache hit must not authorize reader");
+    }
+
+    @Test
     public void testDenyPrefixOnlyRejectionIsDistinguishable() {
         ObjectReaderProvider provider = new ObjectReaderProvider();
         long features = JSONReader.Feature.SupportAutoType.mask;
@@ -378,6 +520,75 @@ public class AutoTypeValidationTest {
         JSONException prefixOnly = assertThrows(JSONException.class, () ->
                 provider.checkAutoType(TEST_CLASS_LOADER, null, features));
         assertTrue(prefixOnly.getMessage().contains("add the type name in full to accept"));
+    }
+
+    static ObjectReaderProvider registerSideEffect(String typeName) {
+        ObjectReaderProvider provider = new ObjectReaderProvider();
+        provider.registerIfAbsent(
+                Fnv.hashCode64(typeName),
+                provider.getObjectReader(SideEffect.class)
+        );
+        return provider;
+    }
+
+    static void parseTextIgnoreError(String typeName, Class<?> expectClass, ObjectReaderProvider provider) {
+        try {
+            JSON.parseObject(
+                    "{\"@type\":\"" + typeName + "\",\"id\":1}",
+                    expectClass,
+                    JSONFactory.createReadContext(provider, JSONReader.Feature.SupportAutoType)
+            );
+        } catch (JSONException ignored) {
+        }
+    }
+
+    static byte[] embeddedTypedJsonb(String typeName) {
+        byte[] typeNameField = JSONB.toBytes("@type");
+        byte[] typeNameValue = JSONB.toBytes(typeName);
+        byte[] idField = JSONB.toBytes("id");
+        // this branch has no JSONB.IO; JSONB.toBytes(int) is the canonical JSONB int encoding here
+        byte[] idValue = JSONB.toBytes(1);
+        byte[] bytes = new byte[1 + typeNameField.length + typeNameValue.length
+                + idField.length + idValue.length + 1];
+        int off = 0;
+        bytes[off++] = JSONB.Constants.BC_OBJECT;
+        System.arraycopy(typeNameField, 0, bytes, off, typeNameField.length);
+        off += typeNameField.length;
+        System.arraycopy(typeNameValue, 0, bytes, off, typeNameValue.length);
+        off += typeNameValue.length;
+        System.arraycopy(idField, 0, bytes, off, idField.length);
+        off += idField.length;
+        System.arraycopy(idValue, 0, bytes, off, idValue.length);
+        off += idValue.length;
+        bytes[off++] = JSONB.Constants.BC_OBJECT_END;
+        return Arrays.copyOf(bytes, off);
+    }
+
+    public interface TestInterface {
+    }
+
+    public static class TestException
+            extends RuntimeException {
+    }
+
+    public static class SideEffect {
+        static volatile boolean created;
+
+        public SideEffect() {
+            created = true;
+        }
+    }
+
+    public static class OneFieldBean {
+        public int id;
+    }
+
+    public static class NoDefaultBean {
+        public final int id;
+
+        public NoDefaultBean(int id) {
+            this.id = id;
+        }
     }
 
     public static class TestBean {

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7808.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7808.java
@@ -1,0 +1,112 @@
+package com.alibaba.fastjson2.issues_7800;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONArray;
+import com.alibaba.fastjson2.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guard test for gh-7808 (ArrayIndexOutOfBoundsException in JSONReaderASCII field-name decoding).
+ *
+ * <p>On main the bug comes from JSONReaderASCII inheriting readFieldNameHashCode0() from
+ * JSONReaderUTF8, which decodes field names as UTF-8 and counts <em>characters</em> into
+ * nameLength, while getFieldName() walks the same span as latin1 <em>bytes</em> and sizes its
+ * output buffer from that same nameLength.
+ *
+ * <p>This branch is not affected: JSONReaderASCII overrides readFieldNameHashCode() and counts
+ * one nameLength unit per unescaped character in its own latin1 loop, so nameLength always equals
+ * the number of chars getFieldName() writes. Also, JSONReader.of(String) always builds a
+ * JSONReaderUTF16 here, so JSONReaderASCII is only reachable through byte[] input decoded as
+ * US_ASCII / ISO_8859_1 -- which is what the cases below exercise.
+ */
+class Issue7808 {
+    // JSON source text for the field name: a backslash+t escape (2 source chars, unescaped by the
+    // parser to one TAB) followed by 3 raw latin1 bytes (E0 AA AE) that a UTF-8 field-name decoder
+    // would misread as a single 3-byte character, undercounting nameLength. See gh-7808.
+    private static final String KEY_SOURCE = "\\t\u00e0\u00aa\u00ae";
+    // The field name after JSON unescaping: TAB + the 3 latin1 characters.
+    private static final String KEY_PARSED = "\t\u00e0\u00aa\u00ae";
+
+    static JSONArray parseLatin1Array(String json) {
+        byte[] bytes = json.getBytes(StandardCharsets.ISO_8859_1);
+        return JSON.parseArray(bytes, 0, bytes.length, StandardCharsets.ISO_8859_1);
+    }
+
+    static JSONObject parseLatin1Object(String json) {
+        byte[] bytes = json.getBytes(StandardCharsets.ISO_8859_1);
+        return JSON.parseObject(bytes, 0, bytes.length, StandardCharsets.ISO_8859_1, JSONObject.class);
+    }
+
+    @Test
+    public void fieldNameWithEscapeAndNonAsciiInsideArray_doesNotThrow() {
+        String json = "[{\"" + KEY_SOURCE + "\":1}]";
+
+        JSONArray array = assertDoesNotThrow(() -> parseLatin1Array(json));
+        JSONObject obj = array.getJSONObject(0);
+        assertEquals(1, obj.size());
+        assertEquals(1, obj.getIntValue(KEY_PARSED));
+    }
+
+    @Test
+    public void nonAsciiWithoutEscape_stillParses() {
+        // Control: same non-ASCII bytes, no escape -- takes the byte-count fast path.
+        JSONObject obj = parseLatin1Array("[{\"a\u00e0\u00aa\u00ae\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("a\u00e0\u00aa\u00ae"));
+    }
+
+    @Test
+    public void escapeWithoutNonAscii_stillParses() {
+        // Control: escape present, but no byte >= 0x80 -- nameLength was already correct.
+        JSONObject obj = parseLatin1Array("[{\"\\tabc\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("\tabc"));
+    }
+
+    @Test
+    public void sameFieldNameAtTopLevel_stillParses() {
+        // Control: not inside an array -- doesn't route through ObjectReaderImplObject.
+        JSONObject obj = parseLatin1Object("{\"" + KEY_SOURCE + "\":1}");
+        assertEquals(1, obj.getIntValue(KEY_PARSED));
+    }
+
+    @Test
+    public void multipleObjectsInArray_stillParse() {
+        JSONArray array = parseLatin1Array("[{\"a\":1},{\"b\":2}]");
+        assertEquals(1, array.getJSONObject(0).getIntValue("a"));
+        assertEquals(2, array.getJSONObject(1).getIntValue("b"));
+    }
+
+    @Test
+    public void unicodeEscapedFieldName_stillParses() {
+        JSONObject obj = parseLatin1Array("[{\"\\u00e9\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("\u00e9"));
+    }
+
+    @Test
+    public void backslashEscapedFieldName_stillParses() {
+        JSONObject obj = parseLatin1Array("[{\"a\\\\b\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("a\\b"));
+    }
+
+    @Test
+    public void quoteEscapedFieldName_stillParses() {
+        JSONObject obj = parseLatin1Array("[{\"a\\\"b\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("a\"b"));
+    }
+
+    @Test
+    public void emptyFieldName_stillParses() {
+        JSONObject obj = parseLatin1Array("[{\"\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue(""));
+    }
+
+    @Test
+    public void controlCharacterEscapes_stillParse() {
+        JSONObject obj = parseLatin1Array("[{\"\\n\\t\\r\":1}]").getJSONObject(0);
+        assertEquals(1, obj.getIntValue("\n\t\r"));
+    }
+}

--- a/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriter14Test.java
+++ b/core/src/test/java/com/alibaba/fastjson2/writer/ObjectWriter14Test.java
@@ -1,0 +1,87 @@
+package com.alibaba.fastjson2.writer;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.JSONB;
+import com.alibaba.fastjson2.JSONObject;
+import com.alibaba.fastjson2.JSONPath;
+import com.alibaba.fastjson2.JSONReader;
+import com.alibaba.fastjson2.JSONWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The getter must not be discarded when serializing char/Character properties:
+ * the serialized value has to come from the getter, not from the backing field.
+ *
+ * <p>Ported from main's ObjectWriter14Test (commit 7c4609f60). The {@code testAdapter}
+ * case is omitted here because this branch has no
+ * {@code ObjectWriters.fieldWriter(String, Function)} overload, and that case covers
+ * ObjectWriterAdapter construction rather than the char-getter behaviour under test.
+ */
+public class ObjectWriter14Test {
+    @Test
+    public void test() {
+        Bean bean = new Bean();
+        bean.setF0('0');
+        bean.setF1(null);
+        String str = JSON.toJSONString(bean);
+        Bean bean1 = JSON.parseObject(str, Bean.class);
+        assertEquals(bean.getF0(), bean1.getF0());
+        assertEquals(bean.getF1(), bean1.getF1());
+        assertEquals(String.valueOf(bean.getF1()), JSON.parseObject(str).getString("f1"));
+
+        JSONObject jsonObject = JSONObject.from(bean);
+        assertEquals(str, jsonObject.toString());
+
+        // this branch has no static JSONPath.eval(Object, String); use JSONPath.of(path).eval(root)
+        assertEquals(bean.getF0(), JSONPath.of("$.f0").eval(bean));
+        assertEquals(bean.getF1(), JSONPath.of("$.f1").eval(bean));
+        assertNull(JSONPath.of("$.f100").eval(bean));
+    }
+
+    @Test
+    public void testJsonb() {
+        Bean bean = new Bean();
+        bean.setF0('0');
+        bean.setF1(null);
+        byte[] jsonbBytes = JSONB.toBytes(bean);
+        Bean bean1 = JSONB.parseObject(jsonbBytes, Bean.class);
+        assertEquals(bean.getF0(), bean1.getF0());
+        assertEquals(bean.getF1(), bean1.getF1());
+    }
+
+    @Test
+    public void testJsonbArray() {
+        Bean bean = new Bean();
+        bean.setF0('0');
+        bean.setF1(null);
+        byte[] jsonbBytes = JSONB.toBytes(bean, JSONWriter.Feature.BeanToArray);
+        Bean bean1 = JSONB.parseObject(jsonbBytes, Bean.class, JSONReader.Feature.SupportArrayToBean);
+        assertEquals(bean.getF0(), bean1.getF0());
+        assertEquals(bean.getF1(), bean1.getF1());
+    }
+
+    interface BeanIf {
+        default Character getF0() {
+            return null;
+        }
+
+        default void setF0(Character f0) {
+        }
+    }
+
+    public static class Bean
+            implements BeanIf {
+        private Character f1 = '0';
+
+        public Character getF1() {
+            return null == f1 ? '0' : f1;
+        }
+
+        public void setF1(Character f1) {
+            this.f1 = f1;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alibaba.fastjson2</groupId>
     <artifactId>fastjson2-parent</artifactId>
-    <version>2.0.64.android5</version>
+    <version>2.0.65.android5</version>
     <name>${project.artifactId}</name>
     <description>Fastjson is a JSON processor (JSON parser + JSON generator) written in Java</description>
     <packaging>pom</packaging>


### PR DESCRIPTION
Port the 2.0.65 changes from `main` to the `android5` branch (manually adapted cherry-picks). Companion to #7843 (android8); the two ports are provably equivalent — see below.

## Ported

**`e2bde524c` — fix: unify AutoType authorization to type name and reject hash-cache hit (#7753, security)**

An FNV-1a-64 hash-cache hit is not an AutoType authorization. Pure-hash dispatch is removed from every untrusted-input path (`JSONReader`, `JSONReaderJSONB`, `ObjectReader`, `ObjectReaderAdapter`, `ObjectReaderBean`, `ObjectReaderSeeAlso`, `ObjectReader1..6`, `ObjectReaderInterface`, `ObjectReaderException`, `ObjectReaderNoneDefaultConstructor`, `ObjectReaderImplObject`, `ObjectReaderImplMapTyped`, `ObjectArrayTypedReader`, `FieldReaderList`), so `@type` now resolves through the real type name and the full `ObjectReaderProvider` checks run — including the ClassLoader/DataSource/RowSet deny lists and the `:`/`!` type-name validation added in 2.0.63. This also removes the classloader-mismatch branch that handed an attacker-controlled `@type` string to the TCCL `loadClass()`.

Compatibility carve-outs kept exactly as on main: explicit `@JSONType(seeAlso = ...)` local mappings still resolve, and a reader whose own `@JSONType` features include `SupportAutoType` still participates in gating. `AutoTypeBeforeHandler` ordering relative to the feature checks is untouched.

## Not ported — verified not applicable on this branch (no production change)

Each of these was re-verified against `android5` sources independently, not assumed from the android8 port:

- **`f11c2ee25` #7808** `JSONReaderASCII` field-name AIOOBE: this branch's `JSONReaderASCII` overrides `readFieldNameHashCode()` (line 117) with its own latin1 loop that sets `nameLength` per unescaped character — exactly what `getFieldName()` writes — so `nameLength` cannot undercount. There is no `STRING_CREATOR_JDK11` path here (0 occurrences), i.e. only the `char[]` path exists. `Issue7808` is ported as a guard test (10/10 pass).
- **`1836c7be5` #7671** `strBuf` sync: `strBuf` and `containsSlashOrQuoteUTF16` do not exist anywhere in this branch (0 occurrences); `JSONReaderUTF16.readString()` allocates a fresh `char[valueLength]` per call (line 3051), so there is no reusable buffer that can go stale. Omitted entirely.
- **`7c4609f60` #7719** char-field getter discarded: this branch still splits the field-based and method-based creators. The method-based one already passes the getter — `new FieldWriterCharMethod(fieldName, ordinal, features, format, label, field, method, fieldClass)` for `char.class || Character.class` (`ObjectWriterCreator:874-875`); the field-based `char.class` branch builds `FieldWriterCharValField(... field)` and takes no method at all. `ObjectWriter14Test` is ported as a guard test (3/3 pass).
- ASM-related upstream fixes (#4009 `ClassFormatError`, #3156 record generics), the schema fix (#7709) and the records naming-strategy fix (#7656): no `ObjectWriterCreatorASM` / `ObjectReaderCreatorASM` / `internal/asm/ASMUtils` / `schema` package on this branch, and it compiles at source level 8 (no records).
- The upstream `safemode-test/SafeModeTest.java` hunk: **this branch has no safeMode support at all** and no `safemode-test` module. Backporting the safeMode feature itself is out of scope for a release port and should be tracked separately.

Version bump: `2.0.64.android5` → `2.0.65.android5` (4 pom version lines only: root, `core`, `benchmark`, `codegen-test`).

## Verification

- `JAVA_HOME=jdk8 mvn clean install` → **BUILD SUCCESS** across all 4 modules (`fastjson2-parent`, `fastjson2`, `fastjson2-benchmark`, `codgen-test`); core: **Tests run: 5084, Failures: 0, Errors: 0, Skipped: 0** (5062 from the 2.0.63 port + 22 new), `codgen-test`: 14 tests green
- **Negative control**: with the new tests present but the production fix reverted to pristine `android5`, **8 of the 9 new tests fail** (36 run / 7 failures / 1 error) — an unauthorized `SideEffect` reader gets instantiated, the deny-list bypass throws nothing, `jar:http://127.0.0.1/evil.jar!/Evil` reaches the class loader, and JSONB uses a bogus hash-cache reader. This confirms the bypass was live on this branch too and that the port closes it.
- **Equivalence with #7843 (android8)**: the production change set is 523 changed lines in `core/src/main` on both branches, and the sorted set of added/removed lines is **byte-identical** between the two ports (0 differing lines). The three ported test files have identical blob hashes on both branches. So the semantics reviewed in #7843 apply unchanged here, even though the two branches diverge substantially in these very files.
- Independently re-run on the maintainer side: same green build, same 8/9 negative-control failures, same 523-line equivalence.

Note: CI cannot run on this branch — the `.github/workflows/ci.yaml` here still targets the retired `ubuntu-20.04` runner label, so jobs queue until they time out (same as #7712). The verification above is the local JDK 8 build.

<details>
<summary>中文说明</summary>

把 2.0.65 的改动 port 到 `android5` 分支（手工适配 cherry-pick）。本 PR 与 #7843（android8）配套，两个端口可证明等价——见下文。

**已 port：**

`e2bde524c` — AutoType 授权统一到真实类型名、拒绝哈希缓存命中（#7753，安全修复）。FNV-1a-64 哈希缓存命中不等于 AutoType 授权：移除所有不可信输入路径上的纯哈希分发（`JSONReader`、`JSONReaderJSONB`、`ObjectReader`、`ObjectReaderAdapter`、`ObjectReaderBean`、`ObjectReaderSeeAlso`、`ObjectReader1..6`、`ObjectReaderInterface`、`ObjectReaderException`、`ObjectReaderNoneDefaultConstructor`、`ObjectReaderImplObject`、`ObjectReaderImplMapTyped`、`ObjectArrayTypedReader`、`FieldReaderList`），`@type` 改为按真实类型名解析，从而走 `ObjectReaderProvider` 的完整检查——包含 ClassLoader/DataSource/RowSet deny 列表与 2.0.63 加入的 `:`/`!` 类型名校验；同时移除把攻击者可控 `@type` 交给 TCCL `loadClass()` 的 classloader 不一致分支。

兼容豁免与 main 完全一致：`@JSONType(seeAlso = ...)` 的显式局部映射仍可解析；reader 自身 `@JSONType` features 含 `SupportAutoType` 时仍参与门控。`AutoTypeBeforeHandler` 与 feature 检查的相对顺序未改动。

**未 port（已针对 `android5` 源码独立重验，不是照搬 android8 的结论）：**

- `f11c2ee25` #7808：本分支 `JSONReaderASCII` 自己 override 了 `readFieldNameHashCode()`（第 117 行），latin1 循环按未转义字符逐个设置 `nameLength`，与 `getFieldName()` 实际写入完全一致，不会少算；本分支无 `STRING_CREATOR_JDK11` 路径（0 处），即只有 `char[]` 路径。`Issue7808` 作为守护测试 port（10/10 通过）。
- `1836c7be5` #7671：本分支完全不存在 `strBuf` 与 `containsSlashOrQuoteUTF16`（0 处）；`JSONReaderUTF16.readString()` 每次新分配 `char[valueLength]`（第 3051 行），不存在会失效的复用缓冲区。完全省略。
- `7c4609f60` #7719：本分支仍拆分 field-based 与 method-based creator。method-based 已经传入 getter——`char.class || Character.class` 走 `new FieldWriterCharMethod(fieldName, ordinal, features, format, label, field, method, fieldClass)`（`ObjectWriterCreator:874-875`）；field-based 的 `char.class` 分支构造 `FieldWriterCharValField(... field)`，根本没有 method 参数。`ObjectWriter14Test` 作为守护测试 port（3/3 通过）。
- 上游 ASM 相关修复（#4009 `ClassFormatError`、#3156 record 泛型）、schema 修复（#7709）、records 命名策略修复（#7656）：本分支无 `ObjectWriterCreatorASM` / `ObjectReaderCreatorASM` / `internal/asm/ASMUtils` / `schema` 包，且以 source level 8 编译（无 records）。
- 上游 `safemode-test/SafeModeTest.java` 这一段：**本分支完全没有 safeMode 支持**，也无 `safemode-test` 模块。把 safeMode 特性本身 port 过来超出发版 port 的范围，应单独立项。

版本号：`2.0.64.android5` → `2.0.65.android5`（仅 4 行 pom 版本：根、`core`、`benchmark`、`codegen-test`）。

**验证：**

- `JAVA_HOME=jdk8 mvn clean install` → **BUILD SUCCESS**，4 个模块全绿（`fastjson2-parent`、`fastjson2`、`fastjson2-benchmark`、`codgen-test`）；core：**5084 个测试，0 失败 0 错误**（2.0.63 port 的 5062 + 新增 22），`codgen-test`：14 个测试通过
- **反向对照**：保留新测试、把生产代码还原为纯净 `android5`，9 个新测试中 **8 个失败**（36 跑 / 7 failures / 1 error）——未授权的 `SideEffect` reader 被实例化、deny 列表被绕过且不抛异常、`jar:http://127.0.0.1/evil.jar!/Evil` 到达类加载器、JSONB 使用了伪造的哈希缓存 reader。说明该绕过在本分支同样真实存在，且本 port 确实修掉了。
- **与 #7843（android8）的等价性**：两个分支在 `core/src/main` 的生产代码改动都是 523 行，且增删行排序后的集合**逐字节相同**（0 处差异）；三个 port 过来的测试文件在两分支上 blob hash 完全一致。因此 #7843 中已审查的语义在此处完全适用——尽管两分支在这些文件本身上分歧很大。
- 维护者侧独立复跑：同样构建全绿、同样 8/9 反向对照失败、同样 523 行等价。

注意：本分支 CI 无法运行——这里的 `.github/workflows/ci.yaml` 仍指向已下线的 `ubuntu-20.04` runner label，job 会排队直到超时（与 #7712 相同）。验证依据是上面的本地 JDK 8 构建。

</details>
