### PR TITLE
fix: Jackson JsonFormat Shape.STRING on BigDecimal writes illegal JSON, for issue #7837

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
@@ -122,6 +122,8 @@ public abstract class FieldWriter<T>
 
         DecimalFormat decimalFormat = null;
         if (format != null
+                && !"string".equals(format)
+                && !"millis".equals(format)
                 && (fieldClass == float.class
                 || fieldClass == float[].class
                 || fieldClass == Float.class
@@ -644,7 +646,11 @@ public abstract class FieldWriter<T>
 
     public void writeInt32(JSONWriter jsonWriter, int value) {
         writeFieldName(jsonWriter);
-        jsonWriter.writeInt32(value);
+        if ((features & WriteNonStringValueAsString.mask) != 0) {
+            jsonWriter.writeString(Integer.toString(value));
+        } else {
+            jsonWriter.writeInt32(value);
+        }
     }
 
     public void writeInt64(JSONWriter jsonWriter, long value) {
@@ -1048,7 +1054,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal.class == valueClass) {
-                if (format == null || format.isEmpty()) {
+                if (format == null || format.isEmpty() || "string".equals(format) || "millis".equals(format)) {
                     return ObjectWriterImplBigDecimal.INSTANCE;
                 } else {
                     return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);
@@ -1056,7 +1062,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal[].class == valueClass) {
-                if (format == null || format.isEmpty()) {
+                if (format == null || format.isEmpty() || "string".equals(format) || "millis".equals(format)) {
                     return new ObjectWriterArrayFinal(BigDecimal.class, null);
                 } else {
                     return new ObjectWriterArrayFinal(BigDecimal.class, new DecimalFormat(format));

--- a/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/FieldWriter.java
@@ -72,6 +72,13 @@ public abstract class FieldWriter<T>
             "initObjectWriter"
     );
 
+    static boolean isFormatKeyword(String format) {
+        return "string".equals(format)
+                || "millis".equals(format)
+                || "trim".equals(format)
+                || "symbol".equals(format);
+    }
+
     FieldWriter(
             String name,
             int ordinal,
@@ -122,8 +129,7 @@ public abstract class FieldWriter<T>
 
         DecimalFormat decimalFormat = null;
         if (format != null
-                && !"string".equals(format)
-                && !"millis".equals(format)
+                && !isFormatKeyword(format)
                 && (fieldClass == float.class
                 || fieldClass == float[].class
                 || fieldClass == Float.class
@@ -1054,7 +1060,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal.class == valueClass) {
-                if (format == null || format.isEmpty() || "string".equals(format) || "millis".equals(format)) {
+                if (format == null || format.isEmpty() || isFormatKeyword(format)) {
                     return ObjectWriterImplBigDecimal.INSTANCE;
                 } else {
                     return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);
@@ -1062,7 +1068,7 @@ public abstract class FieldWriter<T>
             }
 
             if (BigDecimal[].class == valueClass) {
-                if (format == null || format.isEmpty() || "string".equals(format) || "millis".equals(format)) {
+                if (format == null || format.isEmpty() || isFormatKeyword(format)) {
                     return new ObjectWriterArrayFinal(BigDecimal.class, null);
                 } else {
                     return new ObjectWriterArrayFinal(BigDecimal.class, new DecimalFormat(format));

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -460,21 +460,21 @@ public class ObjectWriterProvider
      */
     public ObjectWriter getObjectWriter(Type objectType, String format, Locale locale) {
         if (objectType == Double.class) {
-            if ("string".equals(format) || "millis".equals(format)) {
+            if (format == null || format.isEmpty() || FieldWriter.isFormatKeyword(format)) {
                 return ObjectWriterImplDouble.INSTANCE;
             }
             return new ObjectWriterImplDouble(new DecimalFormat(format));
         }
 
         if (objectType == Float.class) {
-            if ("string".equals(format) || "millis".equals(format)) {
+            if (format == null || format.isEmpty() || FieldWriter.isFormatKeyword(format)) {
                 return ObjectWriterImplFloat.INSTANCE;
             }
             return new ObjectWriterImplFloat(new DecimalFormat(format));
         }
 
         if (objectType == BigDecimal.class) {
-            if ("string".equals(format) || "millis".equals(format)) {
+            if (format == null || format.isEmpty() || FieldWriter.isFormatKeyword(format)) {
                 return ObjectWriterImplBigDecimal.INSTANCE;
             }
             return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);

--- a/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
+++ b/core/src/main/java/com/alibaba/fastjson2/writer/ObjectWriterProvider.java
@@ -460,14 +460,23 @@ public class ObjectWriterProvider
      */
     public ObjectWriter getObjectWriter(Type objectType, String format, Locale locale) {
         if (objectType == Double.class) {
+            if ("string".equals(format) || "millis".equals(format)) {
+                return ObjectWriterImplDouble.INSTANCE;
+            }
             return new ObjectWriterImplDouble(new DecimalFormat(format));
         }
 
         if (objectType == Float.class) {
+            if ("string".equals(format) || "millis".equals(format)) {
+                return ObjectWriterImplFloat.INSTANCE;
+            }
             return new ObjectWriterImplFloat(new DecimalFormat(format));
         }
 
         if (objectType == BigDecimal.class) {
+            if ("string".equals(format) || "millis".equals(format)) {
+                return ObjectWriterImplBigDecimal.INSTANCE;
+            }
             return new ObjectWriterImplBigDecimal(new DecimalFormat(format), null);
         }
 

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7837.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7837.java
@@ -1,11 +1,14 @@
 package com.alibaba.fastjson2.issues_7800;
 
 import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.annotation.JSONField;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -31,6 +34,76 @@ public class Issue7837 {
     public static class BeanInteger {
         @JsonFormat(shape = JsonFormat.Shape.STRING)
         public Integer value = 47;
+    }
+
+    public static class BeanObject {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Object examScore = new BigDecimal("0.47");
+    }
+
+    public static class BeanObjectMillis {
+        @JSONField(format = "millis")
+        public Object examScore = new BigDecimal("0.47");
+    }
+
+    public static class BeanMillisDouble {
+        @JSONField(format = "millis")
+        public Double value = 0.47;
+    }
+
+    public static class BeanMillisBigDecimal {
+        @JSONField(format = "millis")
+        public BigDecimal value = new BigDecimal("0.47");
+    }
+
+    public static class BeanMillisBigDecimalArray {
+        @JSONField(format = "millis")
+        public BigDecimal[] scores = {new BigDecimal("0.47")};
+    }
+
+    public static class BeanObjectBigDecimalArray {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Object scores = new BigDecimal[]{new BigDecimal("0.47")};
+    }
+
+    public static class BeanObjectMillisBigDecimalArray {
+        @JSONField(format = "millis")
+        public Object scores = new BigDecimal[]{new BigDecimal("0.47")};
+    }
+
+    public static class BeanStringDoubleList {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public List<Double> values = Arrays.asList(0.47, 2.0);
+    }
+
+    public static class BeanStringBigDecimalList {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public List<BigDecimal> values = Arrays.asList(new BigDecimal("0.47"));
+    }
+
+    public static class BeanStringFloatList {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public List<Float> values = Arrays.asList(0.47f);
+    }
+
+    public static class BeanMillisDoubleList {
+        @JSONField(format = "millis")
+        public List<Double> values = Arrays.asList(0.47);
+    }
+
+    public static class BeanMillisBigDecimalList {
+        @JSONField(format = "millis")
+        public List<BigDecimal> values = Arrays.asList(new BigDecimal("0.47"));
+    }
+
+    public static class BeanMillisFloatList {
+        @JSONField(format = "millis")
+        public List<Float> values = Arrays.asList(0.47f);
+    }
+
+    public static class BeanTrimDouble {
+        @JSONField(format = "trim")
+        public Double value = 0.47;
     }
 
     @Test
@@ -61,5 +134,103 @@ public class Issue7837 {
         BeanInteger bean = new BeanInteger();
         String json = JSON.toJSONString(bean);
         assertEquals("{\"value\":\"47\"}", json);
+    }
+
+    @Test
+    public void testObjectBigDecimal() {
+        BeanObject bean = new BeanObject();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"examScore\":\"0.47\"}", json);
+    }
+
+    @Test
+    public void testObjectBigDecimalMillis() {
+        BeanObjectMillis bean = new BeanObjectMillis();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"examScore\":0.47}", json);
+    }
+
+    @Test
+    public void testMillisDouble() {
+        BeanMillisDouble bean = new BeanMillisDouble();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"value\":0.47}", json);
+    }
+
+    @Test
+    public void testMillisBigDecimal() {
+        BeanMillisBigDecimal bean = new BeanMillisBigDecimal();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"value\":0.47}", json);
+    }
+
+    @Test
+    public void testMillisBigDecimalArray() {
+        BeanMillisBigDecimalArray bean = new BeanMillisBigDecimalArray();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"scores\":[0.47]}", json);
+    }
+
+    @Test
+    public void testObjectBigDecimalArray() {
+        BeanObjectBigDecimalArray bean = new BeanObjectBigDecimalArray();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"scores\":[\"0.47\"]}", json);
+    }
+
+    @Test
+    public void testObjectMillisBigDecimalArray() {
+        BeanObjectMillisBigDecimalArray bean = new BeanObjectMillisBigDecimalArray();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"scores\":[0.47]}", json);
+    }
+
+    @Test
+    public void testStringDoubleList() {
+        BeanStringDoubleList bean = new BeanStringDoubleList();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"values\":[\"0.47\",\"2.0\"]}", json);
+    }
+
+    @Test
+    public void testStringBigDecimalList() {
+        BeanStringBigDecimalList bean = new BeanStringBigDecimalList();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"values\":[\"0.47\"]}", json);
+    }
+
+    @Test
+    public void testStringFloatList() {
+        BeanStringFloatList bean = new BeanStringFloatList();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"values\":[\"0.47\"]}", json);
+    }
+
+    @Test
+    public void testMillisDoubleList() {
+        BeanMillisDoubleList bean = new BeanMillisDoubleList();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"values\":[0.47]}", json);
+    }
+
+    @Test
+    public void testMillisBigDecimalList() {
+        BeanMillisBigDecimalList bean = new BeanMillisBigDecimalList();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"values\":[0.47]}", json);
+    }
+
+    @Test
+    public void testMillisFloatList() {
+        BeanMillisFloatList bean = new BeanMillisFloatList();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"values\":[0.47]}", json);
+    }
+
+    @Test
+    public void testTrimDouble() {
+        BeanTrimDouble bean = new BeanTrimDouble();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"value\":0.47}", json);
     }
 }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7837.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7837.java
@@ -1,0 +1,65 @@
+package com.alibaba.fastjson2.issues_7800;
+
+import com.alibaba.fastjson2.JSON;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("regression")
+@Tag("annotation")
+@Tag("compat-jackson")
+public class Issue7837 {
+    public static class Bean {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public BigDecimal examScore = new BigDecimal("0.47");
+    }
+
+    public static class BeanDouble {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Double value = 0.47;
+    }
+
+    public static class BeanFloat {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Float value = 0.47f;
+    }
+
+    public static class BeanInteger {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        public Integer value = 47;
+    }
+
+    @Test
+    public void testBigDecimal() {
+        Bean bean = new Bean();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"examScore\":\"0.47\"}", json);
+        Bean parsed = JSON.parseObject(json, Bean.class);
+        assertEquals(0, new BigDecimal("0.47").compareTo(parsed.examScore));
+    }
+
+    @Test
+    public void testDouble() {
+        BeanDouble bean = new BeanDouble();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"value\":\"0.47\"}", json);
+    }
+
+    @Test
+    public void testFloat() {
+        BeanFloat bean = new BeanFloat();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"value\":\"0.47\"}", json);
+    }
+
+    @Test
+    public void testInteger() {
+        BeanInteger bean = new BeanInteger();
+        String json = JSON.toJSONString(bean);
+        assertEquals("{\"value\":\"47\"}", json);
+    }
+}


