### PR TITLE
fix: guard out-of-bounds Unsafe read in field-name hash fast path, fo…

### DIFF
--- a/core/src/main/java/com/alibaba/fastjson2/util/Fnv.java
+++ b/core/src/main/java/com/alibaba/fastjson2/util/Fnv.java
@@ -79,7 +79,15 @@ public final class Fnv {
             return hashCode64UTF8(bytes, offset, len);
         }
         if (len > 0 && len <= 8) {
-            long nameValue = IOUtils.getLongLE(bytes, offset) & (0xFFFFFFFFFFFFFFFFL >>> ((8 - len) << 3));
+            long nameValue;
+            if (offset + 8 <= bytes.length) {
+                nameValue = IOUtils.getLongLE(bytes, offset) & (0xFFFFFFFFFFFFFFFFL >>> ((8 - len) << 3));
+            } else {
+                nameValue = 0;
+                for (int i = len - 1; i >= 0; --i) {
+                    nameValue = (nameValue << 8) | (bytes[offset + i] & 0xFF);
+                }
+            }
             if (nameValue != 0) {
                 return nameValue;
             }

--- a/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7865.java
+++ b/core/src/test/java/com/alibaba/fastjson2/issues_7800/Issue7865.java
@@ -1,0 +1,110 @@
+package com.alibaba.fastjson2.issues_7800;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.util.Fnv;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("regression")
+class Issue7865 {
+    public static class TestBean {
+        public long id;
+        public int count;
+        public double ratio;
+        public boolean enabled;
+        public String name;
+        public BigDecimal amount;
+        public List<String> tags;
+        public Map<String, Object> attributes;
+    }
+
+    public static class AbBean {
+        public int ab;
+    }
+
+    @Test
+    public void reportedReproducer() {
+        TestBean bean = JSON.parseObject("{\"ab\":1}", TestBean.class);
+        assertEquals(0, bean.id);
+    }
+
+    @Test
+    public void shortFieldNameTypedBinding() {
+        AbBean bean = JSON.parseObject("{\"ab\":1}", AbBean.class);
+        assertEquals(1, bean.ab);
+    }
+
+    /**
+     * The field-name hash fast path packed up to 8 bytes with a single {@code Unsafe}
+     * read. When the array was smaller than {@code offset + 8}, the read ran past the
+     * end of the buffer (only observable under a memory sanitizer such as Jazzer
+     * {@code UnsafeSanitizer}), see gh-7865. This exercises names whose byte span ends
+     * before the last 8 bytes of the buffer and pins the resulting hash.
+     */
+    @Test
+    public void shortNameHashNearBufferEnd() {
+        for (int len = 1; len <= 8; len++) {
+            String name = repeat('a', len);
+            byte[] nameBytes = name.getBytes(StandardCharsets.UTF_8);
+            long expected = Fnv.hashCode64(name);
+            for (int offset = 0; offset <= 2; offset++) {
+                byte[] bytes = new byte[offset + len];
+                System.arraycopy(nameBytes, 0, bytes, offset, len);
+                long actual = Fnv.hashCode64(bytes, offset, len, true);
+                assertEquals(expected, actual, "len=" + len + ", offset=" + offset);
+
+                // same name with enough room after it takes the Unsafe fast path and
+                // must produce the identical value
+                byte[] padded = new byte[offset + 8];
+                System.arraycopy(nameBytes, 0, padded, offset, len);
+                assertEquals(expected, Fnv.hashCode64(padded, offset, len, true),
+                        "padded len=" + len + ", offset=" + offset);
+            }
+        }
+    }
+
+    @Test
+    public void boundaryFallbackMatchesFastPath() {
+        for (int len = 1; len <= 8; len++) {
+            byte[] raw = new byte[len];
+            for (int i = 0; i < len; i++) {
+                raw[i] = (byte) (0xE0 + i);
+            }
+
+            byte[] exact = new byte[len];
+            System.arraycopy(raw, 0, exact, 0, len);
+
+            byte[] padded = new byte[len + 8];
+            System.arraycopy(raw, 0, padded, 0, len);
+
+            assertEquals(
+                    Fnv.hashCode64(padded, 0, len, true),
+                    Fnv.hashCode64(exact, 0, len, true),
+                    "len=" + len);
+        }
+    }
+
+    @Test
+    public void shortFieldNameAtEndOfJsonBuffer() {
+        for (int len = 1; len <= 8; len++) {
+            String name = repeat('a', len);
+            String json = "{\"" + name + "\":" + len + "}";
+            assertEquals(len, JSON.parseObject(json, Map.class).get(name));
+        }
+    }
+
+    private static String repeat(char ch, int count) {
+        StringBuilder buf = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            buf.append(ch);
+        }
+        return buf.toString();
+    }
+}