### PR DESCRIPTION
Fixes #7837

### What this PR does / why we need it?

Jackson `@JsonFormat(shape = STRING)` on a `BigDecimal` field serializes to illegal JSON: `{"examScore":string0}`, which then fails to parse (`illegal input error`). Since #3750, `BeanUtils.processJacksonJsonFormat` maps `STRING` to `fieldInfo.format = "string"`, but `FieldWriter` built `new DecimalFormat("string")` for float/double/BigDecimal, and `writeDecimal` prefers the `DecimalFormat` path over `WriteNonStringValueAsString` — `DecimalFormat("string").format(0.47)` yields `string0` written raw.

### Summary of your change

- `FieldWriter`: skip `DecimalFormat` creation when `format` is the `"string"`/`"millis"` keyword (constructor + `BigDecimal`/`BigDecimal[]` writer resolution), so the existing `WriteNonStringValueAsString` path writes the value quoted (`"0.47"`).
- `ObjectWriterProvider.getObjectWriter(Type, format)`: same guard for `Double`/`Float`/`BigDecimal`, return the default `INSTANCE` instead of `DecimalFormat("string"/"millis")`.
- Base `FieldWriter.writeInt32`: respect `WriteNonStringValueAsString` (consistent with `writeInt64`/`writeInt16`), fixing the ASM path for `Integer` fields via `FieldWriterObject`.
- New regression test `core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7837.java` covering `BigDecimal`/`Double`/`Float`/`Integer` with `@JsonFormat(shape = STRING)`.

Verified: `core clean test` 7992 passed in both standard and `-Dfastjson2.creator=reflect` modes, `fastjson1-compatible clean test` 1355 passed, root `mvn validate` clean.

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed. (No docs impact: pure bugfix, no public API change.)