### PR DESCRIPTION
### What this PR does / why we need it?

`Fnv.hashCode64(byte[] bytes, int offset, int len, boolean ascii)` packed up to 8 bytes of a field name with a single `Unsafe` read through `IOUtils.getLongLE` whenever `0 < len <= 8`. When the field name sat within the last 8 bytes of the input buffer — for example the typed binding of `{"ab":1}` (`offset=2`, `len=2`, `arrayLength=8`) — the read ran past the end of the array.

It is a silent out-of-bounds read: it does not throw on a normal JVM and was only detected under [Jazzer](https://github.com/CodeIntelligenceTesting/jazzer)'s `UnsafeSanitizer` (`FuzzerSecurityIssueCritical: Access at offset 18 with size 8 exceeds end offset 24`). Introduced in 3e3886c88 ("Improve skip performance (#3977)"); affects 2.0.61 – 2.0.65.

Fixes #7865.

### Summary of your change

- `Fnv.hashCode64(byte[], int, int, boolean)`: take the `Unsafe` fast path only when `offset + 8 <= bytes.length`; otherwise assemble the **same packed little-endian value** byte-wise. The fallback must reproduce the packed value — not the FNV-1a value of the slow path — otherwise the field-name hash changes and bean binding breaks.
- Add `Issue7865` regression test: the reported typed-binding reproducer, names of length 1..8 whose byte span ends before the last 8 bytes of the buffer (several offsets), equality between the bounds-checked fallback and the `Unsafe` fast path (including bytes >= 0x80), and short field names at the end of the JSON input.

Verification:

- `./mvnw -pl core test` — 7997 tests, 0 failures
- `./mvnw -pl core test -Dfastjson2.creator=reflect` — 7997 tests, 0 failures
- `./mvnw validate` — BUILD SUCCESS

Docs impact: none (internal hash fast path; no public API or behavior change for valid input).

#### Please indicate you've done the following:

- [x] Made sure tests are passing and test coverage is added if needed.
- [x] Made sure commit message follow the rule of [Conventional Commits specification](https://www.conventionalcommits.org/).
- [x] Considered the docs impact and opened a new docs issue or PR with docs changes if needed.

<details>
<summary>中文说明</summary>

`Fnv.hashCode64(byte[], int, int, boolean)` 在 `0 < len <= 8` 时通过 `IOUtils.getLongLE` 用一次 `Unsafe` 读取打包最多 8 个字节。当字段名位于输入缓冲区最后 8 字节之内时（例如 `{"ab":1}` 的 typed binding，`offset=2`、`len=2`、`arrayLength=8`），该读取会越界。

这是静默越界读：普通 JVM 不会抛异常，只有在 Jazzer 的 `UnsafeSanitizer` 下才会被发现。该问题由 3e3886c88（"Improve skip performance (#3977)"）引入，影响 2.0.61 – 2.0.65。

修复方式：仅在 `offset + 8 <= bytes.length` 时走 `Unsafe` 快路径，否则用逐字节方式拼装出**同样的打包值**。注意回退路径必须复现“打包值”，而不是慢路径的 FNV-1a 值，否则字段名哈希会改变、破坏反序列化。

新增 `Issue7865` 回归测试：报告中的 typed binding、缓冲区尾部附近长度 1..8 的字段名（多个 offset）、安全回退与 Unsafe 快路径的结果一致性（含 >= 0x80 的字节）、以及位于 JSON 末尾的短字段名。

</details>